### PR TITLE
feat: implement Phases 6-16 (T025-T072) — parallel execution through polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,151 @@
+# fdsx — Flow-Driven Stateful eXecution
+
+A lightweight framework for building and executing complex AI agent workflows using declarative YAML definitions.
+
+## Overview
+
+fdsx enables you to define AI agent workflows in YAML, combining the durability of LangGraph (checkpoint, interrupt, conditional routing) with the declarative structure of AWS Step Functions.
+
+**Key features:**
+- Declarative YAML-based workflow definition
+- Stateful execution with checkpoint/resume
+- Parallel execution with branch aggregation
+- Batch task processing
+- Multiple LLM provider support (Claude, OpenCode, and more)
+
+## Installation
+
+```bash
+pip install fdsx
+```
+
+## Quick Start
+
+Create a simple YAML workflow file:
+
+```yaml
+name: SimpleFlow
+start_at: greet
+version: "1.0"
+
+states:
+  greet:
+    type: task
+    provider: system
+    command: "echo 'Hello from fdsx!'"
+    result_path: $.message
+    end: true
+```
+
+Run it:
+
+```bash
+fdsx run simple_flow.yaml
+```
+
+## Feature Overview
+
+### State Types
+- **task** — Execute LLM or CLI commands
+- **parallel** — Run multiple branches concurrently
+- **choice** — Conditional routing based on variables
+- **wait** — Pause for human approval or webhook callback
+- **pass** — Pass-through state for data transformation
+
+### Parallel Execution
+Define parallel branches that execute simultaneously with aggregation strategies (majority vote, all, any).
+
+### Checkpoint & Resume
+Flows automatically persist state. Resume from interruption with:
+```bash
+fdsx resume --thread-id <thread_id>
+```
+
+### Batch Tasks
+Process multiple tasks in batch mode:
+```bash
+fdsx run workflow.yaml --tasks tasks.md
+```
+
+### Structured Logging
+All execution details are logged to `runs/<thread_id>.json`.
+
+### Provider Support
+Use any CLI-based LLM provider: Claude, Codex, OpenCode, or system commands.
+
+## CLI Reference
+
+| Command | Description |
+|---------|-------------|
+| `fdsx run <workflow.yaml>` | Execute a workflow |
+| `fdsx run <workflow.yaml> --input key=value` | Pass input variables |
+| `fdsx resume --thread-id <thread_id>` | Resume from checkpoint |
+| `fdsx validate <workflow.yaml>` | Validate YAML syntax |
+| `fdsx list` | List recent runs |
+
+## Example Workflow
+
+```yaml
+name: Plan-Implement-Review Loop
+start_at: plan
+version: "1.0"
+max_loop: 3
+
+states:
+  plan:
+    type: task
+    provider: claude
+    model: claude-sonnet-4-6
+    prompt_template: |
+      You are a planning agent. Break down the following task into clear,
+      actionable implementation steps.
+
+      Task: {task}
+    result_path: $.plan
+    next: implement
+
+  implement:
+    type: task
+    provider: opencode
+    model: opencode/minimax-m2.5-free
+    prompt_template: |
+      You are an implementation agent. Follow this plan exactly.
+
+      Plan: {plan}
+    result_path: $.implementation
+    next: review
+
+  review:
+    type: task
+    provider: codex
+    model: gpt-5.4
+    prompt_template: |
+      Review the implementation against the plan.
+
+      Plan: {plan}
+      Implementation: {implementation}
+    result_path: $.review
+    next: check_review
+
+  check_review:
+    type: choice
+    choices:
+      - variable: $.review
+        operator: contains
+        value: "APPROVED"
+        next: done
+    default: implement
+
+  done:
+    type: pass
+    end: true
+```
+
+Run this example:
+```bash
+fdsx run examples/workflows/plan-implement-review.yaml --input task="Build a web calculator"
+```
+
+## License
+
+MIT License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,20 @@ version = "0.1.0"
 description = "Declarative AI agent workflow execution framework"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
+license = "MIT"
+authors = [
+    {name = "fdsx Contributors"}
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Application Frameworks",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 
 dependencies = [
     "langgraph>=1.0,<2",
@@ -14,6 +27,14 @@ dependencies = [
     "httpx>=0.27",
     "structlog>=24",
 ]
+
+[project.urls]
+Homepage = "https://github.com/fdsx/fdsx"
+Repository = "https://github.com/fdsx/fdsx"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 dev = [

--- a/specs/20260314013547-fdsx-framework/tasks-phase2.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase2.md
@@ -70,7 +70,7 @@
 - Loop control enforces `max_loop` and stops gracefully as "loop completed"
 - Full Scenario 2 flow: parallel review → aggregate → choice → loop or complete
 
-- [ ] T025 [US3] Implement aggregation logic in Pass state in `src/fdsx/core/compiler.py`
+- [x] T025 [US3] Implement aggregation logic in Pass state in `src/fdsx/core/compiler.py`
   - Modify `_create_pass_node` to handle `state.aggregate` when defined
   - `_aggregate(source_data: list[dict], rule: AggregateRule) -> str`: resolve `source` JSONPath to get array, extract `field` from each element, apply strategy:
     - **majority**: count matches for `rule.match` value → if > len/2, return `rule.match`, else return `rule.no_match`
@@ -79,7 +79,7 @@
   - Store result at `aggregate.result_path` in state dict
   - Reference: spec.md FR-4 for aggregation strategy definitions
 
-- [ ] T026 [US3] Write unit tests for aggregation strategies in `tests/unit/test_aggregation.py`
+- [x] T026 [US3] Write unit tests for aggregation strategies in `tests/unit/test_aggregation.py`
   - Test majority strategy: 2/3 match → returns match value
   - Test majority strategy: 1/3 match → returns no_match value
   - Test majority strategy: 0 match → returns no_match value
@@ -88,7 +88,7 @@
   - Test with empty source array → returns no_match
   - Test integration with Pass node: aggregate block processes parallel results correctly
 
-- [ ] T027 [P] [US3] Refactor parallel execution to use LangGraph Send API in `src/fdsx/core/compiler.py`
+- [x] T027 [P] [US3] Refactor parallel execution to use LangGraph Send API in `src/fdsx/core/compiler.py`
   - Replace sequential branch execution in `_create_parallel_node` with LangGraph Send API fan-out/fan-in
   - Create a `_create_branch_node(branch_index: int, branch: Branch, parent_state_name: str) -> Callable`: node function for a single branch execution (provider call, extraction if configured)
   - Create fan-out function: `_create_fan_out(state_name: str, state: ParallelState) -> Callable` that returns `list[Send]` — one `Send("_branch_{state_name}_{i}", {...})` per branch
@@ -98,32 +98,32 @@
   - Update `_extract_result_paths` to handle ParallelState extraction result paths
   - Reference: research.md "Parallel Execution via Send API" for LangGraph Send pattern
 
-- [ ] T028 [US3] Implement per-branch retry with min_success enforcement in `src/fdsx/core/compiler.py`
+- [x] T028 [US3] Implement per-branch retry with min_success enforcement in `src/fdsx/core/compiler.py`
   - In the branch node function: retry failed branches up to `branch.retry` times (existing retry pattern)
   - In the fan-in collector: count branches with `exit_code == 0`
   - If successful count < `min_success` (default: total branch count): raise error with details of which branches failed
   - If successful count >= `min_success`: proceed normally, include all results (both success and failure) in the array
   - Failed branch results in array: `{output: "", exit_code: N, error: "message"}`
 
-- [ ] T029 [P] [US3] Add parallel execution display to terminal in `src/fdsx/display/terminal.py`
+- [x] T029 [P] [US3] Add parallel execution display to terminal in `src/fdsx/display/terminal.py`
   - `display_parallel_start(state_name: str, branch_count: int)`: print `[HH:MM:SS] ▶ state_name (parallel, N branches)`
   - `display_branch_status(state_name: str, branch_index: int, provider: str, status: str, duration: float | None)`: print branch status line per CLI contract format: `  [branch-N] provider/model  status`
   - Status values: `⏳ running...`, `✓ completed (Xs)`, `✗ failed`
   - Reference: contracts/cli.md "Parallel Execution Status" for format
 
-- [ ] T030 [US3] Implement loop control in `src/fdsx/core/engine.py`
+- [x] T030 [US3] Implement loop control in `src/fdsx/core/engine.py`
   - The current `recursion_limit` calculation in `run_flow` already maps `max_loop` to LangGraph's `recursion_limit`
   - Add graceful handling: catch LangGraph's `GraphRecursionError` and convert to a "Loop completed" message rather than a raw error
   - Display "Loop completed after N iterations" on stderr when max_loop is reached
   - Return partial results (last state before loop limit) rather than raising an error
   - Reference: spec.md FR-2.6 for loop behavior
 
-- [ ] T031 [US3] Create parallel + aggregation test fixtures in `tests/fixtures/`
+- [x] T031 [US3] Create parallel + aggregation test fixtures in `tests/fixtures/`
   - `tests/fixtures/parallel_review.yaml`: Parallel state with 3 system provider branches (echo commands outputting APPROVED/REJECTED), followed by Pass state with majority aggregation, followed by Choice state routing on decision
   - `tests/fixtures/loop_flow.yaml`: Plan → Implement → Review → Choice (APPROVED → end, REJECTED → back to Plan) flow with `max_loop: 3`, using system provider
   - `tests/fixtures/parallel_min_success.yaml`: Parallel state with 3 branches, one designed to fail (exit code 1), `min_success: 2` — tests partial failure tolerance
 
-- [ ] T032 [US3] Write integration test for parallel flow in `tests/integration/test_parallel_flow.py`
+- [x] T032 [US3] Write integration test for parallel flow in `tests/integration/test_parallel_flow.py`
   - Test end-to-end: load `parallel_review.yaml` → execute → verify all 3 branches ran
   - Verify branch results array at `result_path` contains 3 elements with `output` field
   - Verify Pass state aggregation produces correct `$.decision` value
@@ -131,7 +131,7 @@
   - Test `min_success`: load `parallel_min_success.yaml` → verify flow continues despite 1 failed branch
   - Test `min_success` failure: all branches fail → flow errors
 
-- [ ] T033 [US3] Write integration test for loop flow in `tests/integration/test_loop_flow.py`
+- [x] T033 [US3] Write integration test for loop flow in `tests/integration/test_loop_flow.py`
   - Test loop execution: load `loop_flow.yaml` → verify flow loops back to planner on REJECTED
   - Test max_loop enforcement: flow with always-REJECTED review → verify graceful stop after max_loop iterations
   - Verify state variables are retained across loop iterations (previous review results available in next plan prompt)

--- a/specs/20260314013547-fdsx-framework/tasks-phase2.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase2.md
@@ -138,12 +138,12 @@
 
 ## Phase 7: Polish & Cross-Cutting
 
-- [ ] T034 Verify ruff and mypy pass with Phase 2 code in `pyproject.toml`
+- [x] T034 Verify ruff and mypy pass with Phase 2 code in `pyproject.toml`
   - Run `uv run ruff check src/ tests/` — fix any lint issues in new files
   - Run `uv run mypy src/fdsx/` — fix any type errors in new files
   - Ensure all Phase 1 tests still pass: `uv run pytest tests/`
 
-- [ ] T035 Write CLI e2e test for Phase 2 scenarios in `tests/integration/test_cli_e2e_phase2.py`
+- [x] T035 Write CLI e2e test for Phase 2 scenarios in `tests/integration/test_cli_e2e_phase2.py`
   - Test `fdsx run` with `parallel_review.yaml` → exit code 0, JSON output contains decision
   - Test `fdsx run` with `extraction_flow.yaml` → exit code 0, extracted value in output
   - Test `fdsx run` with `loop_flow.yaml` → verify loop behavior from CLI

--- a/specs/20260314013547-fdsx-framework/tasks-phase3.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase3.md
@@ -171,12 +171,12 @@
 
 ## Phase 10: Polish & Cross-Cutting
 
-- [ ] T052 Verify ruff and mypy pass with Phase 3 code in `pyproject.toml`
+- [x] T052 Verify ruff and mypy pass with Phase 3 code in `pyproject.toml`
   - Run `uv run ruff check src/ tests/` — fix any lint issues in new files
   - Run `uv run mypy src/fdsx/` — fix any type errors in new files
   - Ensure all Phase 1-2 tests still pass: `uv run pytest tests/`
 
-- [ ] T053 Write CLI e2e test for Phase 3 scenarios in `tests/integration/test_cli_e2e_phase3.py`
+- [x] T053 Write CLI e2e test for Phase 3 scenarios in `tests/integration/test_cli_e2e_phase3.py`
   - Test `fdsx run` with Wait state flow → mock stdin → exit code 0, JSON output contains selection result
   - Test `fdsx resume --thread-id` with a previously interrupted flow → exit code 0
   - Test `fdsx resume --thread-id` with non-existent thread → exit code 2, error message

--- a/specs/20260314013547-fdsx-framework/tasks-phase3.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase3.md
@@ -87,7 +87,7 @@
 - `prompt_file` loads prompt content from an external file with variable substitution
 - A flow interrupted mid-execution can be resumed and produces the same result
 
-- [ ] T043 [US5] Implement checkpoint manager in `src/fdsx/checkpoint/manager.py`
+- [x] T043 [US5] Implement checkpoint manager in `src/fdsx/checkpoint/manager.py`
   - `CheckpointManager` class wrapping LangGraph's `SqliteSaver`:
     - `__init__(base_dir: Path | None = None)`: default base_dir is `.fdsx/` relative to CWD. Create `.fdsx/checkpoints/` and `.fdsx/locks/` directories if they don't exist
     - `get_checkpointer() -> SqliteSaver`: return `SqliteSaver.from_conn_string(str(base_dir / "checkpoints" / "checkpoints.db"))`
@@ -98,7 +98,7 @@
     - `verify_checkpoint(thread_id: str) -> bool`: verify checkpoint integrity (DB readable, thread_id exists in checkpoint store)
   - Reference: impl-plan.md "Checkpoint Directory Layout" for file structure
 
-- [ ] T044 [P] [US5] Write unit tests for checkpoint manager in `tests/unit/test_checkpoint.py`
+- [x] T044 [P] [US5] Write unit tests for checkpoint manager in `tests/unit/test_checkpoint.py`
   - Test `acquire_lock`: new thread → acquires lock, returns True
   - Test `acquire_lock`: same thread, same PID → returns False (already locked)
   - Test `acquire_lock`: stale lock (dead PID) → removes stale lock, acquires new, returns True
@@ -108,7 +108,7 @@
   - Test directory creation: `.fdsx/checkpoints/` and `.fdsx/locks/` created on init
   - Test `verify_checkpoint`: valid checkpoint → True, missing thread → False
 
-- [ ] T045 [US5] Integrate checkpoint manager into engine in `src/fdsx/core/engine.py`
+- [x] T045 [US5] Integrate checkpoint manager into engine in `src/fdsx/core/engine.py`
   - Modify `run_flow` to use `CheckpointManager`:
     - Acquire lock before execution; raise error if locked by another process
     - Pass `SqliteSaver` checkpointer to `graph.compile(checkpointer=checkpointer)` (modify `compile_flow` to accept optional checkpointer)
@@ -117,7 +117,7 @@
   - Modify `compile_flow` in `src/fdsx/core/compiler.py` to accept an optional checkpointer parameter and pass it to `graph.compile(checkpointer=checkpointer)`
   - On error: print "Checkpoint saved. Resume with: fdsx resume --thread-id {thread_id}" to stderr
 
-- [ ] T046 [US5] Implement `resume_flow` function in `src/fdsx/core/engine.py`
+- [x] T046 [US5] Implement `resume_flow` function in `src/fdsx/core/engine.py`
   - `resume_flow(thread_id: str, base_dir: Path | None = None) -> dict`: resume a flow from checkpoint
     - Create `CheckpointManager` and verify checkpoint integrity; raise error if corrupt
     - Acquire lock; raise error if locked by another process
@@ -129,7 +129,7 @@
     - Return final state variables
   - Print `Resuming from state: {state_name}` to stderr at start
 
-- [ ] T047 [US5] Implement `fdsx resume` and `fdsx list` CLI commands in `src/fdsx/cli/main.py`
+- [x] T047 [US5] Implement `fdsx resume` and `fdsx list` CLI commands in `src/fdsx/cli/main.py`
   - Add `resume` command:
     - `fdsx resume --thread-id TEXT`: call `engine.resume_flow(thread_id)`
     - Exit codes: 0=success, 1=flow error, 2=validation error (corrupt checkpoint)
@@ -140,7 +140,7 @@
     - Status detection: check PID lock → running; check for pending interrupt → waiting; no lock + completed → completed; no lock + not completed → stopped
     - If no threads found, print "No flow executions found."
 
-- [ ] T048 [P] [US5] Implement `prompt_file` support in `src/fdsx/core/compiler.py` and `src/fdsx/core/loader.py`
+- [x] T048 [P] [US5] Implement `prompt_file` support in `src/fdsx/core/compiler.py` and `src/fdsx/core/loader.py`
   - In `loader.py`: `prompt_file` paths are already validated as relative to YAML file location (check existing code)
   - In `compiler.py` `_create_task_node`: if `state.prompt_file` is set (and `state.prompt_template` is not):
     - Read the file content from the resolved path
@@ -150,17 +150,17 @@
   - Store the YAML file path in `Flow` or pass it through compilation so file paths can be resolved at runtime
   - Reference: spec.md FR-2.1 for prompt_file behavior
 
-- [ ] T049 [P] [US5] Write unit tests for `prompt_file` support in `tests/unit/test_prompt_file.py`
+- [x] T049 [P] [US5] Write unit tests for `prompt_file` support in `tests/unit/test_prompt_file.py`
   - Test: prompt_file content is read and variable references are resolved
   - Test: prompt_file path is resolved relative to YAML file location
   - Test: prompt_file not found → clear error message
   - Test: prompt_file in parallel branch works the same as in Task state
 
-- [ ] T050 [US5] Create checkpoint/resume test fixtures in `tests/fixtures/`
+- [x] T050 [US5] Create checkpoint/resume test fixtures in `tests/fixtures/`
   - `tests/fixtures/checkpoint_flow.yaml`: 3-state linear flow (plan → implement → review) using system provider, suitable for interrupt/resume testing
   - `tests/fixtures/wait_resume_flow.yaml`: Plan → Wait → Choice → end flow, designed to test checkpoint saving at Wait state and resume after process restart
 
-- [ ] T051 [US5] Write integration test for checkpoint/resume in `tests/integration/test_checkpoint_resume.py`
+- [x] T051 [US5] Write integration test for checkpoint/resume in `tests/integration/test_checkpoint_resume.py`
   - Test checkpoint save: run a flow → verify `.fdsx/checkpoints/checkpoints.db` exists
   - Test resume: run a flow with a Wait state → interrupt at Wait → resume with `resume_flow` → verify flow completes
   - Test PID lock: start a flow → attempt concurrent execution with same thread_id → verify lock error

--- a/specs/20260314013547-fdsx-framework/tasks-phase3.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase3.md
@@ -1,0 +1,268 @@
+# Tasks: fdsx Framework — Phase 3 (Wait + Checkpoint/Resume)
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan/impl-plan.md](plan/impl-plan.md)
+**Scope**: Phase 3 — Wait state with interrupt/resume, webhook notifications, checkpoint persistence with SqliteSaver, `fdsx list` command, and `prompt_file` support
+**Primary Scenarios**: Scenario 3 (Human-in-the-Loop Approval Gate), Scenario 4 (Resumption from Interruption)
+**Prerequisite**: All Phase 1-2 tasks (T001–T035) completed
+
+---
+
+## Phase 8: US4 — Wait State + Webhook Notifications (Scenario 3)
+
+**Story Goal**: Pause flow execution at a Wait state, display a terminal prompt with choices, optionally send a webhook notification (e.g., Slack), and store the user's selection in `result_path`. Combined with a subsequent Choice state, this enables human-in-the-loop approval gates.
+
+**Independent Test Criteria**:
+- Wait state compiles to a LangGraph node that calls `interrupt()` with message and choices
+- Terminal displays the wait prompt with numbered choices and reads user input
+- User's selection is stored at `result_path` in the state dict
+- Webhook notification is sent via httpx POST when `notify` is configured
+- Webhook failure logs a warning but does not block the flow
+- A flow with Wait → Choice routes correctly based on the user's selection
+
+- [x] T036 [US4] Implement webhook notification module in `src/fdsx/notify/webhook.py`
+  - `send_webhook(url: str, message: str) -> bool`: POST JSON payload `{"text": message}` to URL using httpx (sync client)
+  - Set timeout of 10 seconds for the HTTP request
+  - Return `True` on success (2xx status), `False` on any failure (network error, non-2xx, timeout)
+  - Log warning on failure using structlog (do not raise exceptions — notification is auxiliary)
+  - `send_notification(notify: NotifyConfig, state_dict: dict) -> None`: resolve `{variable}` references in `webhook.template` using `resolve_template`, then call `send_webhook`
+
+- [x] T037 [P] [US4] Write unit tests for webhook notification in `tests/unit/test_webhook.py`
+  - Test `send_webhook`: successful POST → returns True (mock httpx)
+  - Test `send_webhook`: network error → returns False, logs warning
+  - Test `send_webhook`: non-2xx status → returns False, logs warning
+  - Test `send_webhook`: timeout → returns False, logs warning
+  - Test `send_notification`: template variables are resolved before sending
+  - Test `send_notification`: when webhook fails, no exception is raised
+
+- [x] T038 [US4] Implement Wait state terminal display in `src/fdsx/display/terminal.py`
+  - `display_wait_prompt(state_name: str, message: str, choices: list[str]) -> str`: display the wait prompt per CLI contract format:
+    - Print `[HH:MM:SS] ⏸ {state_name} (waiting for input)` to stderr
+    - Print blank line + message + blank line to stderr
+    - Print numbered choices `[1] choice1`, `[2] choice2`, etc. to stderr
+    - Print `Select (1-N): ` prompt and read from stdin
+    - Validate input is a valid number in range; re-prompt on invalid input
+    - Return the selected choice string (not the number)
+  - Reference: contracts/cli.md "Wait State Prompt" for exact format
+
+- [x] T039 [US4] Implement Wait state node using LangGraph `interrupt()` in `src/fdsx/core/compiler.py`
+  - Modify `_create_wait_node` to implement the full Wait state logic:
+    - Resolve `{variable}` references in `state.message` using `resolve_template`
+    - If `state.notify` is configured: call `send_notification` (from webhook module) before prompting
+    - Call `interrupt({"message": resolved_message, "choices": state.choices, "state_name": state_name})` to pause the graph
+    - The interrupt payload is used by the resume handler to display the prompt
+    - On resume, `interrupt()` returns the user's selection value
+    - Store the selection at `state.result_path` in the state dict
+  - Reference: research.md "Interrupt/Resume for Wait State" for LangGraph interrupt/Command pattern
+
+- [x] T040 [US4] Update engine to handle interrupt and resume for Wait states in `src/fdsx/core/engine.py`
+  - Modify `run_flow` to detect when the graph is interrupted (Wait state reached):
+    - When `graph.stream()` yields an interrupt event, extract the interrupt payload (message, choices, state_name)
+    - Call `display_wait_prompt` to show the terminal prompt and get user input
+    - Resume the graph with `Command(resume=user_selection)` using `graph.invoke()`
+    - Continue streaming until the graph completes or hits another interrupt
+  - Handle multiple Wait states in a single flow (loop until graph completes)
+
+- [x] T041 [US4] Create Wait state test fixtures in `tests/fixtures/`
+  - `tests/fixtures/wait_approval.yaml`: Plan → Wait (approve/reject/retry choices) → Choice (routes on selection) → end states. Uses system provider for Plan state
+  - `tests/fixtures/wait_webhook.yaml`: Same as above but with `notify.webhook` configured (URL can be a placeholder for testing)
+
+- [x] T042 [US4] Write integration test for Wait state flow in `tests/integration/test_wait_resume.py`
+  - Test Wait state prompt display: mock stdin to provide selection input, verify correct choice is stored at `result_path`
+  - Test Wait → Choice routing: mock stdin to select "approve" → verify flow takes approve branch
+  - Test Wait → Choice routing: mock stdin to select "reject" → verify flow takes reject branch
+  - Test webhook notification: mock httpx to verify POST is sent with resolved template when `notify` is configured
+  - Test webhook failure: mock httpx to fail → verify flow continues normally (warning logged, prompt still shown)
+
+## Phase 9: US5 — Checkpoint/Resume + List + prompt_file (Scenario 4)
+
+**Story Goal**: Enable crash-resilient execution by persisting checkpoints to SQLite after each state. Support resuming interrupted flows with `fdsx resume --thread-id`. Provide `fdsx list` to show all known flow executions. Support loading prompts from external files.
+
+**Independent Test Criteria**:
+- Checkpoints are saved to `.fdsx/checkpoints/checkpoints.db` via SqliteSaver
+- `fdsx resume --thread-id <id>` restores state variables and resumes from the correct state
+- PID-based lock files prevent concurrent execution of the same thread ID
+- Stale locks (dead PIDs) are automatically cleaned up
+- `fdsx list` displays thread IDs with status (running/waiting/stopped/completed)
+- `prompt_file` loads prompt content from an external file with variable substitution
+- A flow interrupted mid-execution can be resumed and produces the same result
+
+- [ ] T043 [US5] Implement checkpoint manager in `src/fdsx/checkpoint/manager.py`
+  - `CheckpointManager` class wrapping LangGraph's `SqliteSaver`:
+    - `__init__(base_dir: Path | None = None)`: default base_dir is `.fdsx/` relative to CWD. Create `.fdsx/checkpoints/` and `.fdsx/locks/` directories if they don't exist
+    - `get_checkpointer() -> SqliteSaver`: return `SqliteSaver.from_conn_string(str(base_dir / "checkpoints" / "checkpoints.db"))`
+    - `acquire_lock(thread_id: str) -> bool`: create PID lock file at `.fdsx/locks/{thread_id}.lock` containing current PID. If lock file exists, check if PID is alive (via `os.kill(pid, 0)`). If alive → return False (concurrent execution). If dead → remove stale lock, acquire new lock → return True
+    - `release_lock(thread_id: str) -> None`: remove lock file
+    - `is_locked(thread_id: str) -> tuple[bool, int | None]`: check if thread is locked and return (is_locked, pid)
+    - `list_threads() -> list[dict]`: scan checkpoint DB for known thread IDs, check lock status for each, return list of `{thread_id, status, flow_name}`
+    - `verify_checkpoint(thread_id: str) -> bool`: verify checkpoint integrity (DB readable, thread_id exists in checkpoint store)
+  - Reference: impl-plan.md "Checkpoint Directory Layout" for file structure
+
+- [ ] T044 [P] [US5] Write unit tests for checkpoint manager in `tests/unit/test_checkpoint.py`
+  - Test `acquire_lock`: new thread → acquires lock, returns True
+  - Test `acquire_lock`: same thread, same PID → returns False (already locked)
+  - Test `acquire_lock`: stale lock (dead PID) → removes stale lock, acquires new, returns True
+  - Test `release_lock`: removes lock file
+  - Test `is_locked`: locked thread → returns (True, pid)
+  - Test `is_locked`: unlocked thread → returns (False, None)
+  - Test directory creation: `.fdsx/checkpoints/` and `.fdsx/locks/` created on init
+  - Test `verify_checkpoint`: valid checkpoint → True, missing thread → False
+
+- [ ] T045 [US5] Integrate checkpoint manager into engine in `src/fdsx/core/engine.py`
+  - Modify `run_flow` to use `CheckpointManager`:
+    - Acquire lock before execution; raise error if locked by another process
+    - Pass `SqliteSaver` checkpointer to `graph.compile(checkpointer=checkpointer)` (modify `compile_flow` to accept optional checkpointer)
+    - Include `thread_id` in LangGraph config: `{"configurable": {"thread_id": thread_id}}`
+    - Release lock on completion (success or error) using try/finally
+  - Modify `compile_flow` in `src/fdsx/core/compiler.py` to accept an optional checkpointer parameter and pass it to `graph.compile(checkpointer=checkpointer)`
+  - On error: print "Checkpoint saved. Resume with: fdsx resume --thread-id {thread_id}" to stderr
+
+- [ ] T046 [US5] Implement `resume_flow` function in `src/fdsx/core/engine.py`
+  - `resume_flow(thread_id: str, base_dir: Path | None = None) -> dict`: resume a flow from checkpoint
+    - Create `CheckpointManager` and verify checkpoint integrity; raise error if corrupt
+    - Acquire lock; raise error if locked by another process
+    - Get the checkpointer and load the graph state for the given thread_id
+    - Detect if the flow was interrupted at a Wait state: check for pending interrupts in the checkpoint
+    - If interrupted at Wait: call `display_wait_prompt` with the interrupt payload, then resume with `Command(resume=user_selection)`
+    - Continue streaming the graph until completion or next interrupt
+    - Release lock on completion
+    - Return final state variables
+  - Print `Resuming from state: {state_name}` to stderr at start
+
+- [ ] T047 [US5] Implement `fdsx resume` and `fdsx list` CLI commands in `src/fdsx/cli/main.py`
+  - Add `resume` command:
+    - `fdsx resume --thread-id TEXT`: call `engine.resume_flow(thread_id)`
+    - Exit codes: 0=success, 1=flow error, 2=validation error (corrupt checkpoint)
+    - Error messages: "No checkpoint found for thread ID {id}", "Thread {id} is locked by PID {pid}"
+  - Add `list` command:
+    - `fdsx list`: call `CheckpointManager().list_threads()`
+    - Display table format per CLI contract: `THREAD_ID  FLOW_NAME  STATUS  CURRENT_STATE  STARTED_AT`
+    - Status detection: check PID lock → running; check for pending interrupt → waiting; no lock + completed → completed; no lock + not completed → stopped
+    - If no threads found, print "No flow executions found."
+
+- [ ] T048 [P] [US5] Implement `prompt_file` support in `src/fdsx/core/compiler.py` and `src/fdsx/core/loader.py`
+  - In `loader.py`: `prompt_file` paths are already validated as relative to YAML file location (check existing code)
+  - In `compiler.py` `_create_task_node`: if `state.prompt_file` is set (and `state.prompt_template` is not):
+    - Read the file content from the resolved path
+    - Apply `resolve_template` to the file content (same as prompt_template)
+    - Use the result as the prompt for the provider
+  - Same for `_create_branch_executor`: handle `branch.prompt_file` in parallel branches
+  - Store the YAML file path in `Flow` or pass it through compilation so file paths can be resolved at runtime
+  - Reference: spec.md FR-2.1 for prompt_file behavior
+
+- [ ] T049 [P] [US5] Write unit tests for `prompt_file` support in `tests/unit/test_prompt_file.py`
+  - Test: prompt_file content is read and variable references are resolved
+  - Test: prompt_file path is resolved relative to YAML file location
+  - Test: prompt_file not found → clear error message
+  - Test: prompt_file in parallel branch works the same as in Task state
+
+- [ ] T050 [US5] Create checkpoint/resume test fixtures in `tests/fixtures/`
+  - `tests/fixtures/checkpoint_flow.yaml`: 3-state linear flow (plan → implement → review) using system provider, suitable for interrupt/resume testing
+  - `tests/fixtures/wait_resume_flow.yaml`: Plan → Wait → Choice → end flow, designed to test checkpoint saving at Wait state and resume after process restart
+
+- [ ] T051 [US5] Write integration test for checkpoint/resume in `tests/integration/test_checkpoint_resume.py`
+  - Test checkpoint save: run a flow → verify `.fdsx/checkpoints/checkpoints.db` exists
+  - Test resume: run a flow with a Wait state → interrupt at Wait → resume with `resume_flow` → verify flow completes
+  - Test PID lock: start a flow → attempt concurrent execution with same thread_id → verify lock error
+  - Test stale lock cleanup: create a lock file with a dead PID → verify it's cleaned up on next acquire
+  - Test checkpoint integrity: corrupt the checkpoint DB → verify `resume_flow` raises clear error
+  - Test full Scenario 4: run a multi-state flow → simulate interrupt after first state → resume → verify all remaining states execute and final result is correct
+  - Use tmp_path fixture for `.fdsx/` directory isolation between tests
+
+## Phase 10: Polish & Cross-Cutting
+
+- [ ] T052 Verify ruff and mypy pass with Phase 3 code in `pyproject.toml`
+  - Run `uv run ruff check src/ tests/` — fix any lint issues in new files
+  - Run `uv run mypy src/fdsx/` — fix any type errors in new files
+  - Ensure all Phase 1-2 tests still pass: `uv run pytest tests/`
+
+- [ ] T053 Write CLI e2e test for Phase 3 scenarios in `tests/integration/test_cli_e2e_phase3.py`
+  - Test `fdsx run` with Wait state flow → mock stdin → exit code 0, JSON output contains selection result
+  - Test `fdsx resume --thread-id` with a previously interrupted flow → exit code 0
+  - Test `fdsx resume --thread-id` with non-existent thread → exit code 2, error message
+  - Test `fdsx list` → verify table output format with at least one known thread
+  - Test `fdsx list` with no threads → "No flow executions found."
+  - Test `fdsx run` with `prompt_file` → verify prompt loaded from file and variables resolved
+  - Use `subprocess.run` to invoke the actual CLI entry point
+
+---
+
+## Dependencies
+
+```
+Phase 1-2 (T001-T035) completed
+  ↓
+T036 → T037 (webhook module + tests)
+T038 (wait display — independent)
+T036 + T038 → T039 (wait node with interrupt + webhook)
+T039 → T040 (engine interrupt/resume handling)
+T040 → T041 → T042 (wait fixtures + integration test)
+  ↓
+T043 → T044 (checkpoint manager + tests)
+T043 + T040 → T045 (integrate checkpoint into engine + compiler)
+T045 → T046 (resume_flow function)
+T046 → T047 (resume + list CLI commands)
+T048 → T049 (prompt_file + tests — independent of checkpoint work)
+T047 → T050 → T051 (checkpoint/resume fixtures + integration test)
+  ↓
+T042 + T051 + T049 → T052 → T053
+```
+
+**Critical path**: T036 → T039 → T040 → T043 → T045 → T046 → T047 → T050 → T051 → T052 → T053
+
+**Parallel opportunities**:
+- T036 (webhook) and T038 (wait display) and T043 (checkpoint manager) can all start in parallel
+- T037 (webhook tests) can run in parallel with T038
+- T048 (prompt_file) is independent and can run in parallel with all US4/checkpoint work
+- T044 (checkpoint tests) can run in parallel with T040 (engine interrupt handling)
+
+## Implementation Strategy
+
+- **MVP**: Complete through T042 (Wait state with interrupt/resume in-memory). This enables Scenario 3 (human-in-the-loop approval gate) without persistent checkpointing.
+- **Incremental delivery**: T036-T042 deliver Wait state + webhook (Scenario 3). T043-T051 add checkpoint persistence + resume + list (Scenario 4). T048-T049 add prompt_file. Each group is independently testable.
+- **Key integration point**: T045 is the critical integration task — wiring SqliteSaver into the existing engine/compiler. The compiler's `graph.compile()` call changes from no-args to `compile(checkpointer=checkpointer)`.
+- **No real LLMs needed**: All tests use `system` provider (echo commands). Webhook tests use mocked httpx.
+- **stdin mocking**: Wait state tests require mocking stdin for user input. Use `unittest.mock.patch("builtins.input")` or similar.
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total tasks | 18 (T036-T053) |
+| US4 tasks (Wait + Webhook) | 7 (T036-T042) |
+| US5 tasks (Checkpoint + List + prompt_file) | 9 (T043-T051) |
+| Polish tasks | 2 (T052-T053) |
+| Unit test tasks | 3 (T037, T044, T049) |
+| Integration test tasks | 3 (T042, T051, T053) |
+| Parallelizable tasks | 3 (T037, T044, T048) |
+
+## Suggested takt Usage
+
+```bash
+# Phase 8: US4 — Webhook module + tests
+takt run code "Implement webhook notification module (httpx POST, template variables, failure handling) in src/fdsx/notify/webhook.py and unit tests in tests/unit/test_webhook.py"
+
+# Phase 8: US4 — Wait state display
+takt run code "Implement Wait state terminal display (numbered choices, stdin input, re-prompt on invalid) in src/fdsx/display/terminal.py"
+
+# Phase 8: US4 — Wait state node + engine interrupt handling
+takt run code "Implement Wait state using LangGraph interrupt() in src/fdsx/core/compiler.py, update engine to handle interrupt/resume with Command(resume=value) in src/fdsx/core/engine.py"
+
+# Phase 8: US4 — Wait state integration tests
+takt run code "Create wait_approval.yaml and wait_webhook.yaml fixtures in tests/fixtures/, write integration tests for Wait state flow in tests/integration/test_wait_resume.py"
+
+# Phase 9: US5 — Checkpoint manager + tests
+takt run code "Implement CheckpointManager (SqliteSaver wrapper, PID lock files, stale lock detection) in src/fdsx/checkpoint/manager.py and unit tests in tests/unit/test_checkpoint.py"
+
+# Phase 9: US5 — Checkpoint integration into engine + resume + list CLI
+takt run code "Integrate CheckpointManager into engine, implement resume_flow in src/fdsx/core/engine.py, add fdsx resume and fdsx list commands in src/fdsx/cli/main.py"
+
+# Phase 9: US5 — prompt_file support
+takt run code "Implement prompt_file support (read file, resolve relative to YAML, variable substitution) in src/fdsx/core/compiler.py and src/fdsx/core/loader.py, write unit tests in tests/unit/test_prompt_file.py"
+
+# Phase 9: US5 — Checkpoint/resume integration tests
+takt run code "Create checkpoint_flow.yaml and wait_resume_flow.yaml fixtures in tests/fixtures/, write integration tests for checkpoint/resume in tests/integration/test_checkpoint_resume.py"
+
+# Phase 10: Polish
+takt run code "Verify ruff/mypy pass, run all tests, write CLI e2e tests for Phase 3 scenarios in tests/integration/test_cli_e2e_phase3.py"
+```

--- a/specs/20260314013547-fdsx-framework/tasks-phase4.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase4.md
@@ -62,7 +62,7 @@
 - A results summary is displayed at the end
 - `--input` and `--tasks` are mutually exclusive (validation error if both provided)
 
-- [ ] T057 [US7] Implement batch task splitter in `src/fdsx/core/batch.py`
+- [x] T057 [US7] Implement batch task splitter in `src/fdsx/core/batch.py`
   - `split_tasks(task_content: str, flow: Flow, task_splitter: TaskSplitter) -> list[str]`: invoke the task_splitter LLM to split the task file content into individual task descriptions
     - Build a prompt that includes the task file content and the workflow definition (state names, input variables) to guide the LLM on appropriate granularity
     - Call the provider specified by `task_splitter.provider` with `task_splitter.model`
@@ -72,14 +72,14 @@
   - `display_batch_summary(results: list[dict]) -> None`: display a summary table of all task results to stderr (task index, description preview, status, thread_id)
   - Reference: spec.md FR-13 for batch execution behavior
 
-- [ ] T058 [P] [US7] Write unit tests for batch task splitter in `tests/unit/test_batch.py`
+- [x] T058 [P] [US7] Write unit tests for batch task splitter in `tests/unit/test_batch.py`
   - Test `split_tasks`: mock provider returns numbered task list → parses correctly into list of strings
   - Test `split_tasks`: mock provider returns empty response → returns empty list
   - Test `display_task_list`: mock stdin "y" → returns True
   - Test `display_task_list`: mock stdin "n" → returns False
   - Test `display_batch_summary`: verify output format includes task index, description, status, thread_id
 
-- [ ] T059 [US7] Implement batch execution orchestrator in `src/fdsx/core/engine.py`
+- [x] T059 [US7] Implement batch execution orchestrator in `src/fdsx/core/engine.py`
   - `run_batch(workflow_path: Path, tasks_file: Path, base_dir: Path | None = None) -> list[dict]`: orchestrate batch execution
     - Load and validate the flow YAML
     - Verify `task_splitter` is defined in the flow; raise error if missing
@@ -92,18 +92,18 @@
     - Call `display_batch_summary` at the end
   - Reference: spec.md FR-13, clarification "approve/reject only"
 
-- [ ] T060 [US7] Add `--tasks` option to CLI and validate mutual exclusion in `src/fdsx/cli/main.py`
+- [x] T060 [US7] Add `--tasks` option to CLI and validate mutual exclusion in `src/fdsx/cli/main.py`
   - Add `--tasks` option to the `run` command: `tasks_file: Path | None = typer.Option(None, "--tasks", help="Batch task file path")`
   - Validate `--input` and `--tasks` mutual exclusion: if both provided, print error and exit with code 2
   - When `--tasks` is provided: call `engine.run_batch(workflow, tasks_file, base_dir)` instead of `engine.run_flow`
   - Print batch results summary JSON to stdout on completion
   - Exit code: 0 if all tasks succeed, 1 if any task failed
 
-- [ ] T061 [US7] Create batch execution test fixtures in `tests/fixtures/`
+- [x] T061 [US7] Create batch execution test fixtures in `tests/fixtures/`
   - `tests/fixtures/batch_flow.yaml`: simple 2-state flow (Plan → Implement) using system provider with `task_splitter: {provider: system, model: default}` and system command that echoes task descriptions
   - `tests/fixtures/sample_tasks.md`: sample task file with 3 task descriptions for testing batch splitting
 
-- [ ] T062 [US7] Write integration test for batch execution in `tests/integration/test_batch.py`
+- [x] T062 [US7] Write integration test for batch execution in `tests/integration/test_batch.py`
   - Test full batch flow: mock the task_splitter provider to return 3 tasks → approve → all 3 execute with independent thread_ids
   - Test batch rejection: mock stdin to reject task list → verify no tasks executed
   - Test batch failure handling: mock one task to fail → prompt to continue → remaining tasks execute

--- a/specs/20260314013547-fdsx-framework/tasks-phase4.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase4.md
@@ -130,14 +130,14 @@
 
 **Story Goal**: Enhance terminal output during parallel execution with real-time status line updates and post-completion branch output display.
 
-- [ ] T065 Implement parallel status line updates in `src/fdsx/display/terminal.py`
+- [x] T065 Implement parallel status line updates in `src/fdsx/display/terminal.py`
   - `display_branch_start(state_name: str, branch_index: int, provider: str, model: str | None) -> None`: print `  [branch-N] provider/model  ⏳ running...` to stderr
   - `display_branch_complete(state_name: str, branch_index: int, provider: str, duration: float) -> None`: print `  [branch-N] provider/model  ✓ completed (Xs)` to stderr
   - `display_branch_failed(state_name: str, branch_index: int, provider: str) -> None`: print `  [branch-N] provider/model  ✗ failed` to stderr
   - `display_parallel_results(state_name: str, branch_results: list[dict]) -> None`: after all branches complete, display each branch's output with header `--- branch-N (provider/model) ---`
   - Reference: contracts/cli.md "Parallel Execution Status" for exact format
 
-- [ ] T066 Integrate parallel display callbacks into compiler in `src/fdsx/core/compiler.py`
+- [x] T066 Integrate parallel display callbacks into compiler in `src/fdsx/core/compiler.py`
   - In `_create_branch_executor`: call `display_branch_start` before provider execution
   - On branch success: call `display_branch_complete` with duration
   - On branch failure: call `display_branch_failed`

--- a/specs/20260314013547-fdsx-framework/tasks-phase4.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase4.md
@@ -148,14 +148,14 @@
 
 **Story Goal**: Finalize pyproject.toml, create README with quickstart, and ensure `pip install fdsx` works.
 
-- [ ] T067 Finalize pyproject.toml for PyPI publishing in `pyproject.toml`
+- [x] T067 Finalize pyproject.toml for PyPI publishing in `pyproject.toml`
   - Add/verify required PyPI fields: `description`, `authors`, `license`, `readme`, `classifiers`, `urls` (homepage, repository)
   - Verify `[project.scripts]` entry point: `fdsx = "fdsx.cli.main:app"`
   - Verify all runtime dependencies are correctly listed
   - Add `[build-system]` section if missing (setuptools or hatchling)
   - Test: `uv build` produces a valid wheel and sdist
 
-- [ ] T068 Write README with quickstart in `README.md`
+- [x] T068 Write README with quickstart in `README.md`
   - Include: project overview (what fdsx is), installation (`pip install fdsx`), quickstart (create a simple YAML flow + run it), feature overview (state types, parallel execution, checkpointing, batch tasks), CLI reference table, example workflow YAML
   - Keep concise and practical — focus on getting users running in under 5 minutes
   - Reference: spec.md Overview and Scenarios for content

--- a/specs/20260314013547-fdsx-framework/tasks-phase4.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase4.md
@@ -1,0 +1,276 @@
+# Tasks: fdsx Framework — Phase 4 (Batch Tasks + Polish + Publish)
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan/impl-plan.md](plan/impl-plan.md)
+**Scope**: Phase 4 — Batch task execution, structured logging, parallel display improvements, PyPI packaging, edge case hardening
+**Primary Scenarios**: All Scenarios 1-5 (comprehensive e2e validation before publish)
+**Prerequisite**: All Phase 1-3 tasks (T001–T053) completed
+
+---
+
+## Phase 11: US6 — Structured Logging (FR-11)
+
+**Story Goal**: Record per-state input/output/duration to a JSON run log at `runs/<thread_id>.json`. On resume, append to the existing log. Structured to enable future Web UI visualization.
+
+**Independent Test Criteria**:
+- `runs/<thread_id>.json` is created on flow execution with correct schema
+- Each state entry records name, type, started_at, completed_at, duration_seconds, status, output_preview, variables_set
+- Parallel state entries include branch-level details (index, provider, status, duration)
+- On resume, new state entries are appended to the existing log file
+- final_variables section contains the complete state dict at flow completion
+
+- [x] T054 [US6] Implement run log recorder in `src/fdsx/logging/recorder.py`
+  - `RunRecorder` class:
+    - `__init__(thread_id: str, flow_name: str, flow_version: str | None = None)`: initialize log structure with thread_id, flow_name, flow_version, started_at (ISO 8601), status="running", states=[]
+    - `record_state_start(state_name: str, state_type: str) -> None`: append new state entry with name, type, started_at
+    - `record_state_complete(state_name: str, status: str, output: str, variables_set: list[str], branches: list[dict] | None = None) -> None`: update the state entry with completed_at, duration_seconds (computed), status, output_preview (first 500 chars), variables_set, branches (for parallel states)
+    - `record_state_error(state_name: str, error: str) -> None`: update the state entry with status="error", error message
+    - `finalize(final_variables: dict, status: str = "completed") -> None`: set completed_at, status, final_variables on the log
+    - `save(base_dir: Path | None = None) -> Path`: write JSON to `runs/<thread_id>.json` relative to CWD (or base_dir). Create `runs/` directory if not exists. If file already exists (resume), load existing log, append new state entries, update completed_at/status/final_variables
+    - `to_dict() -> dict`: return the full log as a dict
+  - Reference: contracts/cli.md "Run Log Format" for exact JSON schema
+
+- [x] T055 [P] [US6] Write unit tests for run log recorder in `tests/unit/test_recorder.py`
+  - Test `RunRecorder` initialization: correct fields, started_at is ISO 8601
+  - Test `record_state_start` + `record_state_complete`: state entry has all required fields
+  - Test `output_preview`: output longer than 500 chars is truncated
+  - Test `record_state_error`: state entry has status="error" and error message
+  - Test `finalize`: sets completed_at, status, final_variables
+  - Test `save`: creates `runs/` directory and writes JSON file
+  - Test `save` on resume: existing log file is loaded, new states appended, metadata updated
+  - Test parallel state recording: branches list is included in state entry
+
+- [x] T056 [US6] Integrate run log recorder into engine in `src/fdsx/core/engine.py`
+  - Import `RunRecorder` and create instance at start of `run_flow`
+  - Call `record_state_start` before each state execution (hook into compiler or engine event flow)
+  - Call `record_state_complete` after each state succeeds
+  - Call `record_state_error` when a state fails
+  - Call `finalize` + `save` at flow completion (both success and error)
+  - In `resume_flow`: load existing log and append new state entries
+  - Pass `RunRecorder` through compiler node functions via state dict or closure
+  - Ensure parallel branches record branch-level details
+
+## Phase 12: US7 — Batch Task Execution (FR-13)
+
+**Story Goal**: Accept a task file via `--tasks <file>`, use an LLM (specified by `task_splitter`) to split it into individual tasks, prompt the user for confirmation, then execute the workflow sequentially for each task with independent thread IDs. Handle failures with continue/stop prompts.
+
+**Independent Test Criteria**:
+- `fdsx run workflow.yaml --tasks tasks.md` reads the task file and invokes the task_splitter LLM
+- The split task list is displayed to the user for confirmation (approve/reject)
+- Each task executes the full workflow with an independent thread_id
+- If a task fails, the user is prompted to continue or stop
+- A results summary is displayed at the end
+- `--input` and `--tasks` are mutually exclusive (validation error if both provided)
+
+- [ ] T057 [US7] Implement batch task splitter in `src/fdsx/core/batch.py`
+  - `split_tasks(task_content: str, flow: Flow, task_splitter: TaskSplitter) -> list[str]`: invoke the task_splitter LLM to split the task file content into individual task descriptions
+    - Build a prompt that includes the task file content and the workflow definition (state names, input variables) to guide the LLM on appropriate granularity
+    - Call the provider specified by `task_splitter.provider` with `task_splitter.model`
+    - Parse the LLM response: expect one task per line (or numbered list), strip empty lines
+    - Return list of task description strings
+  - `display_task_list(tasks: list[str]) -> bool`: display the split tasks in numbered format to stderr, prompt user for confirmation (approve/reject). Return True if approved, False if rejected
+  - `display_batch_summary(results: list[dict]) -> None`: display a summary table of all task results to stderr (task index, description preview, status, thread_id)
+  - Reference: spec.md FR-13 for batch execution behavior
+
+- [ ] T058 [P] [US7] Write unit tests for batch task splitter in `tests/unit/test_batch.py`
+  - Test `split_tasks`: mock provider returns numbered task list → parses correctly into list of strings
+  - Test `split_tasks`: mock provider returns empty response → returns empty list
+  - Test `display_task_list`: mock stdin "y" → returns True
+  - Test `display_task_list`: mock stdin "n" → returns False
+  - Test `display_batch_summary`: verify output format includes task index, description, status, thread_id
+
+- [ ] T059 [US7] Implement batch execution orchestrator in `src/fdsx/core/engine.py`
+  - `run_batch(workflow_path: Path, tasks_file: Path, base_dir: Path | None = None) -> list[dict]`: orchestrate batch execution
+    - Load and validate the flow YAML
+    - Verify `task_splitter` is defined in the flow; raise error if missing
+    - Read the tasks file content
+    - Call `split_tasks` to get the task list
+    - Call `display_task_list` for user confirmation; abort if rejected
+    - For each task: generate independent thread_id, call `run_flow` with `{"task": task_description}` as input
+    - On task failure: display error, prompt user to continue or stop remaining tasks
+    - Return list of `{task_index, task_description, thread_id, status, error}` dicts
+    - Call `display_batch_summary` at the end
+  - Reference: spec.md FR-13, clarification "approve/reject only"
+
+- [ ] T060 [US7] Add `--tasks` option to CLI and validate mutual exclusion in `src/fdsx/cli/main.py`
+  - Add `--tasks` option to the `run` command: `tasks_file: Path | None = typer.Option(None, "--tasks", help="Batch task file path")`
+  - Validate `--input` and `--tasks` mutual exclusion: if both provided, print error and exit with code 2
+  - When `--tasks` is provided: call `engine.run_batch(workflow, tasks_file, base_dir)` instead of `engine.run_flow`
+  - Print batch results summary JSON to stdout on completion
+  - Exit code: 0 if all tasks succeed, 1 if any task failed
+
+- [ ] T061 [US7] Create batch execution test fixtures in `tests/fixtures/`
+  - `tests/fixtures/batch_flow.yaml`: simple 2-state flow (Plan → Implement) using system provider with `task_splitter: {provider: system, model: default}` and system command that echoes task descriptions
+  - `tests/fixtures/sample_tasks.md`: sample task file with 3 task descriptions for testing batch splitting
+
+- [ ] T062 [US7] Write integration test for batch execution in `tests/integration/test_batch.py`
+  - Test full batch flow: mock the task_splitter provider to return 3 tasks → approve → all 3 execute with independent thread_ids
+  - Test batch rejection: mock stdin to reject task list → verify no tasks executed
+  - Test batch failure handling: mock one task to fail → prompt to continue → remaining tasks execute
+  - Test `--input` + `--tasks` mutual exclusion: verify exit code 2 and error message
+  - Test missing `task_splitter`: flow without task_splitter field + `--tasks` option → clear error message
+
+## Phase 13: Edge Case Hardening
+
+**Story Goal**: Add exponential backoff for retries and ensure timeout handling is robust across all retry paths.
+
+- [ ] T063 Implement exponential backoff for retry loops in `src/fdsx/core/compiler.py`
+  - Modify the retry loop in `_create_task_node` to add exponential backoff delay between retries: `time.sleep(min(2 ** attempt, 30))` (1s, 2s, 4s, 8s... capped at 30s)
+  - Apply the same backoff to the retry loop in `_create_branch_executor` for parallel branch retries
+  - Add `import time` at the top of the file
+  - Ensure the first attempt has no delay (backoff starts from the second attempt)
+
+- [ ] T064 [P] Write unit test for exponential backoff in `tests/unit/test_backoff.py`
+  - Test: mock `time.sleep` and verify backoff delays for 3 retries → sleep(1), sleep(2), sleep(4)
+  - Test: verify first attempt has no delay
+  - Test: verify backoff is capped at 30 seconds for high retry counts
+  - Test: verify timeout_seconds triggers subprocess.TimeoutExpired which is caught and retried with backoff
+
+## Phase 14: Parallel Display Improvements
+
+**Story Goal**: Enhance terminal output during parallel execution with real-time status line updates and post-completion branch output display.
+
+- [ ] T065 Implement parallel status line updates in `src/fdsx/display/terminal.py`
+  - `display_branch_start(state_name: str, branch_index: int, provider: str, model: str | None) -> None`: print `  [branch-N] provider/model  ⏳ running...` to stderr
+  - `display_branch_complete(state_name: str, branch_index: int, provider: str, duration: float) -> None`: print `  [branch-N] provider/model  ✓ completed (Xs)` to stderr
+  - `display_branch_failed(state_name: str, branch_index: int, provider: str) -> None`: print `  [branch-N] provider/model  ✗ failed` to stderr
+  - `display_parallel_results(state_name: str, branch_results: list[dict]) -> None`: after all branches complete, display each branch's output with header `--- branch-N (provider/model) ---`
+  - Reference: contracts/cli.md "Parallel Execution Status" for exact format
+
+- [ ] T066 Integrate parallel display callbacks into compiler in `src/fdsx/core/compiler.py`
+  - In `_create_branch_executor`: call `display_branch_start` before provider execution
+  - On branch success: call `display_branch_complete` with duration
+  - On branch failure: call `display_branch_failed`
+  - In fan-in collector: call `display_parallel_results` with all branch outputs
+  - Import display functions from `src/fdsx/display/terminal.py`
+
+## Phase 15: PyPI Packaging (FR-12)
+
+**Story Goal**: Finalize pyproject.toml, create README with quickstart, and ensure `pip install fdsx` works.
+
+- [ ] T067 Finalize pyproject.toml for PyPI publishing in `pyproject.toml`
+  - Add/verify required PyPI fields: `description`, `authors`, `license`, `readme`, `classifiers`, `urls` (homepage, repository)
+  - Verify `[project.scripts]` entry point: `fdsx = "fdsx.cli.main:app"`
+  - Verify all runtime dependencies are correctly listed
+  - Add `[build-system]` section if missing (setuptools or hatchling)
+  - Test: `uv build` produces a valid wheel and sdist
+
+- [ ] T068 Write README with quickstart in `README.md`
+  - Include: project overview (what fdsx is), installation (`pip install fdsx`), quickstart (create a simple YAML flow + run it), feature overview (state types, parallel execution, checkpointing, batch tasks), CLI reference table, example workflow YAML
+  - Keep concise and practical — focus on getting users running in under 5 minutes
+  - Reference: spec.md Overview and Scenarios for content
+
+## Phase 16: Polish & Cross-Cutting
+
+- [ ] T069 Verify ruff and mypy pass with Phase 4 code in `pyproject.toml`
+  - Run `uv run ruff check src/ tests/` — fix any lint issues in new files
+  - Run `uv run mypy src/fdsx/` — fix any type errors in new files
+  - Ensure all Phase 1-3 tests still pass: `uv run pytest tests/`
+
+- [ ] T070 Write CLI e2e test for batch task scenario in `tests/integration/test_cli_e2e_phase4.py`
+  - Test `fdsx run workflow.yaml --tasks tasks.md` → mock task_splitter → approve → all tasks execute → exit code 0
+  - Test `fdsx run workflow.yaml --input task=foo --tasks tasks.md` → exit code 2, mutual exclusion error
+  - Test `fdsx run workflow.yaml --tasks tasks.md` with flow missing task_splitter → exit code 2
+  - Use `subprocess.run` to invoke the actual CLI entry point
+
+- [ ] T071 Write comprehensive e2e test suite for all scenarios in `tests/integration/test_e2e_scenarios.py`
+  - **Scenario 1**: Simple linear flow (Plan → Implement → Review) with system provider → verify state transitions and final JSON output
+  - **Scenario 2**: Parallel review + majority vote → verify parallel execution, aggregation result, choice routing
+  - **Scenario 3**: Wait state + webhook notification → mock stdin for selection, mock httpx for webhook → verify routing
+  - **Scenario 4**: Checkpoint/resume → run flow, interrupt, resume → verify completion and state restoration
+  - **Scenario 5**: Extraction + Choice routing → verify json/regex/keyword extraction drives correct branch
+  - Each scenario uses dedicated fixture YAMLs from `tests/fixtures/`
+  - Use `subprocess.run` for CLI invocation where applicable, direct engine calls for finer control
+
+- [ ] T072 Verify structured logging output in e2e tests in `tests/integration/test_e2e_scenarios.py`
+  - After each scenario run, verify `runs/<thread_id>.json` exists and conforms to the Run Log Format schema
+  - Verify state entries match the executed states (name, type, status)
+  - Verify `final_variables` contains expected keys
+  - Verify resume appends to existing log (Scenario 4 specifically)
+
+---
+
+## Dependencies
+
+```
+Phase 1-3 (T001-T053) completed
+  ↓
+T054 → T055 (run log recorder + tests)
+T054 → T056 (integrate recorder into engine)
+  ↓
+T057 → T058 (batch splitter + tests)
+T057 + T056 → T059 (batch orchestrator — needs engine + logging)
+T059 → T060 (CLI --tasks option)
+T060 → T061 → T062 (batch fixtures + integration test)
+  ↓
+T063 → T064 (exponential backoff + tests — independent)
+T065 → T066 (parallel display + integration — independent)
+  ↓
+T067 (PyPI packaging — independent)
+T068 (README — independent)
+  ↓
+T056 + T062 + T064 + T066 → T069 → T070 → T071 → T072
+```
+
+**Critical path**: T054 → T056 → T059 → T060 → T061 → T062 → T069 → T071 → T072
+
+**Parallel opportunities**:
+- T054 (structured logging) and T057 (batch splitter) and T063 (backoff) and T065 (parallel display) can all start in parallel
+- T055 (recorder tests) can run in parallel with T056 (engine integration)
+- T058 (batch tests) can run in parallel with T059 (batch orchestrator)
+- T067 (PyPI) and T068 (README) are independent and can run at any time
+- T064 (backoff tests) is independent of batch/logging work
+
+## Implementation Strategy
+
+- **MVP**: Complete through T062 (batch execution + structured logging). This enables the full Phase 4 batch workflow with observable execution.
+- **Incremental delivery**: T054-T056 deliver structured logging. T057-T062 add batch execution. T063-T064 harden retries. T065-T066 improve parallel UX. T067-T068 prepare for publish. T069-T072 validate everything.
+- **Key integration point**: T056 is the critical integration task — wiring RunRecorder into the engine's state execution lifecycle. Each node function needs recorder callbacks.
+- **No real LLMs needed**: Batch task splitter tests mock the LLM response. All other tests use `system` provider.
+- **E2E coverage**: T071 is the capstone task — verifying all 5 scenarios work end-to-end before publishing.
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total tasks | 19 (T054-T072) |
+| US6 tasks (Structured Logging) | 3 (T054-T056) |
+| US7 tasks (Batch Execution) | 6 (T057-T062) |
+| Edge Case Hardening tasks | 2 (T063-T064) |
+| Parallel Display tasks | 2 (T065-T066) |
+| PyPI Packaging tasks | 2 (T067-T068) |
+| Polish tasks | 4 (T069-T072) |
+| Unit test tasks | 3 (T055, T058, T064) |
+| Integration test tasks | 4 (T062, T070, T071, T072) |
+| Parallelizable tasks | 2 (T055, T058) |
+
+## Suggested takt Usage
+
+```bash
+# Phase 11: US6 — Structured logging recorder + tests
+takt run code "Implement RunRecorder (per-state input/output/duration, JSON run log to runs/<thread_id>.json, resume appends) in src/fdsx/logging/recorder.py and unit tests in tests/unit/test_recorder.py"
+
+# Phase 11: US6 — Integrate logging into engine
+takt run code "Integrate RunRecorder into run_flow and resume_flow in src/fdsx/core/engine.py, recording state start/complete/error and parallel branch details"
+
+# Phase 12: US7 — Batch task splitter + tests
+takt run code "Implement batch task splitter (LLM invocation, task list display, confirmation prompt, summary) in src/fdsx/core/batch.py and unit tests in tests/unit/test_batch.py"
+
+# Phase 12: US7 — Batch orchestrator + CLI integration
+takt run code "Implement run_batch orchestrator in src/fdsx/core/engine.py, add --tasks option with --input mutual exclusion in src/fdsx/cli/main.py"
+
+# Phase 12: US7 — Batch integration tests
+takt run code "Create batch_flow.yaml and sample_tasks.md fixtures in tests/fixtures/, write integration tests for batch execution in tests/integration/test_batch.py"
+
+# Phase 13: Edge case hardening
+takt run code "Add exponential backoff (2^attempt, capped 30s) to retry loops in src/fdsx/core/compiler.py, write unit tests in tests/unit/test_backoff.py"
+
+# Phase 14: Parallel display improvements
+takt run code "Implement branch start/complete/failed/results display functions in src/fdsx/display/terminal.py, integrate into parallel branch executor in src/fdsx/core/compiler.py"
+
+# Phase 15: PyPI packaging + README
+takt run code "Finalize pyproject.toml for PyPI, write README.md with quickstart, installation, feature overview, CLI reference, and example workflow"
+
+# Phase 16: Polish + e2e tests
+takt run code "Verify ruff/mypy pass, write CLI e2e tests for batch in tests/integration/test_cli_e2e_phase4.py, comprehensive e2e suite for all Scenarios 1-5 in tests/integration/test_e2e_scenarios.py with structured log verification"
+```

--- a/specs/20260314013547-fdsx-framework/tasks-phase4.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase4.md
@@ -162,18 +162,18 @@
 
 ## Phase 16: Polish & Cross-Cutting
 
-- [ ] T069 Verify ruff and mypy pass with Phase 4 code in `pyproject.toml`
+- [x] T069 Verify ruff and mypy pass with Phase 4 code in `pyproject.toml`
   - Run `uv run ruff check src/ tests/` — fix any lint issues in new files
   - Run `uv run mypy src/fdsx/` — fix any type errors in new files
   - Ensure all Phase 1-3 tests still pass: `uv run pytest tests/`
 
-- [ ] T070 Write CLI e2e test for batch task scenario in `tests/integration/test_cli_e2e_phase4.py`
+- [x] T070 Write CLI e2e test for batch task scenario in `tests/integration/test_cli_e2e_phase4.py`
   - Test `fdsx run workflow.yaml --tasks tasks.md` → mock task_splitter → approve → all tasks execute → exit code 0
   - Test `fdsx run workflow.yaml --input task=foo --tasks tasks.md` → exit code 2, mutual exclusion error
   - Test `fdsx run workflow.yaml --tasks tasks.md` with flow missing task_splitter → exit code 2
   - Use `subprocess.run` to invoke the actual CLI entry point
 
-- [ ] T071 Write comprehensive e2e test suite for all scenarios in `tests/integration/test_e2e_scenarios.py`
+- [x] T071 Write comprehensive e2e test suite for all scenarios in `tests/integration/test_e2e_scenarios.py`
   - **Scenario 1**: Simple linear flow (Plan → Implement → Review) with system provider → verify state transitions and final JSON output
   - **Scenario 2**: Parallel review + majority vote → verify parallel execution, aggregation result, choice routing
   - **Scenario 3**: Wait state + webhook notification → mock stdin for selection, mock httpx for webhook → verify routing
@@ -182,7 +182,7 @@
   - Each scenario uses dedicated fixture YAMLs from `tests/fixtures/`
   - Use `subprocess.run` for CLI invocation where applicable, direct engine calls for finer control
 
-- [ ] T072 Verify structured logging output in e2e tests in `tests/integration/test_e2e_scenarios.py`
+- [x] T072 Verify structured logging output in e2e tests in `tests/integration/test_e2e_scenarios.py`
   - After each scenario run, verify `runs/<thread_id>.json` exists and conforms to the Run Log Format schema
   - Verify state entries match the executed states (name, type, status)
   - Verify `final_variables` contains expected keys

--- a/specs/20260314013547-fdsx-framework/tasks-phase4.md
+++ b/specs/20260314013547-fdsx-framework/tasks-phase4.md
@@ -114,13 +114,13 @@
 
 **Story Goal**: Add exponential backoff for retries and ensure timeout handling is robust across all retry paths.
 
-- [ ] T063 Implement exponential backoff for retry loops in `src/fdsx/core/compiler.py`
+- [x] T063 Implement exponential backoff for retry loops in `src/fdsx/core/compiler.py`
   - Modify the retry loop in `_create_task_node` to add exponential backoff delay between retries: `time.sleep(min(2 ** attempt, 30))` (1s, 2s, 4s, 8s... capped at 30s)
   - Apply the same backoff to the retry loop in `_create_branch_executor` for parallel branch retries
   - Add `import time` at the top of the file
   - Ensure the first attempt has no delay (backoff starts from the second attempt)
 
-- [ ] T064 [P] Write unit test for exponential backoff in `tests/unit/test_backoff.py`
+- [x] T064 [P] Write unit test for exponential backoff in `tests/unit/test_backoff.py`
   - Test: mock `time.sleep` and verify backoff delays for 3 retries → sleep(1), sleep(2), sleep(4)
   - Test: verify first attempt has no delay
   - Test: verify backoff is capped at 30 seconds for high retry counts

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -1,0 +1,252 @@
+import os
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+
+def _extract_meta_from_checkpoint(checkpoint_data: dict) -> dict:
+    """Extract _meta from checkpoint channel_values, handling both
+    __root__ (object schema) and named-channel (TypedDict schema) layouts."""
+    channel_values = checkpoint_data.get("channel_values", {})
+    # Named-channel layout (flows with ParallelState or TypedDict schema)
+    meta = channel_values.get("_meta")
+    if isinstance(meta, dict):
+        return meta
+    # __root__ layout (flows using object schema, e.g. no ParallelState)
+    root = channel_values.get("__root__")
+    if isinstance(root, dict):
+        meta = root.get("_meta")
+        if isinstance(meta, dict):
+            return meta
+    return {}
+
+
+_SAFE_THREAD_ID = re.compile(r"^[a-zA-Z0-9_\-]+$")
+
+
+class CheckpointManager:
+    """Manages checkpoints and PID-based locks for flow execution.
+
+    Wraps LangGraph's SqliteSaver to provide:
+    - Checkpoint persistence to SQLite
+    - PID-based lock files to prevent concurrent execution
+    - Stale lock detection and cleanup
+    - Thread listing functionality
+    """
+
+    DEFAULT_BASE_DIR = Path(".fdsx")
+
+    def __init__(self, base_dir: Path | None = None):
+        """Initialize the CheckpointManager.
+
+        Args:
+            base_dir: Base directory for checkpoints and locks.
+                     Defaults to '.fdsx/' relative to CWD.
+        """
+        self.base_dir = base_dir if base_dir is not None else self.DEFAULT_BASE_DIR
+        self.checkpoints_dir = self.base_dir / "checkpoints"
+        self.locks_dir = self.base_dir / "locks"
+
+        self.base_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.checkpoints_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        self.locks_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    def get_checkpointer(self) -> SqliteSaver:
+        """Get a SqliteSaver checkpointer for the checkpoint directory.
+
+        Returns:
+            SqliteSaver configured to use the checkpoints database
+        """
+        db_path = self.checkpoints_dir / "checkpoints.db"
+        conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        try:
+            os.chmod(str(db_path), 0o600)
+        except OSError:
+            pass
+        return SqliteSaver(conn)
+
+    def _get_lock_path(self, thread_id: str) -> Path:
+        """Get the path to the lock file for a thread.
+
+        Raises:
+            ValueError: If thread_id contains unsafe characters or escapes locks_dir.
+        """
+        if not _SAFE_THREAD_ID.match(thread_id):
+            raise ValueError(f"Invalid thread ID: {thread_id!r}")
+        lock_path = (self.locks_dir / f"{thread_id}.lock").resolve()
+        if not str(lock_path).startswith(str(self.locks_dir.resolve())):
+            raise ValueError(f"Thread ID escapes lock directory: {thread_id!r}")
+        return lock_path
+
+    def acquire_lock(self, thread_id: str) -> bool:
+        """Acquire a lock for the given thread ID.
+
+        Args:
+            thread_id: The thread ID to lock
+
+        Returns:
+            True if lock was acquired, False if already locked by alive process
+        """
+        lock_path = self._get_lock_path(thread_id)
+
+        if lock_path.exists():
+            try:
+                with open(lock_path) as f:
+                    pid = int(f.read().strip())
+                try:
+                    os.kill(pid, 0)
+                    return False
+                except OSError:
+                    pass
+            except (ValueError, IOError):
+                pass
+
+            lock_path.unlink(missing_ok=True)
+
+        fd = os.open(str(lock_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(str(os.getpid()))
+
+        return True
+
+    def release_lock(self, thread_id: str) -> None:
+        """Release the lock for the given thread ID.
+
+        Args:
+            thread_id: The thread ID to unlock
+        """
+        lock_path = self._get_lock_path(thread_id)
+        lock_path.unlink(missing_ok=True)
+
+    def is_locked(self, thread_id: str) -> tuple[bool, int | None]:
+        """Check if a thread is locked.
+
+        Args:
+            thread_id: The thread ID to check
+
+        Returns:
+            Tuple of (is_locked, pid) where pid is the locking PID if locked
+        """
+        lock_path = self._get_lock_path(thread_id)
+
+        if not lock_path.exists():
+            return False, None
+
+        try:
+            with open(lock_path) as f:
+                pid = int(f.read().strip())
+            try:
+                os.kill(pid, 0)
+                return True, pid
+            except OSError:
+                return False, None
+        except (ValueError, IOError):
+            return False, None
+
+    def verify_checkpoint(self, thread_id: str) -> bool:
+        """Verify checkpoint integrity for a thread ID.
+
+        Args:
+            thread_id: The thread ID to verify
+
+        Returns:
+            True if checkpoint is valid, False otherwise
+        """
+        db_path = self.checkpoints_dir / "checkpoints.db"
+        if not db_path.exists():
+            return False
+
+        try:
+            conn = sqlite3.connect(str(db_path))
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COUNT(*) FROM checkpoints WHERE thread_id = ?",
+                (thread_id,),
+            )
+            count = cursor.fetchone()[0]
+            conn.close()
+            return count > 0
+        except Exception:
+            return False
+
+    def list_threads(self) -> list[dict[str, Any]]:
+        """List all known thread executions.
+
+        Returns:
+            List of thread info dictionaries with thread_id, status, flow_name
+        """
+        db_path = self.checkpoints_dir / "checkpoints.db"
+        if not db_path.exists():
+            return []
+
+        try:
+            conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            cursor = conn.cursor()
+            cursor.execute("SELECT DISTINCT thread_id FROM checkpoints")
+            thread_rows = cursor.fetchall()
+            conn.close()
+
+            threads = []
+            checkpointer = self.get_checkpointer()
+            for (thread_id,) in thread_rows:
+                is_locked, pid = self.is_locked(thread_id)
+                status = "running" if is_locked else "stopped"
+                flow_name = thread_id  # fallback default
+
+                current_state = ""
+                started_at = ""
+                config = {"configurable": {"thread_id": thread_id}}
+                try:
+                    checkpoint_tuple = checkpointer.get_tuple(config)
+                    if checkpoint_tuple is not None:
+                        checkpoint_data = checkpoint_tuple.checkpoint
+                        meta = _extract_meta_from_checkpoint(checkpoint_data)
+                        flow_name = meta.get("flow_name", thread_id)
+                        if not is_locked:
+                            if checkpoint_tuple.pending_writes:
+                                has_error = any(
+                                    pw[1] == "__error__"
+                                    for pw in checkpoint_tuple.pending_writes
+                                    if isinstance(pw, (list, tuple)) and len(pw) >= 2
+                                )
+                                status = "stopped" if has_error else "waiting"
+                            else:
+                                status = "completed"
+                        # Extract current_state from checkpoint.
+                        # For stopped/waiting flows, prefer _meta.next_state (the node
+                        # about to execute when the crash/interrupt happened).
+                        # For completed/running flows, use last entry in versions_seen.
+                        if status in ("stopped", "waiting"):
+                            next_state_val = meta.get("next_state", "")
+                            if next_state_val and next_state_val != "__end__":
+                                current_state = next_state_val
+                            else:
+                                versions_seen = checkpoint_data.get("versions_seen", {})
+                                if isinstance(versions_seen, dict) and versions_seen:
+                                    current_state = list(versions_seen.keys())[-1]
+                        else:
+                            versions_seen = checkpoint_data.get("versions_seen", {})
+                            if isinstance(versions_seen, dict) and versions_seen:
+                                current_state = list(versions_seen.keys())[-1]
+                        # Extract started_at from checkpoint ts
+                        ts = checkpoint_data.get("ts", "")
+                        if ts and "T" in str(ts):
+                            started_at = str(ts)[:16].replace("T", " ")
+                except Exception:
+                    pass
+
+                threads.append(
+                    {
+                        "thread_id": thread_id,
+                        "status": status,
+                        "flow_name": flow_name,
+                        "current_state": current_state,
+                        "started_at": started_at,
+                    }
+                )
+            return threads
+        except Exception:
+            return []

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -4,10 +4,14 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
+from langchain_core.runnables.config import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 
-def _extract_meta_from_checkpoint(checkpoint_data: dict) -> dict:
+def _extract_meta_from_checkpoint(
+    checkpoint_data: Checkpoint | dict[str, Any],
+) -> dict[str, Any]:
     """Extract _meta from checkpoint channel_values, handling both
     __root__ (object schema) and named-channel (TypedDict schema) layouts."""
     channel_values = checkpoint_data.get("channel_values", {})
@@ -168,7 +172,7 @@ class CheckpointManager:
             )
             count = cursor.fetchone()[0]
             conn.close()
-            return count > 0
+            return bool(count > 0)
         except Exception:
             return False
 
@@ -198,7 +202,7 @@ class CheckpointManager:
 
                 current_state = ""
                 started_at = ""
-                config = {"configurable": {"thread_id": thread_id}}
+                config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
                 try:
                     checkpoint_tuple = checkpointer.get_tuple(config)
                     if checkpoint_tuple is not None:

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -61,6 +61,8 @@ def run(
         typer.echo(f"Validation error: {e}", err=True)
         raise typer.Exit(code=2)
     except RuntimeError as e:
+        if isinstance(e, typer.Exit):
+            raise
         typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
         raise typer.Exit(code=1)
     except Exception as e:

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -18,8 +18,18 @@ def run(
     input_vars: list[str] | None = typer.Option(
         None, "--input", help="Input variable as KEY=VALUE"
     ),
+    tasks_file: Path | None = typer.Option(
+        None, "--tasks", help="Batch task file path"
+    ),
 ) -> None:
     """Run a workflow from a YAML file."""
+    if input_vars and tasks_file is not None:
+        typer.echo(
+            "Error: --input and --tasks are mutually exclusive",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
     inputs = None
     if input_vars:
         inputs = {}
@@ -36,8 +46,17 @@ def run(
     base_dir = Path(".fdsx")
 
     try:
-        result = engine.run_flow(workflow, inputs, thread_id, base_dir)
-        typer.echo(json.dumps(result, indent=2))
+        if tasks_file is not None:
+            results = engine.run_batch(workflow, tasks_file, base_dir)
+            typer.echo(json.dumps(results, indent=2))
+            has_failure = any(r.get("status") == "failed" for r in results)
+            if has_failure:
+                raise typer.Exit(code=1)
+            else:
+                raise typer.Exit(code=0)
+        else:
+            result = engine.run_flow(workflow, inputs, thread_id, base_dir)
+            typer.echo(json.dumps(result, indent=2))
     except FlowValidationError as e:
         typer.echo(f"Validation error: {e}", err=True)
         raise typer.Exit(code=2)
@@ -45,8 +64,10 @@ def run(
         typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
         raise typer.Exit(code=1)
     except Exception as e:
-        typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
-        raise typer.Exit(code=1)
+        if not isinstance(e, typer.Exit):
+            typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
+            raise typer.Exit(code=1)
+        raise
 
 
 @app.command()

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import typer
 
+from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core import engine
 from fdsx.core.engine import FlowValidationError
 from fdsx.display.terminal import _sanitize_output
@@ -14,15 +15,15 @@ app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework
 def run(
     workflow: Path = typer.Argument(..., help="Path to the YAML workflow file"),
     thread_id: str | None = typer.Option(None, help="Thread ID for this execution"),
-    input: list[str] | None = typer.Option(
+    input_vars: list[str] | None = typer.Option(
         None, "--input", help="Input variable as KEY=VALUE"
     ),
 ) -> None:
     """Run a workflow from a YAML file."""
     inputs = None
-    if input:
+    if input_vars:
         inputs = {}
-        for pair in input:
+        for pair in input_vars:
             if "=" not in pair:
                 typer.echo(
                     f"Invalid input format: {pair}. Use KEY=VALUE",
@@ -32,8 +33,10 @@ def run(
             key, value = pair.split("=", 1)
             inputs[key] = value
 
+    base_dir = Path(".fdsx")
+
     try:
-        result = engine.run_flow(workflow, inputs, thread_id)
+        result = engine.run_flow(workflow, inputs, thread_id, base_dir)
         typer.echo(json.dumps(result, indent=2))
     except FlowValidationError as e:
         typer.echo(f"Validation error: {e}", err=True)
@@ -60,6 +63,68 @@ def validate(
         for error in errors:
             typer.echo(f"Error: {error}", err=True)
         raise typer.Exit(code=2)
+
+
+@app.command()
+def resume(
+    thread_id: str = typer.Option(..., "--thread-id", help="Thread ID to resume"),
+    base_dir: Path | None = typer.Option(
+        None, "--base-dir", help="Base directory for checkpoints (default: .fdsx/)"
+    ),
+) -> None:
+    """Resume a flow from a checkpoint."""
+    try:
+        result = engine.resume_flow(thread_id, base_dir)
+        typer.echo(json.dumps(result, indent=2))
+    except RuntimeError as e:
+        error_msg = str(e)
+        if "No checkpoint found" in error_msg:
+            typer.echo(
+                f"Error: No checkpoint found for thread ID {_sanitize_output(thread_id)}",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        elif "locked by PID" in error_msg:
+            typer.echo(f"Error: {_sanitize_output(error_msg)}", err=True)
+            raise typer.Exit(code=2)
+        else:
+            typer.echo(f"Error: {_sanitize_output(error_msg)}", err=True)
+            raise typer.Exit(code=1)
+    except Exception as e:
+        typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
+        raise typer.Exit(code=1)
+
+
+@app.command(name="list")
+def list_flows(
+    base_dir: Path | None = typer.Option(
+        None, "--base-dir", help="Base directory for checkpoints (default: .fdsx/)"
+    ),
+) -> None:
+    """List all flow executions."""
+    if base_dir is None:
+        base_dir = Path(".fdsx")
+
+    manager = CheckpointManager(base_dir=base_dir)
+    threads = manager.list_threads()
+
+    if not threads:
+        typer.echo("No flow executions found.")
+        return
+
+    typer.echo(
+        f"{'THREAD_ID':<40} {'FLOW_NAME':<20} {'STATUS':<12} "
+        f"{'CURRENT_STATE':<20} {'STARTED_AT':<20}"
+    )
+    typer.echo("-" * 112)
+    for thread in threads:
+        typer.echo(
+            f"{_sanitize_output(thread['thread_id']):<40} "
+            f"{_sanitize_output(thread['flow_name']):<20} "
+            f"{_sanitize_output(thread['status']):<12} "
+            f"{_sanitize_output(thread.get('current_state', '')):<20} "
+            f"{_sanitize_output(thread.get('started_at', '')):<20}"
+        )
 
 
 if __name__ == "__main__":

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -1,0 +1,185 @@
+import sys
+from typing import Any
+
+from fdsx.display.terminal import _sanitize_output
+from fdsx.models.flow import Flow, TaskSplitter
+from fdsx.providers.base import get_provider
+
+
+def split_tasks(
+    task_content: str, flow: Flow, task_splitter: TaskSplitter
+) -> list[str]:
+    """Invoke the task_splitter LLM to split the task file content into individual tasks.
+
+    Args:
+        task_content: The content of the task file
+        flow: The flow definition
+        task_splitter: The task splitter configuration
+
+    Returns:
+        List of task description strings
+    """
+    provider = get_provider(task_splitter.provider)
+
+    state_names = list(flow.states.keys())
+    input_vars = _extract_input_variables(flow)
+
+    prompt = _build_task_split_prompt(task_content, state_names, input_vars)
+
+    result = provider.execute(
+        prompt=prompt,
+        model=task_splitter.model,
+    )
+
+    if result.exit_code != 0:
+        raise RuntimeError(f"Task splitter failed: {result.stderr}")
+
+    tasks = _parse_task_list(result.stdout)
+
+    return tasks
+
+
+def _build_task_split_prompt(
+    task_content: str, state_names: list[str], input_vars: set[str]
+) -> str:
+    """Build the prompt for the task splitter LLM."""
+    states_desc = ", ".join(state_names)
+    input_vars_desc = ", ".join(input_vars) if input_vars else "none"
+
+    prompt = f"""You are a task splitter. Given a batch of work, split it into individual executable tasks.
+
+The workflow has these states: {states_desc}
+The workflow accepts these input variables: {input_vars_desc}
+
+TASK CONTENT:
+{task_content}
+
+INSTRUCTIONS:
+1. Analyze the task content above
+2. Split it into individual, self-contained task descriptions
+3. Each task should be executable by the workflow and should set a 'task' variable
+4. Output ONLY a numbered list (1., 2., 3., etc.) with one task per line
+5. Keep tasks concise but clear
+6. Do NOT include any additional text, explanations, or formatting
+
+OUTPUT:"""
+
+    return prompt
+
+
+def _extract_input_variables(flow: Flow) -> set[str]:
+    """Extract expected input variables from the flow.
+
+    Scans prompt_template fields for {variable} references to identify actual inputs.
+    Also includes 'task' as the standard batch input variable.
+    """
+    import re
+
+    from fdsx.models.flow import ParallelState, TaskState
+
+    input_vars: set[str] = {"task"}
+    # Matches {var}, {var.field}, {var[0]} etc.
+    var_pattern = r"\{(\w+(?:\.\w+)*(?:\[\d+\])?)\}"
+
+    for state_name, state in flow.states.items():
+        if isinstance(state, TaskState) and state.prompt_template:
+            for match in re.findall(var_pattern, state.prompt_template):
+                root = match.split(".")[0].split("[")[0]
+                input_vars.add(root)
+        elif isinstance(state, ParallelState):
+            for branch in state.branches:
+                if branch.prompt_template:
+                    for match in re.findall(var_pattern, branch.prompt_template):
+                        root = match.split(".")[0].split("[")[0]
+                        input_vars.add(root)
+
+    return input_vars
+
+
+def _parse_task_list(response: str) -> list[str]:
+    """Parse the LLM response into a list of task strings."""
+    tasks: list[str] = []
+    lines = response.strip().split("\n")
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+
+        if line[0].isdigit() and ". " in line:
+            task = line.split(". ", 1)[1].strip()
+            tasks.append(task)
+        else:
+            tasks.append(line)
+
+    return tasks
+
+
+def display_task_list(tasks: list[str]) -> bool:
+    """Display the split tasks in numbered format and prompt for confirmation.
+
+    Args:
+        tasks: List of task description strings
+
+    Returns:
+        True if user approves, False if rejected
+    """
+    print("The following tasks will be executed:", file=sys.stderr)
+    print("-" * 60, file=sys.stderr)
+
+    for i, task in enumerate(tasks, 1):
+        task_preview = task[:70] + "..." if len(task) > 70 else task
+        print(f"  {i}. {_sanitize_output(task_preview)}", file=sys.stderr)
+
+    print("-" * 60, file=sys.stderr)
+
+    while True:
+        response = input("Approve task list? (y/n): ").strip().lower()
+        if response == "y":
+            return True
+        elif response == "n":
+            return False
+
+
+def display_batch_summary(results: list[dict[str, Any]]) -> None:
+    """Display a summary table of all task results.
+
+    Args:
+        results: List of result dicts with task_index, task_description, thread_id, status, error
+    """
+    print("\n" + "=" * 80, file=sys.stderr)
+    print("BATCH EXECUTION SUMMARY", file=sys.stderr)
+    print("=" * 80, file=sys.stderr)
+    print(
+        f"{'#':<4} {'STATUS':<12} {'THREAD_ID':<36} {'TASK':<25}",
+        file=sys.stderr,
+    )
+    print("-" * 80, file=sys.stderr)
+
+    for result in results:
+        task_idx = result.get("task_index", 0) + 1
+        status = result.get("status", "unknown")
+        thread_id = result.get("thread_id", "")[:36]
+        task_desc = result.get("task_description", "")[:25]
+
+        status_symbol = "✓" if status == "completed" else "✗"
+
+        print(
+            f"{task_idx:<4} {status_symbol} {status:<10} {_sanitize_output(thread_id):<36} {_sanitize_output(task_desc):<25}",
+            file=sys.stderr,
+        )
+
+        if result.get("error"):
+            error_preview = result["error"][:60]
+            print(f"       Error: {_sanitize_output(error_preview)}", file=sys.stderr)
+
+    print("-" * 80, file=sys.stderr)
+
+    total = len(results)
+    succeeded = sum(1 for r in results if r.get("status") == "completed")
+    failed = total - succeeded
+
+    print(
+        f"Total: {total} | Succeeded: {succeeded} | Failed: {failed}", file=sys.stderr
+    )
+    print("=" * 80, file=sys.stderr)

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -448,12 +448,11 @@ def _create_branch_executor(
         branch = state.branches[branch_index]
 
         start_time = time.time()
-        terminal.display_branch_status(
+        terminal.display_branch_start(
             state_name=state_name,
             branch_index=branch_index,
             provider=branch.provider,
-            status="running",
-            duration=None,
+            model=branch.model,
         )
 
         prompt = branch.prompt_template or ""
@@ -512,12 +511,11 @@ def _create_branch_executor(
         duration = time.time() - start_time
 
         if result.exit_code != 0:
-            terminal.display_branch_status(
+            terminal.display_branch_failed(
                 state_name=state_name,
                 branch_index=branch_index,
                 provider=branch.provider,
-                status="failed",
-                duration=duration,
+                model=branch.model,
             )
             branch_result: dict[str, Any] = {
                 "index": branch_index,
@@ -527,12 +525,11 @@ def _create_branch_executor(
                 "_duration": duration,
             }
         elif branch.extract and extracted is None:
-            terminal.display_branch_status(
+            terminal.display_branch_failed(
                 state_name=state_name,
                 branch_index=branch_index,
                 provider=branch.provider,
-                status="failed",
-                duration=duration,
+                model=branch.model,
             )
             branch_result = {
                 "index": branch_index,
@@ -542,11 +539,11 @@ def _create_branch_executor(
                 "_duration": duration,
             }
         else:
-            terminal.display_branch_status(
+            terminal.display_branch_complete(
                 state_name=state_name,
                 branch_index=branch_index,
                 provider=branch.provider,
-                status="completed",
+                model=branch.model,
                 duration=duration,
             )
             branch_result = {
@@ -649,6 +646,23 @@ def _create_collector_node(
             )
 
         new_state = set_jsonpath(state.result_path, state_dict, clean_results)
+
+        display_results = []
+        for r in sorted_results:
+            idx = r.get("index", 0)
+            if idx < len(state.branches):
+                branch = state.branches[idx]
+                display_results.append(
+                    {
+                        **r,
+                        "provider": branch.provider,
+                        "model": branch.model,
+                    }
+                )
+            else:
+                display_results.append({**r, "provider": "unknown", "model": None})
+
+        terminal.display_parallel_results(state_name, display_results)
 
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -1,7 +1,9 @@
+import operator
 import time
-from typing import Any, Callable, TypedDict
+from typing import Annotated, Any, Callable, TypedDict
 
 from langgraph.graph import END, StateGraph
+from langgraph.types import Send
 
 from fdsx.core.variables import (
     resolve_template,
@@ -11,6 +13,7 @@ from fdsx.core.variables import (
 from fdsx.display import terminal
 from fdsx.display.terminal import _sanitize_output
 from fdsx.models.flow import (
+    AggregateRule,
     ChoiceState,
     Flow,
     ParallelState,
@@ -36,32 +39,134 @@ class CompiledGraph:
         self.result_paths = result_paths
 
 
-def compile_flow(flow: Flow) -> CompiledGraph:
+def _top_level_key(path: str) -> str | None:
+    """Extract the top-level key from a JSONPath like '$.reviews' → 'reviews'."""
+    if path.startswith("$."):
+        path = path[2:]
+    if not path:
+        return None
+    return path.split(".")[0].split("[")[0] or None
+
+
+def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
+    """Build a TypedDict state schema that covers ALL state keys used by the flow.
+
+    LangGraph's _get_updates filters every node's output dict to only keys that
+    are declared as channels in the schema. With a partial schema (only _br_* keys),
+    all workflow variables like $.reviews, $.decision, $.plan_output would be silently
+    dropped by _get_updates. This function declares ALL needed keys:
+
+    1. _br_{state_name} reducer channels (Annotated[list, operator.add]) for each
+       ParallelState — required for Send API fan-in accumulation.
+    2. All result_path / extract / aggregate top-level keys as LastValue channels.
+    3. Input keys from --input CLI flags.
+    4. _meta internal key.
+
+    Returns `object` (→ __root__ single channel, no filtering) for flows with no
+    ParallelState, since they don't need the Send API reducer channels.
+    """
+    has_parallel = any(isinstance(s, ParallelState) for s in flow.states.values())
+    if not has_parallel:
+        return object
+
+    annotations: dict[str, Any] = {}
+
+    # 1. Reducer channels for parallel branch result accumulation
+    for state_name, state in flow.states.items():
+        if isinstance(state, ParallelState):
+            annotations[f"_br_{state_name}"] = Annotated[list, operator.add]
+
+    # 2. All result_path / extract.result_path / aggregate.result_path top-level keys
+    for state_name, state in flow.states.items():
+        if isinstance(state, TaskState) and state.result_path:
+            k = _top_level_key(state.result_path)
+            if k:
+                annotations.setdefault(k, Any)
+            if state.extract:
+                k = _top_level_key(state.extract.result_path)
+                if k:
+                    annotations.setdefault(k, Any)
+        elif isinstance(state, ParallelState) and state.result_path:
+            k = _top_level_key(state.result_path)
+            if k:
+                annotations.setdefault(k, Any)
+        elif isinstance(state, PassState):
+            if state.aggregate:
+                k = _top_level_key(state.aggregate.result_path)
+                if k:
+                    annotations.setdefault(k, Any)
+            if state.parameters:
+                for target in state.parameters:
+                    k = _top_level_key(str(target))
+                    if k:
+                        annotations.setdefault(k, Any)
+        elif isinstance(state, WaitState) and state.result_path:
+            k = _top_level_key(state.result_path)
+            if k:
+                annotations.setdefault(k, Any)
+
+    # 3. Input keys from --input CLI flags
+    if input_keys:
+        for key in input_keys:
+            annotations.setdefault(key, Any)
+
+    # 4. Internal tracking key
+    annotations.setdefault("_meta", Any)
+
+    return TypedDict("FlowState", annotations, total=False)  # type: ignore[no-any-return,operator]
+
+
+def compile_flow(
+    flow: Flow, input_keys: set[str] | None = None
+) -> CompiledGraph:
     """Compile a Flow into a LangGraph StateGraph.
 
     Args:
         flow: The Flow to compile
+        input_keys: Top-level keys injected via --input; needed for the state schema
+                    so LangGraph channels are created for them.
 
     Returns:
         CompiledGraph with the compiled state machine
     """
     result_paths = _extract_result_paths(flow)
 
-    graph: StateGraph[Any] = StateGraph(object)
+    schema = _build_state_schema(flow, input_keys)
+    graph: StateGraph[Any] = StateGraph(schema)
 
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
             graph.add_node(state_name, _create_task_node(state_name, state, flow))  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
             graph.add_node(state_name, _create_choice_node(state_name, state, flow))  # type: ignore[call-overload]
-        elif state.type == "parallel":
-            graph.add_node(state_name, _create_parallel_node(state_name, state, flow))  # type: ignore[call-overload]
+        elif isinstance(state, ParallelState):
+            # Three-node pattern: dispatch → branch (×N via Send) → collector
+            graph.add_node(state_name, _create_dispatch_node(state_name, state))  # type: ignore[call-overload]
+            graph.add_node(f"_branch_{state_name}", _create_branch_executor(state_name, state, flow))  # type: ignore[call-overload]
+            graph.add_node(f"_collect_{state_name}", _create_collector_node(state_name, state, flow))  # type: ignore[call-overload]
         elif state.type == "pass":
             graph.add_node(state_name, _create_pass_node(state_name, state, flow))  # type: ignore[call-overload]
         elif state.type == "wait":
             graph.add_node(state_name, _create_wait_node(state_name, state, flow))  # type: ignore[call-overload]
 
     for state_name, state in flow.states.items():
+        if isinstance(state, ParallelState):
+            # Fan-out: dispatch node → branch nodes via Send API (no path_map needed)
+            graph.add_conditional_edges(
+                state_name,
+                _create_fan_out(state_name, state),
+            )
+            # Fan-in: each branch node → collector
+            graph.add_edge(f"_branch_{state_name}", f"_collect_{state_name}")
+            # Outgoing: collector → next state (NOT dispatch node)
+            next_s = _get_next_state(state)
+            if next_s:
+                graph.add_edge(
+                    f"_collect_{state_name}",
+                    END if next_s == "END" else next_s,
+                )
+            continue  # Skip the regular edge-adding below for ParallelState
+
         next_state = _get_next_state(state)
         if next_state:
             if next_state == "END":
@@ -95,8 +200,8 @@ def _extract_result_paths(flow: Flow) -> list[str]:
                 paths.append(state.extract.result_path)
         elif isinstance(state, ParallelState) and state.result_path:
             paths.append(state.result_path)
-            # Do NOT add branch extract paths — they are nested inside
-            # result array elements, not top-level state keys.
+        elif isinstance(state, PassState) and state.aggregate:
+            paths.append(state.aggregate.result_path)
         elif isinstance(state, WaitState) and state.result_path:
             paths.append(state.result_path)
     return paths
@@ -205,36 +310,61 @@ def _create_choice_node(
     return node
 
 
-def _create_parallel_node(
+def _create_dispatch_node(
+    state_name: str, state: ParallelState
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Create the dispatch node for a Parallel state.
+
+    Displays the parallel state start line and triggers fan-out via Send.
+    Returns {} (no state update) — the fan-out is triggered by the conditional edges.
+    Only emits display_parallel_start (not display_state_start) to match CLI contract.
+    """
+
+    def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        terminal.display_parallel_start(state_name, len(state.branches))
+        return {}
+
+    return node
+
+
+def _create_branch_executor(
     state_name: str, state: ParallelState, flow: Flow
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Create a LangGraph node function for a Parallel state."""
+    """Create a shared branch executor node invoked once per branch via Send.
+
+    Reads `_branch_index` from the state dict to identify which branch to run.
+    Returns `{f"_br_{state_name}": [result]}` — accumulated by operator.add reducer.
+    Never raises: all errors are captured in the result dict (exit_code != 0).
+    """
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         from fdsx.core.extraction import extract_value
         from fdsx.providers.base import ProviderResult
 
+        branch_index: int = state_dict.get("_branch_index", 0)
+        branch = state.branches[branch_index]
+
         start_time = time.time()
-        terminal.display_state_start(
+        terminal.display_branch_status(
             state_name=state_name,
-            state_type="parallel",
-            provider=None,
-            model=None,
+            branch_index=branch_index,
+            provider=branch.provider,
+            status="running",
+            duration=None,
         )
 
-        results = []
-        for branch in state.branches:
-            prompt = branch.prompt_template or ""
-            resolved_prompt = resolve_template(prompt, state_dict)
+        prompt = branch.prompt_template or ""
+        resolved_prompt = resolve_template(prompt, state_dict)
 
-            provider = get_provider(branch.provider)
+        provider = get_provider(branch.provider)
 
-            max_retries = branch.retry if branch.retry is not None else 3
-            last_error = "No attempts made"
-            result = ProviderResult(exit_code=1, stdout="", stderr="")
-            extracted: str | None = None
+        max_retries = branch.retry if branch.retry is not None else 3
+        last_error = "No attempts made"
+        result = ProviderResult(exit_code=1, stdout="", stderr="")
+        extracted: str | None = None
 
-            for attempt in range(max_retries + 1):
+        for _attempt in range(max_retries + 1):
+            try:
                 if branch.provider == "system":
                     resolved_command = resolve_template_shell_safe(
                         branch.command or "", state_dict
@@ -253,43 +383,146 @@ def _create_parallel_node(
                         timeout=branch.timeout_seconds,
                         output_callback=terminal.display_output_line,
                     )
+            except Exception as exc:
+                last_error = str(exc)
+                result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
+                continue
 
-                if result.exit_code == 0:
-                    if branch.extract:
-                        extracted = extract_value(
-                            result.stdout.strip(),
-                            branch.extract,
-                            get_provider,
-                            source_provider=branch.provider,
-                        )
-                        if extracted is not None:
-                            break
-                        last_error = "Extraction failed: all strategies returned None"
-                    else:
+            if result.exit_code == 0:
+                if branch.extract:
+                    extracted = extract_value(
+                        result.stdout.strip(),
+                        branch.extract,
+                        get_provider,
+                        source_provider=branch.provider,
+                    )
+                    if extracted is not None:
                         break
+                    last_error = "Extraction failed: all strategies returned None"
                 else:
-                    last_error = result.stderr
+                    break
+            else:
+                last_error = result.stderr
 
-            if result.exit_code != 0:
-                last_error = f"Failed after {max_retries + 1} attempts: {_sanitize_output(last_error)}"
-            elif branch.extract and extracted is None:
-                result = ProviderResult(exit_code=1, stdout=result.stdout, stderr="")
-                last_error = f"Extraction failed after {max_retries + 1} attempts: all strategies returned None"
+        duration = time.time() - start_time
 
-            branch_result = {
+        if result.exit_code != 0:
+            terminal.display_branch_status(
+                state_name=state_name,
+                branch_index=branch_index,
+                provider=branch.provider,
+                status="failed",
+                duration=duration,
+            )
+            branch_result: dict[str, Any] = {
+                "index": branch_index,
                 "output": result.stdout.strip(),
                 "exit_code": result.exit_code,
-                "error": last_error if result.exit_code != 0 else None,
+                "error": _sanitize_output(last_error),
+            }
+        elif branch.extract and extracted is None:
+            terminal.display_branch_status(
+                state_name=state_name,
+                branch_index=branch_index,
+                provider=branch.provider,
+                status="failed",
+                duration=duration,
+            )
+            branch_result = {
+                "index": branch_index,
+                "output": result.stdout.strip(),
+                "exit_code": 1,
+                "error": f"Extraction failed after {max_retries + 1} attempts: all strategies returned None",
+            }
+        else:
+            terminal.display_branch_status(
+                state_name=state_name,
+                branch_index=branch_index,
+                provider=branch.provider,
+                status="completed",
+                duration=duration,
+            )
+            branch_result = {
+                "index": branch_index,
+                "output": result.stdout.strip(),
+                "exit_code": 0,
+                "error": None,
             }
 
-            if branch.extract and extracted is not None:
-                branch_result = set_jsonpath(
-                    branch.extract.result_path, branch_result, extracted
-                )
+        if branch.extract and extracted is not None:
+            branch_result = set_jsonpath(
+                branch.extract.result_path, branch_result, extracted
+            )
 
-            results.append(branch_result)
+        return {f"_br_{state_name}": [branch_result]}
 
-        new_state = set_jsonpath(state.result_path, state_dict, results)
+    return node
+
+
+def _create_fan_out(
+    state_name: str, state: ParallelState
+) -> Callable[[dict[str, Any]], list[Send]]:
+    """Create the fan-out function that returns one Send per branch.
+
+    Each Send carries a fresh `_br_{state_name}: []` reset so that accumulation
+    from a previous pass through this parallel state (in a loop) does not bleed
+    into the current pass.
+    """
+
+    def fan_out(state_dict: dict[str, Any]) -> list[Send]:
+        return [
+            Send(
+                f"_branch_{state_name}",
+                {**state_dict, "_branch_index": i, f"_br_{state_name}": []},
+            )
+            for i in range(len(state.branches))
+        ]
+
+    return fan_out
+
+
+def _create_collector_node(
+    state_name: str, state: ParallelState, flow: Flow
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Create the fan-in collector node for a Parallel state.
+
+    Reads branch results accumulated by the operator.add reducer, sorts by index,
+    enforces min_success (defaulting to all branches), and stores at result_path.
+    """
+
+    def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        start_time = time.time()
+
+        # All branch results fan-in via operator.add reducer
+        raw_results: list[dict[str, Any]] = state_dict.get(f"_br_{state_name}", [])
+
+        # Sort by original branch index to preserve declaration order
+        sorted_results = sorted(raw_results, key=lambda r: r.get("index", 0))
+
+        # Strip internal "index" key — not part of the public branch result schema
+        clean_results = [
+            {k: v for k, v in r.items() if k != "index"} for r in sorted_results
+        ]
+
+        # Enforce min_success — default: ALL branches must succeed (FR-2.3)
+        min_required = (
+            state.min_success if state.min_success is not None else len(state.branches)
+        )
+        successful = sum(1 for r in clean_results if r.get("exit_code") == 0)
+
+        if successful < min_required:
+            failed_branches = [
+                f"branch {i}: {r.get('error', 'unknown error')}"
+                for i, r in enumerate(clean_results)
+                if r.get("exit_code") != 0
+            ]
+            raise RuntimeError(
+                f"Parallel state '{state_name}' failed: only {successful}/{len(state.branches)} "
+                f"branches succeeded, required {min_required}. "
+                f"Failed branches: {'; '.join(failed_branches)}"
+            )
+
+        new_state = set_jsonpath(state.result_path, state_dict, clean_results)
 
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
@@ -297,6 +530,46 @@ def _create_parallel_node(
         return new_state
 
     return node
+
+
+def _aggregate(source_data: list[dict[str, Any]], rule: AggregateRule) -> str:
+    """Aggregate parallel results using majority/all/any strategy.
+
+    Args:
+        source_data: List of branch result dictionaries (already resolved from state)
+        rule: AggregateRule with field, strategy, match/no_match values
+
+    Returns:
+        The aggregated result (rule.match or rule.no_match)
+
+    Security note: Uses total branch count (len(source_data)) as the denominator,
+    so failed branches that did not produce the field count as no_match votes.
+    This prevents bypassing a dissenting reviewer by knocking out their branch.
+    """
+    if not source_data:
+        return rule.no_match
+
+    if not isinstance(source_data, list):
+        return rule.no_match
+
+    # Use total branch count as denominator — failed/missing branches count as no_match
+    total = len(source_data)
+
+    match_count = 0
+    for item in source_data:
+        if isinstance(item, dict) and rule.field in item:
+            if str(item[rule.field]) == str(rule.match):
+                match_count += 1
+        # Items without the field (failed branches) are treated as no_match
+
+    if rule.strategy == "majority":
+        return rule.match if match_count > total / 2 else rule.no_match
+    elif rule.strategy == "all":
+        return rule.match if match_count == total else rule.no_match
+    elif rule.strategy == "any":
+        return rule.match if match_count > 0 else rule.no_match
+    else:
+        raise ValueError(f"Unknown aggregation strategy: {rule.strategy}")
 
 
 def _create_pass_node(
@@ -313,6 +586,17 @@ def _create_pass_node(
                     value = source
                 new_state = set_jsonpath(target, state_dict, value)
                 state_dict = new_state
+
+        if state.aggregate:
+            from fdsx.core.variables import resolve_jsonpath
+
+            source_data = resolve_jsonpath(state.aggregate.source, state_dict)
+            if isinstance(source_data, list):
+                result = _aggregate(source_data, state.aggregate)
+            else:
+                result = state.aggregate.no_match
+            state_dict = set_jsonpath(state.aggregate.result_path, state_dict, result)
+
         return state_dict
 
     return node

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -120,6 +120,7 @@ def compile_flow(
     flow: Flow,
     input_keys: set[str] | None = None,
     checkpointer: Any = None,
+    recorder: Any = None,
 ) -> CompiledGraph:
     """Compile a Flow into a LangGraph StateGraph.
 
@@ -150,29 +151,36 @@ def compile_flow(
 
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
-            graph.add_node(state_name, _create_task_node(state_name, state, flow))  # type: ignore[call-overload]
+            graph.add_node(
+                state_name, _create_task_node(state_name, state, flow, recorder)
+            )  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
-            graph.add_node(state_name, _create_choice_node(state_name, state, flow))  # type: ignore[call-overload]
+            graph.add_node(
+                state_name, _create_choice_node(state_name, state, flow, recorder)
+            )  # type: ignore[call-overload]
         elif isinstance(state, ParallelState):
-            # Three-node pattern: dispatch → branch (×N via Send) → collector
-            graph.add_node(state_name, _create_dispatch_node(state_name, state))  # type: ignore[call-overload]
+            graph.add_node(
+                state_name, _create_dispatch_node(state_name, state, recorder)
+            )  # type: ignore[call-overload]
             graph.add_node(
                 f"_branch_{state_name}",
-                _create_branch_executor(state_name, state, flow),
+                _create_branch_executor(state_name, state, flow, recorder),
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_collect_{state_name}",
-                _create_collector_node(state_name, state, flow),
+                _create_collector_node(state_name, state, flow, recorder),
             )  # type: ignore[call-overload]
         elif state.type == "pass":
-            graph.add_node(state_name, _create_pass_node(state_name, state, flow))  # type: ignore[call-overload]
-        elif state.type == "wait":
-            # Two-node pattern: notify pre-node (checkpointed) → interrupt node.
-            # The notify node fires once; on resume LangGraph replays only the
-            # interrupt node because the checkpoint advances past the notify node.
-            graph.add_node(state_name, _create_wait_notify_node(state_name, state))  # type: ignore[call-overload]
             graph.add_node(
-                f"_{state_name}_int", _create_wait_interrupt_node(state_name, state)
+                state_name, _create_pass_node(state_name, state, flow, recorder)
+            )  # type: ignore[call-overload]
+        elif state.type == "wait":
+            graph.add_node(
+                state_name, _create_wait_notify_node(state_name, state, recorder)
+            )  # type: ignore[call-overload]
+            graph.add_node(
+                f"_{state_name}_int",
+                _create_wait_interrupt_node(state_name, state, recorder),
             )  # type: ignore[call-overload]
             graph.add_edge(state_name, f"_{state_name}_int")
 
@@ -272,7 +280,7 @@ def _set_next_state_meta(state_dict: dict[str, Any], state: Any) -> dict[str, An
 
 
 def _create_task_node(
-    state_name: str, state: TaskState, flow: Flow
+    state_name: str, state: TaskState, flow: Flow, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Task state."""
 
@@ -287,6 +295,9 @@ def _create_task_node(
             provider=state.provider,
             model=state.model,
         )
+
+        if recorder is not None:
+            recorder.record_state_start(state_name, "task")
 
         prompt = state.prompt_template or ""
         resolved_prompt = resolve_template(prompt, state_dict)
@@ -336,6 +347,8 @@ def _create_task_node(
 
         if result.exit_code != 0:
             terminal.display_state_error(state_name, last_error)
+            if recorder is not None:
+                recorder.record_state_error(state_name, last_error)
             raise RuntimeError(
                 f"Provider {state.provider} failed after {max_retries + 1} attempts with exit code {result.exit_code}: {_sanitize_output(last_error)}"
             )
@@ -343,6 +356,8 @@ def _create_task_node(
         if state.extract:
             if extracted is None:
                 terminal.display_state_error(state_name, last_error)
+                if recorder is not None:
+                    recorder.record_state_error(state_name, last_error)
                 raise RuntimeError(
                     f"Extraction failed after {max_retries + 1} attempts: all strategies returned None"
                 )
@@ -350,13 +365,23 @@ def _create_task_node(
             new_state = set_jsonpath(
                 state.result_path, new_state, result.stdout.strip()
             )
+            variables_set = [state.extract.result_path, state.result_path]
         else:
             new_state = set_jsonpath(
                 state.result_path, state_dict, result.stdout.strip()
             )
+            variables_set = [state.result_path]
 
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
+
+        if recorder is not None:
+            recorder.record_state_complete(
+                state_name,
+                "success",
+                result.stdout,
+                variables_set,
+            )
 
         new_state = _set_next_state_meta(new_state, state)
         return new_state
@@ -365,18 +390,21 @@ def _create_task_node(
 
 
 def _create_choice_node(
-    state_name: str, state: ChoiceState, flow: Flow
+    state_name: str, state: ChoiceState, flow: Flow, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Choice state."""
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        if recorder is not None:
+            recorder.record_state_start(state_name, "choice")
+            recorder.record_state_complete(state_name, "success", "", [])
         return state_dict
 
     return node
 
 
 def _create_dispatch_node(
-    state_name: str, state: ParallelState
+    state_name: str, state: ParallelState, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create the dispatch node for a Parallel state.
 
@@ -387,13 +415,15 @@ def _create_dispatch_node(
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         terminal.display_parallel_start(state_name, len(state.branches))
+        if recorder is not None:
+            recorder.record_state_start(state_name, "parallel")
         return {}
 
     return node
 
 
 def _create_branch_executor(
-    state_name: str, state: ParallelState, flow: Flow
+    state_name: str, state: ParallelState, flow: Flow, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a shared branch executor node invoked once per branch via Send.
 
@@ -484,6 +514,7 @@ def _create_branch_executor(
                 "output": result.stdout.strip(),
                 "exit_code": result.exit_code,
                 "error": _sanitize_output(last_error),
+                "_duration": duration,
             }
         elif branch.extract and extracted is None:
             terminal.display_branch_status(
@@ -498,6 +529,7 @@ def _create_branch_executor(
                 "output": result.stdout.strip(),
                 "exit_code": 1,
                 "error": f"Extraction failed after {max_retries + 1} attempts: all strategies returned None",
+                "_duration": duration,
             }
         else:
             terminal.display_branch_status(
@@ -512,6 +544,7 @@ def _create_branch_executor(
                 "output": result.stdout.strip(),
                 "exit_code": 0,
                 "error": None,
+                "_duration": duration,
             }
 
         if branch.extract and extracted is not None:
@@ -547,7 +580,7 @@ def _create_fan_out(
 
 
 def _create_collector_node(
-    state_name: str, state: ParallelState, flow: Flow
+    state_name: str, state: ParallelState, flow: Flow, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create the fan-in collector node for a Parallel state.
 
@@ -558,18 +591,28 @@ def _create_collector_node(
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         start_time = time.time()
 
-        # All branch results fan-in via operator.add reducer
         raw_results: list[dict[str, Any]] = state_dict.get(f"_br_{state_name}", [])
 
-        # Sort by original branch index to preserve declaration order
         sorted_results = sorted(raw_results, key=lambda r: r.get("index", 0))
 
-        # Strip internal "index" key — not part of the public branch result schema
+        branch_info_list: list[dict[str, Any]] = []
+        for r in sorted_results:
+            branch_info_list.append(
+                {
+                    "index": r.get("index", 0),
+                    "provider": state.branches[r.get("index", 0)].provider
+                    if r.get("index", 0) < len(state.branches)
+                    else "unknown",
+                    "status": "success" if r.get("exit_code") == 0 else "error",
+                    "duration_seconds": int(r.get("_duration", 0)),
+                }
+            )
+
         clean_results = [
-            {k: v for k, v in r.items() if k != "index"} for r in sorted_results
+            {k: v for k, v in r.items() if k != "index" and k != "_duration"}
+            for r in sorted_results
         ]
 
-        # Enforce min_success — default: ALL branches must succeed (FR-2.3)
         min_required = (
             state.min_success if state.min_success is not None else len(state.branches)
         )
@@ -581,6 +624,14 @@ def _create_collector_node(
                 for i, r in enumerate(clean_results)
                 if r.get("exit_code") != 0
             ]
+            if recorder is not None:
+                recorder.record_state_complete(
+                    state_name,
+                    "error",
+                    f"Only {successful}/{len(state.branches)} branches succeeded",
+                    [state.result_path],
+                    branch_info_list,
+                )
             raise RuntimeError(
                 f"Parallel state '{state_name}' failed: only {successful}/{len(state.branches)} "
                 f"branches succeeded, required {min_required}. "
@@ -591,6 +642,15 @@ def _create_collector_node(
 
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
+
+        if recorder is not None:
+            recorder.record_state_complete(
+                state_name,
+                "success",
+                "",
+                [state.result_path],
+                branch_info_list,
+            )
 
         new_state = _set_next_state_meta(new_state, state)
         return new_state
@@ -639,11 +699,15 @@ def _aggregate(source_data: list[dict[str, Any]], rule: AggregateRule) -> str:
 
 
 def _create_pass_node(
-    state_name: str, state: PassState, flow: Flow
+    state_name: str, state: PassState, flow: Flow, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Pass state."""
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        if recorder is not None:
+            recorder.record_state_start(state_name, "pass")
+
+        variables_set = []
         if state.parameters:
             for target, source in state.parameters.items():
                 if isinstance(source, str):
@@ -652,6 +716,7 @@ def _create_pass_node(
                     value = source
                 new_state = set_jsonpath(target, state_dict, value)
                 state_dict = new_state
+                variables_set.append(target)
 
         if state.aggregate:
             from fdsx.core.variables import resolve_jsonpath
@@ -662,6 +727,10 @@ def _create_pass_node(
             else:
                 result = state.aggregate.no_match
             state_dict = set_jsonpath(state.aggregate.result_path, state_dict, result)
+            variables_set.append(state.aggregate.result_path)
+
+        if recorder is not None:
+            recorder.record_state_complete(state_name, "success", "", variables_set)
 
         state_dict = _set_next_state_meta(state_dict, state)
         return state_dict
@@ -670,7 +739,7 @@ def _create_pass_node(
 
 
 def _create_wait_notify_node(
-    state_name: str, state: WaitState
+    state_name: str, state: WaitState, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create the pre-interrupt notify node for a Wait state.
 
@@ -681,6 +750,9 @@ def _create_wait_notify_node(
     """
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        if recorder is not None:
+            recorder.record_state_start(state_name, "wait")
+
         if state.notify is not None:
             from fdsx.notify.webhook import send_notification
 
@@ -691,7 +763,7 @@ def _create_wait_notify_node(
 
 
 def _create_wait_interrupt_node(
-    state_name: str, state: WaitState
+    state_name: str, state: WaitState, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create the interrupt node for a Wait state.
 
@@ -712,6 +784,13 @@ def _create_wait_interrupt_node(
         )
 
         new_state = set_jsonpath(state.result_path, state_dict, user_selection)
+
+        if recorder is not None:
+            recorder.record_state_complete(
+                state_name, "success", user_selection, [state.result_path],
+                state_type="wait",
+            )
+
         new_state = _set_next_state_meta(new_state, state)
         return new_state
 

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -1,4 +1,5 @@
 import operator
+import subprocess
 import time
 from typing import Annotated, Any, Callable, TypedDict
 
@@ -310,24 +311,31 @@ def _create_task_node(
         extracted: str | None = None
 
         for attempt in range(max_retries + 1):
-            if state.provider == "system":
-                resolved_command = resolve_template_shell_safe(
-                    state.command or "", state_dict
-                )
-                result = provider.execute(
-                    prompt="",
-                    model=state.model,
-                    timeout=state.timeout_seconds,
-                    command=resolved_command,
-                    output_callback=None,
-                )
-            else:
-                result = provider.execute(
-                    prompt=resolved_prompt,
-                    model=state.model,
-                    timeout=state.timeout_seconds,
-                    output_callback=terminal.display_output_line,
-                )
+            if attempt > 0:
+                time.sleep(min(2 ** (attempt - 1), 30))
+            try:
+                if state.provider == "system":
+                    resolved_command = resolve_template_shell_safe(
+                        state.command or "", state_dict
+                    )
+                    result = provider.execute(
+                        prompt="",
+                        model=state.model,
+                        timeout=state.timeout_seconds,
+                        command=resolved_command,
+                        output_callback=None,
+                    )
+                else:
+                    result = provider.execute(
+                        prompt=resolved_prompt,
+                        model=state.model,
+                        timeout=state.timeout_seconds,
+                        output_callback=terminal.display_output_line,
+                    )
+            except (subprocess.TimeoutExpired, TimeoutError) as exc:
+                last_error = str(exc)
+                result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
+                continue
 
             if result.exit_code == 0:
                 if state.extract:
@@ -458,7 +466,9 @@ def _create_branch_executor(
         result = ProviderResult(exit_code=1, stdout="", stderr="")
         extracted: str | None = None
 
-        for _attempt in range(max_retries + 1):
+        for attempt in range(max_retries + 1):
+            if attempt > 0:
+                time.sleep(min(2 ** (attempt - 1), 30))
             try:
                 if branch.provider == "system":
                     resolved_command = resolve_template_shell_safe(
@@ -478,7 +488,7 @@ def _create_branch_executor(
                         timeout=branch.timeout_seconds,
                         output_callback=terminal.display_output_line,
                     )
-            except Exception as exc:
+            except (subprocess.TimeoutExpired, TimeoutError) as exc:
                 last_error = str(exc)
                 result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
                 continue
@@ -787,7 +797,10 @@ def _create_wait_interrupt_node(
 
         if recorder is not None:
             recorder.record_state_complete(
-                state_name, "success", user_selection, [state.result_path],
+                state_name,
+                "success",
+                user_selection,
+                [state.result_path],
                 state_type="wait",
             )
 

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -249,6 +249,28 @@ def _extract_result_paths(flow: Flow) -> list[str]:
     return paths
 
 
+def _set_next_state_meta(state_dict: dict[str, Any], state: Any) -> dict[str, Any]:
+    """Inject _meta.next_state so list_threads can show the correct current state.
+
+    Stores the name of the node that will execute NEXT so that if the next node
+    crashes before its checkpoint is written, list_threads() can still report the
+    correct CURRENT_STATE for the stopped flow.
+    """
+    next_name = ""
+    if hasattr(state, "next") and state.next:
+        next_name = state.next
+    elif hasattr(state, "end") and state.end:
+        next_name = "__end__"
+    if not next_name:
+        return state_dict
+    meta = state_dict.get("_meta", {})
+    if isinstance(meta, dict):
+        state_dict["_meta"] = {**meta, "next_state": next_name}
+    else:
+        state_dict["_meta"] = {"next_state": next_name}
+    return state_dict
+
+
 def _create_task_node(
     state_name: str, state: TaskState, flow: Flow
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
@@ -336,6 +358,7 @@ def _create_task_node(
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
 
+        new_state = _set_next_state_meta(new_state, state)
         return new_state
 
     return node
@@ -569,6 +592,7 @@ def _create_collector_node(
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
 
+        new_state = _set_next_state_meta(new_state, state)
         return new_state
 
     return node
@@ -639,6 +663,7 @@ def _create_pass_node(
                 result = state.aggregate.no_match
             state_dict = set_jsonpath(state.aggregate.result_path, state_dict, result)
 
+        state_dict = _set_next_state_meta(state_dict, state)
         return state_dict
 
     return node
@@ -687,6 +712,7 @@ def _create_wait_interrupt_node(
         )
 
         new_state = set_jsonpath(state.result_path, state_dict, user_selection)
+        new_state = _set_next_state_meta(new_state, state)
         return new_state
 
     return node

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -3,7 +3,7 @@ import time
 from typing import Annotated, Any, Callable, TypedDict
 
 from langgraph.graph import END, StateGraph
-from langgraph.types import Send
+from langgraph.types import interrupt, Send
 
 from fdsx.core.variables import (
     resolve_template,
@@ -117,7 +117,9 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
 
 
 def compile_flow(
-    flow: Flow, input_keys: set[str] | None = None
+    flow: Flow,
+    input_keys: set[str] | None = None,
+    checkpointer: Any = None,
 ) -> CompiledGraph:
     """Compile a Flow into a LangGraph StateGraph.
 
@@ -125,6 +127,9 @@ def compile_flow(
         flow: The Flow to compile
         input_keys: Top-level keys injected via --input; needed for the state schema
                     so LangGraph channels are created for them.
+        checkpointer: Optional checkpointer for state persistence.
+                      If not provided and the flow contains Wait states,
+                      a MemorySaver will be used as default.
 
     Returns:
         CompiledGraph with the compiled state machine
@@ -134,6 +139,15 @@ def compile_flow(
     schema = _build_state_schema(flow, input_keys)
     graph: StateGraph[Any] = StateGraph(schema)
 
+    if checkpointer is None:
+        from fdsx.models.flow import WaitState as _WaitState
+
+        has_wait = any(isinstance(s, _WaitState) for s in flow.states.values())
+        if has_wait:
+            from langgraph.checkpoint.memory import MemorySaver
+
+            checkpointer = MemorySaver()
+
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
             graph.add_node(state_name, _create_task_node(state_name, state, flow))  # type: ignore[call-overload]
@@ -142,12 +156,25 @@ def compile_flow(
         elif isinstance(state, ParallelState):
             # Three-node pattern: dispatch → branch (×N via Send) → collector
             graph.add_node(state_name, _create_dispatch_node(state_name, state))  # type: ignore[call-overload]
-            graph.add_node(f"_branch_{state_name}", _create_branch_executor(state_name, state, flow))  # type: ignore[call-overload]
-            graph.add_node(f"_collect_{state_name}", _create_collector_node(state_name, state, flow))  # type: ignore[call-overload]
+            graph.add_node(
+                f"_branch_{state_name}",
+                _create_branch_executor(state_name, state, flow),
+            )  # type: ignore[call-overload]
+            graph.add_node(
+                f"_collect_{state_name}",
+                _create_collector_node(state_name, state, flow),
+            )  # type: ignore[call-overload]
         elif state.type == "pass":
             graph.add_node(state_name, _create_pass_node(state_name, state, flow))  # type: ignore[call-overload]
         elif state.type == "wait":
-            graph.add_node(state_name, _create_wait_node(state_name, state, flow))  # type: ignore[call-overload]
+            # Two-node pattern: notify pre-node (checkpointed) → interrupt node.
+            # The notify node fires once; on resume LangGraph replays only the
+            # interrupt node because the checkpoint advances past the notify node.
+            graph.add_node(state_name, _create_wait_notify_node(state_name, state))  # type: ignore[call-overload]
+            graph.add_node(
+                f"_{state_name}_int", _create_wait_interrupt_node(state_name, state)
+            )  # type: ignore[call-overload]
+            graph.add_edge(state_name, f"_{state_name}_int")
 
     for state_name, state in flow.states.items():
         if isinstance(state, ParallelState):
@@ -167,6 +194,18 @@ def compile_flow(
                 )
             continue  # Skip the regular edge-adding below for ParallelState
 
+        if isinstance(state, WaitState):
+            # Outgoing edge comes from the interrupt node (_{state_name}_int), not
+            # the notify pre-node ({state_name}).  The pre-node → interrupt edge was
+            # already added in the node-registration loop above.
+            next_s = _get_next_state(state)
+            if next_s:
+                graph.add_edge(
+                    f"_{state_name}_int",
+                    END if next_s == "END" else next_s,
+                )
+            continue  # Skip the regular edge-adding below for WaitState
+
         next_state = _get_next_state(state)
         if next_state:
             if next_state == "END":
@@ -185,7 +224,10 @@ def compile_flow(
 
     graph.set_entry_point(flow.start_at)
 
-    compiled = graph.compile()
+    if checkpointer is not None:
+        compiled = graph.compile(checkpointer=checkpointer)
+    else:
+        compiled = graph.compile()
 
     return CompiledGraph(compiled, flow.start_at, result_paths)
 
@@ -602,13 +644,50 @@ def _create_pass_node(
     return node
 
 
-def _create_wait_node(
-    state_name: str, state: WaitState, flow: Flow
+def _create_wait_notify_node(
+    state_name: str, state: WaitState
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
-    """Create a LangGraph node function for a Wait state."""
+    """Create the pre-interrupt notify node for a Wait state.
+
+    Sends the webhook notification (if configured) and returns the state so the
+    result is checkpointed before the interrupt.  This guarantees the notification
+    fires exactly once: on the first entry the checkpoint advances past this node,
+    so on resume LangGraph replays only the interrupt node — not this one.
+    """
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        if state.notify is not None:
+            from fdsx.notify.webhook import send_notification
+
+            send_notification(state.notify, state_dict)
         return state_dict
+
+    return node
+
+
+def _create_wait_interrupt_node(
+    state_name: str, state: WaitState
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Create the interrupt node for a Wait state.
+
+    Uses LangGraph's interrupt() to pause execution and wait for user input.
+    The engine handles the actual prompting and resume with Command(resume=value).
+    Only this node is re-executed on resume; the notify node above is not.
+    """
+
+    def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        resolved_message = resolve_template(state.message, state_dict)
+
+        user_selection = interrupt(
+            {
+                "message": resolved_message,
+                "choices": state.choices,
+                "state_name": state_name,
+            }
+        )
+
+        new_state = set_jsonpath(state.result_path, state_dict, user_selection)
+        return new_state
 
     return node
 

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -7,9 +7,10 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
 
+from fdsx.checkpoint.manager import CheckpointManager, _extract_meta_from_checkpoint
 from fdsx.core.compiler import compile_flow
 from fdsx.core.loader import load_flow
-from fdsx.display.terminal import display_wait_prompt
+from fdsx.display.terminal import _sanitize_output, display_wait_prompt
 
 
 class FlowValidationError(Exception):
@@ -22,6 +23,7 @@ def run_flow(
     flow_path: Path,
     inputs: dict[str, str] | None = None,
     thread_id: str | None = None,
+    base_dir: Path | None = None,
 ) -> dict[str, Any]:
     """Run a flow from a YAML file.
 
@@ -29,6 +31,8 @@ def run_flow(
         flow_path: Path to the YAML workflow file
         inputs: Optional input variables
         thread_id: Optional thread ID (generated if not provided)
+        base_dir: Optional base directory for checkpoints (.fdsx/).
+                  If None, uses MemorySaver (no persistence).
 
     Returns:
         Final state variables as result dict. When max_loop is reached,
@@ -41,7 +45,7 @@ def run_flow(
     if thread_id is None:
         thread_id = str(uuid.uuid4())
 
-    print(f"Thread ID: {thread_id}", file=sys.stderr)
+    print(f"Thread ID: {_sanitize_output(thread_id)}", file=sys.stderr)
 
     flow, errors = load_flow(
         flow_path, input_keys=set(inputs.keys()) if inputs else None
@@ -49,11 +53,22 @@ def run_flow(
     if flow is None:
         raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
 
-    # Check if we need a checkpointer (for Wait states, interrupt requires checkpointing)
-    from fdsx.models.flow import WaitState
+    from fdsx.models.flow import WaitState, ParallelState
 
     needs_checkpointer = any(isinstance(s, WaitState) for s in flow.states.values())
-    checkpointer = MemorySaver() if needs_checkpointer else None
+
+    checkpoint_manager: CheckpointManager | None = None
+    checkpointer: Any = None
+    if base_dir is not None:
+        checkpoint_manager = CheckpointManager(base_dir=base_dir)
+        if not checkpoint_manager.acquire_lock(thread_id):
+            locked, pid = checkpoint_manager.is_locked(thread_id)
+            if locked:
+                raise RuntimeError(f"Thread {thread_id} is locked by PID {pid}")
+        checkpointer = checkpoint_manager.get_checkpointer()
+        needs_checkpointer = True
+    elif needs_checkpointer:
+        checkpointer = MemorySaver()
 
     compiled = compile_flow(
         flow,
@@ -61,17 +76,17 @@ def run_flow(
         checkpointer=checkpointer,
     )
 
-    initial_state: dict[str, Any] = {"_meta": {"thread_id": thread_id}}
+    initial_state: dict[str, Any] = {
+        "_meta": {
+            "thread_id": thread_id,
+            "flow_path": str(flow_path),
+            "flow_name": flow.name,
+        }
+    }
 
     if inputs:
         for key, value in inputs.items():
             initial_state[key] = value
-
-    # Compute recursion limit: account for extra graph nodes not in flow.states count.
-    # ParallelState adds dispatch + N branch + collector (len(branches)+1 extra beyond the
-    # one already counted in len(flow.states)).
-    # WaitState is split into notify-pre + interrupt (1 extra beyond the one counted).
-    from fdsx.models.flow import ParallelState
 
     parallel_extra = sum(
         len(s.branches) + 1
@@ -87,29 +102,22 @@ def run_flow(
         "configurable": {"thread_id": thread_id},
     }
 
-    # Track the last successfully completed state so it can be returned on loop exhaustion
     last_state: dict[str, Any] = initial_state.copy()
 
     try:
-        # Initial run — streams graph to completion or first interrupt
         for state_snapshot in compiled.graph.stream(
             initial_state, config=config, stream_mode="values"
         ):
             if "__interrupt__" not in state_snapshot:
                 last_state = state_snapshot
 
-        # Interrupt handling loop — only runs when a checkpointer is configured (Wait states)
-        # Uses get_state() to inspect pending interrupts and Command(resume=) + stream() to continue.
-        # Never re-passes last_state to stream(); the checkpointer handles continuity.
         if needs_checkpointer:
             while True:
                 state_info = compiled.graph.get_state(config)
 
-                # No pending tasks means the graph has completed
                 if not state_info.tasks:
                     break
 
-                # Extract interrupt payload from the first pending interrupted task
                 payload = None
                 for task in state_info.tasks:
                     if hasattr(task, "interrupts") and task.interrupts:
@@ -125,7 +133,6 @@ def run_flow(
 
                 user_selection = display_wait_prompt(state_name, message, choices)
 
-                # Resume from checkpoint — continues execution from the interrupt point
                 for state_snapshot in compiled.graph.stream(
                     Command(resume=user_selection),
                     config=config,
@@ -139,7 +146,15 @@ def run_flow(
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         return _extract_results(last_state, compiled.result_paths)
     except Exception as e:
+        if checkpoint_manager is not None:
+            print(
+                f"Checkpoint saved. Resume with: fdsx resume --thread-id {_sanitize_output(thread_id)}",
+                file=sys.stderr,
+            )
         raise RuntimeError(f"Flow execution failed: {e}")
+    finally:
+        if checkpoint_manager is not None:
+            checkpoint_manager.release_lock(thread_id)
 
 
 def _extract_results(state: dict[str, Any], result_paths: list[str]) -> dict[str, Any]:
@@ -154,6 +169,166 @@ def _extract_results(state: dict[str, Any], result_paths: list[str]) -> dict[str
             results = set_jsonpath(clean_path, results, value)
 
     return results
+
+
+def resume_flow(
+    thread_id: str,
+    base_dir: Path | None = None,
+    flow_path: Path | None = None,
+) -> dict[str, Any]:
+    """Resume a flow from a checkpoint.
+
+    Args:
+        thread_id: The thread ID to resume
+        base_dir: Base directory for checkpoints (.fdsx/). Defaults to '.fdsx/'.
+        flow_path: Optional path to the flow YAML file. Required if not stored in checkpoint.
+
+    Returns:
+        Final state variables as result dict.
+
+    Raises:
+        RuntimeError: If checkpoint is corrupt or execution fails
+    """
+    if base_dir is None:
+        base_dir = CheckpointManager.DEFAULT_BASE_DIR
+
+    checkpoint_manager = CheckpointManager(base_dir=base_dir)
+
+    if not checkpoint_manager.verify_checkpoint(thread_id):
+        raise RuntimeError(f"No checkpoint found for thread ID {thread_id}")
+
+    if not checkpoint_manager.acquire_lock(thread_id):
+        locked, pid = checkpoint_manager.is_locked(thread_id)
+        if locked:
+            raise RuntimeError(f"Thread {thread_id} is locked by PID {pid}")
+
+    print(f"Resuming from thread: {_sanitize_output(thread_id)}", file=sys.stderr)
+
+    try:
+        checkpointer = checkpoint_manager.get_checkpointer()
+
+        if flow_path is None or not flow_path.exists():
+            config_for_lookup: Any = {"configurable": {"thread_id": thread_id}}
+            checkpoint = checkpointer.get(config_for_lookup)
+
+            if checkpoint:
+                stored_meta = _extract_meta_from_checkpoint(checkpoint)
+                if isinstance(stored_meta, dict):
+                    flow_path_str = stored_meta.get("flow_path")
+                    if flow_path_str:
+                        flow_path = Path(flow_path_str)
+
+            if flow_path is None or not (flow_path and flow_path.exists()):
+                raise RuntimeError(
+                    f"Flow path not found for thread ID {thread_id}. "
+                    "Please provide the flow YAML path using the flow_path parameter."
+                )
+
+        flow, errors = load_flow(flow_path)
+        if flow is None:
+            raise RuntimeError(f"Failed to load flow for resume: {', '.join(errors)}")
+
+        from fdsx.models.flow import WaitState, ParallelState
+
+        compiled = compile_flow(
+            flow,
+            checkpointer=checkpointer,
+        )
+
+        parallel_extra = sum(
+            len(s.branches) + 1
+            for s in flow.states.values()
+            if isinstance(s, ParallelState)
+        )
+        wait_extra = sum(1 for s in flow.states.values() if isinstance(s, WaitState))
+        steps_per_iter = len(flow.states) + parallel_extra + wait_extra
+        recursion_limit = flow.max_loop * steps_per_iter + 1
+
+        resume_config: dict[str, Any] = {
+            "recursion_limit": recursion_limit,
+            "configurable": {"thread_id": thread_id},
+        }
+
+        last_state: dict[str, Any] = {}
+
+        state_info = compiled.graph.get_state(resume_config)
+        if state_info.tasks:
+            payload = None
+            for task in state_info.tasks:
+                if hasattr(task, "interrupts") and task.interrupts:
+                    payload = task.interrupts[0].value
+                    break
+
+            if payload:
+                print(
+                    f"Resuming from state: {_sanitize_output(payload.get('state_name', 'wait'))}",
+                    file=sys.stderr,
+                )
+                message = payload.get("message", "")
+                choices = payload.get("choices", [])
+                state_name = payload.get("state_name", "wait")
+
+                user_selection = display_wait_prompt(state_name, message, choices)
+
+                for state_snapshot in compiled.graph.stream(
+                    Command(resume=user_selection),
+                    config=resume_config,
+                    stream_mode="values",
+                ):
+                    if "__interrupt__" not in state_snapshot:
+                        last_state = state_snapshot
+            else:
+                # Error/pending task (no interrupt) — re-execute from checkpoint
+                for state_snapshot in compiled.graph.stream(
+                    None, config=resume_config, stream_mode="values"
+                ):
+                    if "__interrupt__" not in state_snapshot:
+                        last_state = state_snapshot
+        else:
+            for state_snapshot in compiled.graph.stream(
+                None, config=resume_config, stream_mode="values"
+            ):
+                if "__interrupt__" not in state_snapshot:
+                    last_state = state_snapshot
+
+        # Continue handling any further interrupts (e.g. multi-Wait flows)
+        while True:
+            state_info = compiled.graph.get_state(resume_config)
+            if not state_info.tasks:
+                break
+            payload = None
+            for task in state_info.tasks:
+                if hasattr(task, "interrupts") and task.interrupts:
+                    payload = task.interrupts[0].value
+                    break
+            if payload is None:
+                break
+            message = payload.get("message", "")
+            choices = payload.get("choices", [])
+            state_name = payload.get("state_name", "wait")
+            user_selection = display_wait_prompt(state_name, message, choices)
+            for state_snapshot in compiled.graph.stream(
+                Command(resume=user_selection),
+                config=resume_config,
+                stream_mode="values",
+            ):
+                if "__interrupt__" not in state_snapshot:
+                    last_state = state_snapshot
+
+        # Read authoritative state from checkpointer after resume completes
+        final_state_info = compiled.graph.get_state(resume_config)
+        if final_state_info.values:
+            last_state = final_state_info.values
+
+        return _extract_results(last_state, compiled.result_paths)
+    except GraphRecursionError:
+        if flow is not None:
+            print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
+        return {}
+    except Exception as e:
+        raise RuntimeError(f"Flow resume failed: {e}")
+    finally:
+        checkpoint_manager.release_lock(thread_id)
 
 
 def validate_flow(flow_path: Path) -> tuple[bool, list[str]]:

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -8,6 +8,11 @@ from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
 
 from fdsx.checkpoint.manager import CheckpointManager, _extract_meta_from_checkpoint
+from fdsx.core.batch import (
+    display_batch_summary,
+    display_task_list,
+    split_tasks,
+)
 from fdsx.core.compiler import compile_flow
 from fdsx.core.loader import load_flow
 from fdsx.display.terminal import _sanitize_output, display_wait_prompt
@@ -201,6 +206,109 @@ def _sanitize_state_for_log(state: dict[str, Any]) -> dict[str, Any]:
         and not k.startswith("__")
         and not k.startswith("_br_")
     }
+
+
+def run_batch(
+    workflow_path: Path,
+    tasks_file: Path,
+    base_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Orchestrate batch execution of tasks.
+
+    Args:
+        workflow_path: Path to the YAML workflow file
+        tasks_file: Path to the task file
+        base_dir: Optional base directory for checkpoints (.fdsx/).
+
+    Returns:
+        List of result dicts with task_index, task_description, thread_id, status, error
+
+    Raises:
+        FlowValidationError: If flow validation fails
+        RuntimeError: If task_splitter is missing or execution fails
+    """
+    import uuid
+
+    flow, errors = load_flow(workflow_path)
+    if flow is None:
+        raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
+
+    if flow.task_splitter is None:
+        raise FlowValidationError(
+            "Flow must define 'task_splitter' configuration for batch execution"
+        )
+
+    task_splitter = flow.task_splitter
+
+    tasks_file_content = tasks_file.read_text()
+
+    tasks = split_tasks(tasks_file_content, flow, task_splitter)
+
+    if not tasks:
+        print("No tasks to execute.", file=sys.stderr)
+        return []
+
+    approved = display_task_list(tasks)
+    if not approved:
+        print("Task list rejected. Aborting batch execution.", file=sys.stderr)
+        return []
+
+    results: list[dict[str, Any]] = []
+
+    for i, task_description in enumerate(tasks):
+        thread_id = str(uuid.uuid4())
+
+        print(
+            f"\nExecuting task {i + 1}/{len(tasks)}: {_sanitize_output(task_description[:50])}...",
+            file=sys.stderr,
+        )
+
+        try:
+            task_inputs = {"task": task_description}
+            run_flow(
+                flow_path=workflow_path,
+                inputs=task_inputs,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+            results.append(
+                {
+                    "task_index": i,
+                    "task_description": task_description,
+                    "thread_id": thread_id,
+                    "status": "completed",
+                    "error": None,
+                }
+            )
+        except Exception as e:
+            results.append(
+                {
+                    "task_index": i,
+                    "task_description": task_description,
+                    "thread_id": thread_id,
+                    "status": "failed",
+                    "error": str(e),
+                }
+            )
+
+            if i < len(tasks) - 1:
+                print(
+                    f"Task {i + 1} failed: {_sanitize_output(str(e))}", file=sys.stderr
+                )
+                while True:
+                    response = (
+                        input("Continue with remaining tasks? (y/n): ").strip().lower()
+                    )
+                    if response == "y":
+                        break
+                    elif response == "n":
+                        print("Stopping batch execution.", file=sys.stderr)
+                        display_batch_summary(results)
+                        return results
+
+    display_batch_summary(results)
+
+    return results
 
 
 def resume_flow(

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -3,6 +3,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from langgraph.errors import GraphRecursionError
+
 from fdsx.core.compiler import compile_flow
 from fdsx.core.loader import load_flow
 
@@ -26,7 +28,9 @@ def run_flow(
         thread_id: Optional thread ID (generated if not provided)
 
     Returns:
-        Final state variables as result dict
+        Final state variables as result dict. When max_loop is reached,
+        returns partial results from the last completed iteration rather
+        than raising an error.
 
     Raises:
         RuntimeError: If flow validation fails or execution fails
@@ -36,11 +40,13 @@ def run_flow(
 
     print(f"Thread ID: {thread_id}", file=sys.stderr)
 
-    flow, errors = load_flow(flow_path, input_keys=set(inputs.keys()) if inputs else None)
+    flow, errors = load_flow(
+        flow_path, input_keys=set(inputs.keys()) if inputs else None
+    )
     if flow is None:
         raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
 
-    compiled = compile_flow(flow)
+    compiled = compile_flow(flow, input_keys=set(inputs.keys()) if inputs else None)
 
     initial_state: dict[str, Any] = {"_meta": {"thread_id": thread_id}}
 
@@ -48,16 +54,33 @@ def run_flow(
         for key, value in inputs.items():
             initial_state[key] = value
 
+    # Compute recursion limit: account for extra nodes added by Send API fan-out/fan-in
+    from fdsx.models.flow import ParallelState
+
+    parallel_extra = sum(
+        len(s.branches) + 1
+        for s in flow.states.values()
+        if isinstance(s, ParallelState)
+    )
+    steps_per_iter = len(flow.states) + parallel_extra
+    recursion_limit = flow.max_loop * steps_per_iter + 1
+
+    config: dict[str, Any] = {"recursion_limit": recursion_limit}
+
+    # Track the last successfully completed state so it can be returned on loop exhaustion
+    last_state: dict[str, Any] = initial_state.copy()
+
     try:
-        recursion_limit = flow.max_loop * len(flow.states) + 1
-        result = compiled.graph.invoke(
-            initial_state,
-            config={"recursion_limit": recursion_limit},
-        )
+        for state_snapshot in compiled.graph.stream(
+            initial_state, config=config, stream_mode="values"
+        ):
+            last_state = state_snapshot
+        return _extract_results(last_state, compiled.result_paths)
+    except GraphRecursionError:
+        print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
+        return _extract_results(last_state, compiled.result_paths)
     except Exception as e:
         raise RuntimeError(f"Flow execution failed: {e}")
-
-    return _extract_results(result, compiled.result_paths)
 
 
 def _extract_results(state: dict[str, Any], result_paths: list[str]) -> dict[str, Any]:

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -154,7 +154,7 @@ def run_flow(
                     if "__interrupt__" not in state_snapshot:
                         last_state = state_snapshot
 
-        if needs_checkpointer and checkpoint_manager is not None:
+        if needs_checkpointer:
             final_state_info = compiled.graph.get_state(config)
             if final_state_info.values:
                 last_state = final_state_info.values

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -11,6 +11,7 @@ from fdsx.checkpoint.manager import CheckpointManager, _extract_meta_from_checkp
 from fdsx.core.compiler import compile_flow
 from fdsx.core.loader import load_flow
 from fdsx.display.terminal import _sanitize_output, display_wait_prompt
+from fdsx.logging import RunRecorder
 
 
 class FlowValidationError(Exception):
@@ -70,10 +71,17 @@ def run_flow(
     elif needs_checkpointer:
         checkpointer = MemorySaver()
 
+    recorder = RunRecorder(
+        thread_id=thread_id,
+        flow_name=flow.name,
+        flow_version=flow.version,
+    )
+
     compiled = compile_flow(
         flow,
         input_keys=set(inputs.keys()) if inputs else None,
         checkpointer=checkpointer,
+        recorder=recorder,
     )
 
     initial_state: dict[str, Any] = {
@@ -146,16 +154,24 @@ def run_flow(
             if final_state_info.values:
                 last_state = final_state_info.values
 
-        return _extract_results(last_state, compiled.result_paths)
+        results = _extract_results(last_state, compiled.result_paths)
+        recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+        recorder.save()
+        return results
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
-        return _extract_results(last_state, compiled.result_paths)
+        results = _extract_results(last_state, compiled.result_paths)
+        recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+        recorder.save()
+        return results
     except Exception as e:
         if checkpoint_manager is not None:
             print(
                 f"Checkpoint saved. Resume with: fdsx resume --thread-id {_sanitize_output(thread_id)}",
                 file=sys.stderr,
             )
+        recorder.finalize(_sanitize_state_for_log(last_state), "error")
+        recorder.save()
         raise RuntimeError(f"Flow execution failed: {e}")
     finally:
         if checkpoint_manager is not None:
@@ -174,6 +190,17 @@ def _extract_results(state: dict[str, Any], result_paths: list[str]) -> dict[str
             results = set_jsonpath(clean_path, results, value)
 
     return results
+
+
+def _sanitize_state_for_log(state: dict[str, Any]) -> dict[str, Any]:
+    """Create a sanitized copy of state for logging, stripping internal keys."""
+    return {
+        k: v
+        for k, v in state.items()
+        if not k.startswith("_meta")
+        and not k.startswith("__")
+        and not k.startswith("_br_")
+    }
 
 
 def resume_flow(
@@ -209,6 +236,9 @@ def resume_flow(
 
     print(f"Resuming from thread: {_sanitize_output(thread_id)}", file=sys.stderr)
 
+    recorder: RunRecorder | None = None
+    last_state: dict[str, Any] = {}
+
     try:
         checkpointer = checkpoint_manager.get_checkpointer()
 
@@ -235,9 +265,30 @@ def resume_flow(
 
         from fdsx.models.flow import WaitState, ParallelState
 
+        runs_dir = Path.cwd() / "runs"
+        existing_log_path = runs_dir / f"{thread_id}.json"
+
+        if existing_log_path.exists():
+            import json
+
+            with open(existing_log_path, "r") as f:
+                existing_log = json.load(f)
+            flow_name = existing_log.get("flow_name", flow.name)
+            flow_version = existing_log.get("flow_version")
+        else:
+            flow_name = flow.name
+            flow_version = flow.version
+
+        recorder = RunRecorder(
+            thread_id=thread_id,
+            flow_name=flow_name,
+            flow_version=flow_version,
+        )
+
         compiled = compile_flow(
             flow,
             checkpointer=checkpointer,
+            recorder=recorder,
         )
 
         parallel_extra = sum(
@@ -253,8 +304,6 @@ def resume_flow(
             "recursion_limit": recursion_limit,
             "configurable": {"thread_id": thread_id},
         }
-
-        last_state: dict[str, Any] = {}
 
         state_info = compiled.graph.get_state(resume_config)
         if state_info.tasks:
@@ -325,12 +374,22 @@ def resume_flow(
         if final_state_info.values:
             last_state = final_state_info.values
 
-        return _extract_results(last_state, compiled.result_paths)
+        results = _extract_results(last_state, compiled.result_paths)
+        if recorder is not None:
+            recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+            recorder.save()
+        return results
     except GraphRecursionError:
         if flow is not None:
             print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
+        if recorder is not None:
+            recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+            recorder.save()
         return {}
     except Exception as e:
+        if recorder is not None:
+            recorder.finalize(_sanitize_state_for_log(last_state), "error")
+            recorder.save()
         raise RuntimeError(f"Flow resume failed: {e}")
     finally:
         checkpoint_manager.release_lock(thread_id)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -141,6 +141,11 @@ def run_flow(
                     if "__interrupt__" not in state_snapshot:
                         last_state = state_snapshot
 
+        if needs_checkpointer and checkpoint_manager is not None:
+            final_state_info = compiled.graph.get_state(config)
+            if final_state_info.values:
+                last_state = final_state_info.values
+
         return _extract_results(last_state, compiled.result_paths)
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -3,10 +3,13 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.errors import GraphRecursionError
+from langgraph.types import Command
 
 from fdsx.core.compiler import compile_flow
 from fdsx.core.loader import load_flow
+from fdsx.display.terminal import display_wait_prompt
 
 
 class FlowValidationError(Exception):
@@ -46,7 +49,17 @@ def run_flow(
     if flow is None:
         raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
 
-    compiled = compile_flow(flow, input_keys=set(inputs.keys()) if inputs else None)
+    # Check if we need a checkpointer (for Wait states, interrupt requires checkpointing)
+    from fdsx.models.flow import WaitState
+
+    needs_checkpointer = any(isinstance(s, WaitState) for s in flow.states.values())
+    checkpointer = MemorySaver() if needs_checkpointer else None
+
+    compiled = compile_flow(
+        flow,
+        input_keys=set(inputs.keys()) if inputs else None,
+        checkpointer=checkpointer,
+    )
 
     initial_state: dict[str, Any] = {"_meta": {"thread_id": thread_id}}
 
@@ -54,7 +67,10 @@ def run_flow(
         for key, value in inputs.items():
             initial_state[key] = value
 
-    # Compute recursion limit: account for extra nodes added by Send API fan-out/fan-in
+    # Compute recursion limit: account for extra graph nodes not in flow.states count.
+    # ParallelState adds dispatch + N branch + collector (len(branches)+1 extra beyond the
+    # one already counted in len(flow.states)).
+    # WaitState is split into notify-pre + interrupt (1 extra beyond the one counted).
     from fdsx.models.flow import ParallelState
 
     parallel_extra = sum(
@@ -62,19 +78,62 @@ def run_flow(
         for s in flow.states.values()
         if isinstance(s, ParallelState)
     )
-    steps_per_iter = len(flow.states) + parallel_extra
+    wait_extra = sum(1 for s in flow.states.values() if isinstance(s, WaitState))
+    steps_per_iter = len(flow.states) + parallel_extra + wait_extra
     recursion_limit = flow.max_loop * steps_per_iter + 1
 
-    config: dict[str, Any] = {"recursion_limit": recursion_limit}
+    config: dict[str, Any] = {
+        "recursion_limit": recursion_limit,
+        "configurable": {"thread_id": thread_id},
+    }
 
     # Track the last successfully completed state so it can be returned on loop exhaustion
     last_state: dict[str, Any] = initial_state.copy()
 
     try:
+        # Initial run — streams graph to completion or first interrupt
         for state_snapshot in compiled.graph.stream(
             initial_state, config=config, stream_mode="values"
         ):
-            last_state = state_snapshot
+            if "__interrupt__" not in state_snapshot:
+                last_state = state_snapshot
+
+        # Interrupt handling loop — only runs when a checkpointer is configured (Wait states)
+        # Uses get_state() to inspect pending interrupts and Command(resume=) + stream() to continue.
+        # Never re-passes last_state to stream(); the checkpointer handles continuity.
+        if needs_checkpointer:
+            while True:
+                state_info = compiled.graph.get_state(config)
+
+                # No pending tasks means the graph has completed
+                if not state_info.tasks:
+                    break
+
+                # Extract interrupt payload from the first pending interrupted task
+                payload = None
+                for task in state_info.tasks:
+                    if hasattr(task, "interrupts") and task.interrupts:
+                        payload = task.interrupts[0].value
+                        break
+
+                if payload is None:
+                    break
+
+                message = payload.get("message", "")
+                choices = payload.get("choices", [])
+                state_name = payload.get("state_name", "wait")
+
+                user_selection = display_wait_prompt(state_name, message, choices)
+
+                # Resume from checkpoint — continues execution from the interrupt point
+                for state_snapshot in compiled.graph.stream(
+                    Command(resume=user_selection),
+                    config=config,
+                    stream_mode="values",
+                ):
+                    if "__interrupt__" not in state_snapshot:
+                        last_state = state_snapshot
+
         return _extract_results(last_state, compiled.result_paths)
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -1,5 +1,6 @@
 import sys
 from datetime import datetime
+from typing import Any
 
 
 def _sanitize_output(text: str) -> str:
@@ -87,34 +88,108 @@ def display_parallel_start(state_name: str, branch_count: int) -> None:
     print(line, file=sys.stderr)
 
 
-def display_branch_status(
+def display_branch_start(
     state_name: str,
     branch_index: int,
     provider: str,
-    status: str,
-    duration: float | None,
+    model: str | None = None,
 ) -> None:
-    """Display branch status in terminal.
+    """Display branch start in terminal.
 
     Args:
         state_name: Name of the parent parallel state
         branch_index: Index of the branch (0-based)
         provider: Provider name for the branch
-        status: Status string - "running", "completed", "failed"
-        duration: Duration in seconds (None if still running)
+        model: Model name for the branch (optional)
     """
-    if status == "running":
-        status_text = "⏳ running..."
-    elif status == "completed" and duration is not None:
-        status_text = f"✓ completed ({int(duration)}s)"
-    elif status == "failed":
-        status_text = "✗ failed"
-    else:
-        status_text = status
-
-    display_index = branch_index + 1  # CLI contract is 1-indexed
-    line = f"  [branch-{display_index}] {provider}  {status_text}"
+    display_index = branch_index + 1
+    sanitized_model = _sanitize_output(model) if model else None
+    model_info = f"/{sanitized_model}" if sanitized_model else ""
+    line = f"  [branch-{display_index}] {provider}{model_info}  ⏳ running..."
     print(line, file=sys.stderr)
+
+
+def display_branch_complete(
+    state_name: str,
+    branch_index: int,
+    provider: str,
+    model: str | None = None,
+    duration: float | None = None,
+) -> None:
+    """Display branch completion in terminal.
+
+    Args:
+        state_name: Name of the parent parallel state
+        branch_index: Index of the branch (0-based)
+        provider: Provider name for the branch
+        model: Model name for the branch (optional)
+        duration: Duration in seconds (optional, for display)
+    """
+    display_index = branch_index + 1
+    sanitized_model = _sanitize_output(model) if model else None
+    model_info = f"/{sanitized_model}" if sanitized_model else ""
+    duration_info = f" ({int(duration)}s)" if duration is not None else ""
+    line = (
+        f"  [branch-{display_index}] {provider}{model_info}  ✓ completed{duration_info}"
+    )
+    print(line, file=sys.stderr)
+
+
+def display_branch_failed(
+    state_name: str,
+    branch_index: int,
+    provider: str,
+    model: str | None = None,
+) -> None:
+    """Display branch failure in terminal.
+
+    Args:
+        state_name: Name of the parent parallel state
+        branch_index: Index of the branch (0-based)
+        provider: Provider name for the branch
+        model: Model name for the branch (optional)
+    """
+    display_index = branch_index + 1
+    sanitized_model = _sanitize_output(model) if model else None
+    model_info = f"/{sanitized_model}" if sanitized_model else ""
+    line = f"  [branch-{display_index}] {provider}{model_info}  ✗ failed"
+    print(line, file=sys.stderr)
+
+
+def display_parallel_results(
+    state_name: str,
+    branch_results: list[dict[str, Any]],
+) -> None:
+    """Display parallel branch results in terminal.
+
+    Args:
+        state_name: Name of the parallel state
+        branch_results: List of branch result dictionaries
+    """
+    print("", file=sys.stderr)
+    for result in branch_results:
+        branch_index = result.get("index", 0)
+        display_index = branch_index + 1
+        provider = result.get("provider", "unknown")
+        model = result.get("model")
+        output = result.get("output", "")
+        exit_code = result.get("exit_code", 1)
+
+        sanitized_provider = _sanitize_output(provider) if provider else "unknown"
+        sanitized_model = _sanitize_output(model) if model else None
+        model_info = f"/{sanitized_model}" if sanitized_model else ""
+
+        if exit_code == 0:
+            header = (
+                f"--- branch-{display_index} ({sanitized_provider}{model_info}) ---"
+            )
+        else:
+            header = f"--- branch-{display_index} ({sanitized_provider}{model_info}) FAILED ---"
+
+        print(_sanitize_output(header), file=sys.stderr)
+        if output:
+            for line in output.splitlines():
+                print(_sanitize_output(line), file=sys.stderr)
 
 
 def display_wait_prompt(state_name: str, message: str, choices: list[str]) -> str:

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -73,3 +73,45 @@ def display_output_line(line: str) -> None:
         line: Output line from the LLM
     """
     print(_sanitize_output(line), file=sys.stderr)
+
+
+def display_parallel_start(state_name: str, branch_count: int) -> None:
+    """Display parallel state start in terminal.
+
+    Args:
+        state_name: Name of the parallel state
+        branch_count: Number of parallel branches
+    """
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    line = f"[{timestamp}] ▶ {state_name} (parallel, {branch_count} branches)"
+    print(line, file=sys.stderr)
+
+
+def display_branch_status(
+    state_name: str,
+    branch_index: int,
+    provider: str,
+    status: str,
+    duration: float | None,
+) -> None:
+    """Display branch status in terminal.
+
+    Args:
+        state_name: Name of the parent parallel state
+        branch_index: Index of the branch (0-based)
+        provider: Provider name for the branch
+        status: Status string - "running", "completed", "failed"
+        duration: Duration in seconds (None if still running)
+    """
+    if status == "running":
+        status_text = "⏳ running..."
+    elif status == "completed" and duration is not None:
+        status_text = f"✓ completed ({int(duration)}s)"
+    elif status == "failed":
+        status_text = "✗ failed"
+    else:
+        status_text = status
+
+    display_index = branch_index + 1  # CLI contract is 1-indexed
+    line = f"  [branch-{display_index}] {provider}  {status_text}"
+    print(line, file=sys.stderr)

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -115,3 +115,51 @@ def display_branch_status(
     display_index = branch_index + 1  # CLI contract is 1-indexed
     line = f"  [branch-{display_index}] {provider}  {status_text}"
     print(line, file=sys.stderr)
+
+
+def display_wait_prompt(state_name: str, message: str, choices: list[str]) -> str:
+    """Display a wait prompt and get user selection.
+
+    Args:
+        state_name: Name of the wait state
+        message: Message to display to the user
+        choices: List of choice options
+
+    Returns:
+        The selected choice string (not the number)
+    """
+    if not choices:
+        raise ValueError("choices must not be empty")
+
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    print(
+        f"[{timestamp}] ⏸ {_sanitize_output(state_name)} (waiting for input)",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for line in _sanitize_output(message).splitlines():
+        print(f"  {line}", file=sys.stderr)
+    print("", file=sys.stderr)
+
+    for i, choice in enumerate(choices, start=1):
+        print(f"  [{i}] {_sanitize_output(choice)}", file=sys.stderr)
+
+    print("", file=sys.stderr)
+
+    while True:
+        try:
+            sys.stderr.write(f"  Select (1-{len(choices)}): ")
+            sys.stderr.flush()
+            user_input = input()
+            choice_num = int(user_input)
+            if 1 <= choice_num <= len(choices):
+                return choices[choice_num - 1]
+            print(
+                f"Invalid choice. Please enter a number between 1 and {len(choices)}.",
+                file=sys.stderr,
+            )
+        except ValueError:
+            print(
+                f"Invalid input. Please enter a number between 1 and {len(choices)}.",
+                file=sys.stderr,
+            )

--- a/src/fdsx/logging/__init__.py
+++ b/src/fdsx/logging/__init__.py
@@ -1,1 +1,5 @@
 """Logging utilities."""
+
+from fdsx.logging.recorder import RunRecorder
+
+__all__ = ["RunRecorder"]

--- a/src/fdsx/logging/recorder.py
+++ b/src/fdsx/logging/recorder.py
@@ -1,0 +1,191 @@
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+OUTPUT_PREVIEW_MAX_LENGTH = 500
+
+THREAD_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+class RunRecorder:
+    """Records per-state input/output/duration to a JSON run log."""
+
+    def __init__(
+        self,
+        thread_id: str,
+        flow_name: str,
+        flow_version: str | None = None,
+    ):
+        if not THREAD_ID_PATTERN.match(thread_id):
+            raise ValueError(
+                f"Invalid thread_id '{thread_id}': must contain only alphanumeric characters, hyphens, and underscores"
+            )
+        self.thread_id = thread_id
+        self.flow_name = flow_name
+        self.flow_version = flow_version
+        self.started_at = datetime.now(timezone.utc).isoformat()
+        self.status = "running"
+        self.states: list[dict[str, Any]] = []
+        self.completed_at: str | None = None
+        self.final_variables: dict[str, Any] | None = None
+        self._current_state: dict[str, Any] | None = None
+
+    def record_state_start(self, state_name: str, state_type: str) -> None:
+        """Append new state entry with name, type, started_at."""
+        self._current_state = {
+            "name": state_name,
+            "type": state_type,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self.states.append(self._current_state)
+
+    def record_state_complete(
+        self,
+        state_name: str,
+        status: str,
+        output: str,
+        variables_set: list[str],
+        branches: list[dict[str, Any]] | None = None,
+        state_type: str | None = None,
+    ) -> None:
+        """Update the state entry with completed_at, duration_seconds, status, output_preview, variables_set, branches."""
+        state = self._find_state_by_name(state_name)
+        if state is None:
+            state = {
+                "name": state_name,
+                "type": state_type or "unknown",
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self.states.append(state)
+
+        completed_at = datetime.now(timezone.utc).isoformat()
+        started_at = state.get("started_at", completed_at)
+
+        try:
+            start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+            duration_seconds = int((end_dt - start_dt).total_seconds())
+        except (ValueError, TypeError):
+            duration_seconds = 0
+
+        output_preview = output[:OUTPUT_PREVIEW_MAX_LENGTH] if output else ""
+
+        state["completed_at"] = completed_at
+        state["duration_seconds"] = duration_seconds
+        state["status"] = status
+        state["output_preview"] = output_preview
+        state["variables_set"] = variables_set
+
+        if branches is not None:
+            state["branches"] = branches
+
+        self._current_state = None
+
+    def record_state_error(
+        self, state_name: str, error: str, state_type: str | None = None
+    ) -> None:
+        """Update the state entry with status="error" and error message."""
+        state = self._find_state_by_name(state_name)
+        if state is None:
+            state = {
+                "name": state_name,
+                "type": state_type or "unknown",
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self.states.append(state)
+
+        completed_at = datetime.now(timezone.utc).isoformat()
+        started_at = state.get("started_at", completed_at)
+
+        try:
+            start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+            duration_seconds = int((end_dt - start_dt).total_seconds())
+        except (ValueError, TypeError):
+            duration_seconds = 0
+
+        state["status"] = "error"
+        state["error"] = error
+        state["completed_at"] = completed_at
+        state["duration_seconds"] = duration_seconds
+        state["output_preview"] = ""
+        state["variables_set"] = []
+
+        self._current_state = None
+
+    def finalize(
+        self, final_variables: dict[str, Any], status: str = "completed"
+    ) -> None:
+        """Set completed_at, status, final_variables on the log."""
+        self.completed_at = datetime.now(timezone.utc).isoformat()
+        self.status = status
+        self.final_variables = final_variables
+
+    def save(self, base_dir: Path | None = None) -> Path:
+        """Write JSON to runs/<thread_id>.json relative to CWD (or base_dir)."""
+        if base_dir is not None:
+            runs_dir = (base_dir / "runs").resolve()
+        else:
+            runs_dir = (Path.cwd() / "runs").resolve()
+
+        os.makedirs(runs_dir, mode=0o700, exist_ok=True)
+        os.chmod(str(runs_dir), 0o700)
+
+        file_path = (runs_dir / f"{self.thread_id}").resolve()
+
+        if not str(file_path).startswith(str(runs_dir)):
+            raise ValueError("Invalid thread_id: path resolved outside runs directory")
+
+        file_path = file_path.with_suffix(".json")
+
+        if file_path.exists():
+            with open(file_path, "r") as f:
+                existing_log: dict[str, Any] = json.load(f)
+
+            existing_states = existing_log.get("states", [])
+            existing_states.extend(self.states)
+
+            self.states = existing_states
+            self.started_at = existing_log.get("started_at", self.started_at)
+
+        log_data = self.to_dict()
+        log_json = json.dumps(log_data, indent=2)
+
+        fd = os.open(str(file_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+            os.write(fd, log_json.encode("utf-8"))
+        finally:
+            os.close(fd)
+
+        return file_path
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the full log as a dict."""
+        result: dict[str, Any] = {
+            "thread_id": self.thread_id,
+            "flow_name": self.flow_name,
+            "flow_version": self.flow_version,
+            "started_at": self.started_at,
+            "status": self.status,
+            "states": self.states,
+        }
+
+        if self.completed_at is not None:
+            result["completed_at"] = self.completed_at
+
+        if self.final_variables is not None:
+            result["final_variables"] = self.final_variables
+
+        return result
+
+    def _find_state_by_name(self, state_name: str) -> dict[str, Any] | None:
+        """Find a state by name, searching from the end (most recent first)."""
+        for state in reversed(self.states):
+            if state.get("name") == state_name:
+                return state
+        return None

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 def _parse_path_segments(path: str) -> list[str | int]:
@@ -89,6 +89,21 @@ class WebhookConfig(BaseModel):
 
     url: str = Field(..., description="Webhook URL")
     template: str = Field(..., description="Message template with {variable} refs")
+
+    @field_validator("url")
+    @classmethod
+    def validate_https(cls, v: str) -> str:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(v)
+        if parsed.scheme == "https":
+            return v
+        if parsed.scheme == "http" and parsed.hostname in ("localhost", "127.0.0.1"):
+            return v
+        raise ValueError(
+            f"Webhook URL must use HTTPS (got {parsed.scheme}://). "
+            "HTTP is only allowed for localhost."
+        )
 
 
 class NotifyConfig(BaseModel):
@@ -326,7 +341,7 @@ class WaitState(BaseModel):
     type: Literal["wait"] = "wait"
     mode: Literal["prompt"] = "prompt"
     message: str = Field(..., description="Terminal display message")
-    choices: list[str] = Field(..., description="User selection options")
+    choices: list[str] = Field(..., min_length=1, description="User selection options")
     result_path: str = Field(..., description="JSONPath for selection result")
     notify: NotifyConfig | None = Field(
         default=None, description="Webhook notification"

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -64,6 +64,16 @@ class TaskSplitter(BaseModel):
     provider: str = Field(..., description="Provider name (claude/opencode/codex)")
     model: str = Field(..., description="Model name")
 
+    @model_validator(mode="after")
+    def validate_provider(self) -> "TaskSplitter":
+        valid_llm_providers = {"claude", "opencode", "codex"}
+        if self.provider not in valid_llm_providers:
+            raise ValueError(
+                f"task_splitter provider must be one of "
+                f"{', '.join(sorted(valid_llm_providers))}, got '{self.provider}'"
+            )
+        return self
+
 
 class ExtractRule(BaseModel):
     """Output extraction configuration."""

--- a/src/fdsx/notify/webhook.py
+++ b/src/fdsx/notify/webhook.py
@@ -1,0 +1,72 @@
+from typing import Any
+from urllib.parse import urlparse
+
+import structlog
+from httpx import Client, HTTPError, TimeoutException
+
+from fdsx.core.variables import resolve_template
+from fdsx.models.flow import NotifyConfig
+
+logger = structlog.get_logger(__name__)
+
+WEBHOOK_TIMEOUT_SECONDS = 10
+
+
+def _redact_url(url: str) -> str:
+    """Return only scheme and host from a URL; hide path/query which may contain secrets."""
+    try:
+        parsed = urlparse(url)
+        return f"{parsed.scheme}://{parsed.netloc}/***"
+    except Exception:
+        return "[url-redacted]"
+
+
+def send_webhook(url: str, message: str) -> bool:
+    """Send a webhook notification.
+
+    Args:
+        url: The webhook URL to POST to
+        message: The message body to send as JSON {"text": message}
+
+    Returns:
+        True on success (2xx status), False on any failure
+    """
+    payload = {"text": message}
+
+    try:
+        with Client(timeout=WEBHOOK_TIMEOUT_SECONDS) as client:
+            response = client.post(url, json=payload)
+            if response.status_code >= 200 and response.status_code < 300:
+                return True
+            logger.warning(
+                "webhook_non_2xx_response",
+                url=_redact_url(url),
+                status_code=response.status_code,
+            )
+            return False
+    except TimeoutException:
+        logger.warning(
+            "webhook_timeout", url=_redact_url(url), timeout=WEBHOOK_TIMEOUT_SECONDS
+        )
+        return False
+    except HTTPError as e:
+        logger.warning(
+            "webhook_http_error", url=_redact_url(url), error=type(e).__name__
+        )
+        return False
+    except Exception as e:
+        logger.warning(
+            "webhook_unknown_error", url=_redact_url(url), error=type(e).__name__
+        )
+        return False
+
+
+def send_notification(notify: NotifyConfig, state_dict: dict[str, Any]) -> None:
+    """Send a webhook notification with resolved template variables.
+
+    Args:
+        notify: The notification configuration containing webhook URL and template
+        state_dict: The current state dictionary for template variable resolution
+    """
+    resolved_message = resolve_template(notify.webhook.template, state_dict)
+    send_webhook(notify.webhook.url, resolved_message)

--- a/tests/fixtures/batch_flow.yaml
+++ b/tests/fixtures/batch_flow.yaml
@@ -1,0 +1,22 @@
+name: Batch Task Execution Flow
+start_at: plan
+version: '1.0'
+
+task_splitter:
+  provider: claude
+  model: claude-3-5-sonnet-20241022
+
+states:
+  plan:
+    type: task
+    provider: system
+    command: "echo 'Planning for task: $task'"
+    result_path: $.plan
+    next: implement
+
+  implement:
+    type: task
+    provider: system
+    command: "echo 'Implementation for task: $task'"
+    result_path: $.implementation
+    end: true

--- a/tests/fixtures/checkpoint_flow.yaml
+++ b/tests/fixtures/checkpoint_flow.yaml
@@ -1,0 +1,29 @@
+name: Checkpoint Test Flow
+description: A simple 3-state linear flow for checkpoint/resume testing
+start_at: plan
+max_loop: 100
+
+states:
+  plan:
+    type: task
+    provider: system
+    model: null
+    command: echo "plan output"
+    result_path: "$.plan_output"
+    next: implement
+
+  implement:
+    type: task
+    provider: system
+    model: null
+    command: echo "implement output"
+    result_path: "$.implement_output"
+    next: review
+
+  review:
+    type: task
+    provider: system
+    model: null
+    command: echo "review output"
+    result_path: "$.review_output"
+    end: true

--- a/tests/fixtures/loop_flow.yaml
+++ b/tests/fixtures/loop_flow.yaml
@@ -1,27 +1,41 @@
 name: Loop Test Flow
-start_at: counter
+start_at: plan
 max_loop: 3
 
 states:
-  counter:
+  plan:
     type: task
     provider: system
-    command: "echo counting"
-    result_path: $.count
-    next: check
+    command: echo "Planning step"
+    result_path: $.plan_output
+    next: implement
 
-  check:
+  implement:
+    type: task
+    provider: system
+    command: echo "Implementation step"
+    result_path: $.impl_output
+    next: review
+
+  review:
+    type: task
+    provider: system
+    command: echo "REJECTED"
+    result_path: $.review_output
+    next: decide
+
+  decide:
     type: choice
     choices:
-      - variable: $.count
+      - variable: $.review_output
         operator: equals
-        value: "never_matches"
+        value: "APPROVED"
         next: done
-    default: counter
+    default: plan
 
   done:
     type: task
     provider: system
-    command: "echo done"
-    result_path: $.final
+    command: echo "Flow completed"
+    result_path: $.final_result
     end: true

--- a/tests/fixtures/parallel_min_success.yaml
+++ b/tests/fixtures/parallel_min_success.yaml
@@ -1,0 +1,27 @@
+name: Parallel Min Success Flow
+start_at: parallel_with_failure
+version: '1.0'
+
+states:
+  parallel_with_failure:
+    type: parallel
+    branches:
+      - provider: system
+        command: echo "success"
+        retry: 0
+      - provider: system
+        command: echo "success"
+        retry: 0
+      - provider: system
+        command: "exit 1"
+        retry: 0
+    result_path: $.results
+    min_success: 2
+    next: check_success
+
+  check_success:
+    type: task
+    provider: system
+    command: echo "Flow continued after partial failure"
+    result_path: $.success_check
+    end: true

--- a/tests/fixtures/parallel_review.yaml
+++ b/tests/fixtures/parallel_review.yaml
@@ -1,0 +1,79 @@
+name: Parallel Review Flow
+start_at: review_parallel
+version: '1.0'
+
+states:
+  review_parallel:
+    type: parallel
+    branches:
+      - provider: system
+        command: echo "APPROVED"
+        extract:
+          strategy:
+            - keyword
+          pattern: APPROVED|REJECTED
+          result_path: $.decision
+        retry: 0
+      - provider: system
+        command: echo "APPROVED"
+        extract:
+          strategy:
+            - keyword
+          pattern: APPROVED|REJECTED
+          result_path: $.decision
+        retry: 0
+      - provider: system
+        command: echo "REJECTED"
+        extract:
+          strategy:
+            - keyword
+          pattern: APPROVED|REJECTED
+          result_path: $.decision
+        retry: 0
+    result_path: $.reviews
+    next: aggregate
+
+  aggregate:
+    type: pass
+    aggregate:
+      source: $.reviews
+      field: decision
+      strategy: majority
+      match: APPROVED
+      no_match: REJECTED
+      result_path: $.decision
+    next: decision
+
+  decision:
+    type: choice
+    choices:
+      - variable: $.decision
+        operator: equals
+        value: APPROVED
+        next: approved_path
+      - variable: $.decision
+        operator: equals
+        value: REJECTED
+        next: rejected_path
+    default: unknown_path
+
+  approved_path:
+    type: task
+    provider: system
+    command: echo "Approved path taken"
+    result_path: $.approved_result
+    end: true
+
+  rejected_path:
+    type: task
+    provider: system
+    command: echo "Rejected path taken"
+    result_path: $.rejected_result
+    end: true
+
+  unknown_path:
+    type: task
+    provider: system
+    command: echo "Unknown decision"
+    result_path: $.unknown_result
+    end: true

--- a/tests/fixtures/sample_tasks.md
+++ b/tests/fixtures/sample_tasks.md
@@ -1,0 +1,3 @@
+Task 1: Implement user authentication feature
+Task 2: Add password reset functionality  
+Task 3: Create user profile management

--- a/tests/fixtures/wait_approval.yaml
+++ b/tests/fixtures/wait_approval.yaml
@@ -1,0 +1,55 @@
+name: Wait Approval Flow
+start_at: plan
+version: '1.0'
+
+states:
+  plan:
+    type: task
+    provider: system
+    command: echo Planning phase complete
+    result_path: $.plan_output
+    next: approval_gate
+
+  approval_gate:
+    type: wait
+    mode: prompt
+    message: |
+      Please review the plan and approve for implementation.
+      Plan: {plan_output}
+    choices:
+      - approve
+      - reject
+      - retry
+    result_path: $.approval_decision
+    next: route_approval
+
+  route_approval:
+    type: choice
+    choices:
+      - variable: $.approval_decision
+        operator: equals
+        value: approve
+        next: implement
+      - variable: $.approval_decision
+        operator: equals
+        value: reject
+        next: rejected
+      - variable: $.approval_decision
+        operator: equals
+        value: retry
+        next: plan
+    default: rejected
+
+  implement:
+    type: task
+    provider: system
+    command: echo Implementation complete
+    result_path: $.implementation_output
+    end: true
+
+  rejected:
+    type: task
+    provider: system
+    command: echo Request rejected
+    result_path: $.rejected_output
+    end: true

--- a/tests/fixtures/wait_resume_flow.yaml
+++ b/tests/fixtures/wait_resume_flow.yaml
@@ -1,0 +1,56 @@
+name: Wait Resume Test Flow
+description: A flow with Wait state for checkpoint/resume testing
+start_at: plan
+max_loop: 100
+
+states:
+  plan:
+    type: task
+    provider: system
+    model: null
+    command: echo "plan output"
+    result_path: "$.plan_output"
+    next: wait
+
+  wait:
+    type: wait
+    message: "Please approve or reject the plan"
+    choices:
+      - approve
+      - reject
+      - retry
+    result_path: "$.approval"
+    next: decision
+
+  decision:
+    type: choice
+    choices:
+      - variable: "$.approval"
+        operator: equals
+        value: approve
+        next: approved
+      - variable: "$.approval"
+        operator: equals
+        value: reject
+        next: rejected
+      - variable: "$.approval"
+        operator: equals
+        value: retry
+        next: plan
+    default: rejected
+
+  approved:
+    type: task
+    provider: system
+    model: null
+    command: echo "approved"
+    result_path: "$.status"
+    end: true
+
+  rejected:
+    type: task
+    provider: system
+    model: null
+    command: echo "rejected"
+    result_path: "$.status"
+    end: true

--- a/tests/fixtures/wait_webhook.yaml
+++ b/tests/fixtures/wait_webhook.yaml
@@ -1,0 +1,59 @@
+name: Wait Webhook Flow
+start_at: plan
+version: '1.0'
+
+states:
+  plan:
+    type: task
+    provider: system
+    command: echo Planning phase complete
+    result_path: $.plan_output
+    next: approval_gate
+
+  approval_gate:
+    type: wait
+    mode: prompt
+    message: |
+      Please review the plan and approve for implementation.
+      Plan: {plan_output}
+    choices:
+      - approve
+      - reject
+      - retry
+    result_path: $.approval_decision
+    notify:
+      webhook:
+        url: https://example.com/webhook
+        template: "Approval needed: {plan_output}"
+    next: route_approval
+
+  route_approval:
+    type: choice
+    choices:
+      - variable: $.approval_decision
+        operator: equals
+        value: approve
+        next: implement
+      - variable: $.approval_decision
+        operator: equals
+        value: reject
+        next: rejected
+      - variable: $.approval_decision
+        operator: equals
+        value: retry
+        next: plan
+    default: rejected
+
+  implement:
+    type: task
+    provider: system
+    command: echo Implementation complete
+    result_path: $.implementation_output
+    end: true
+
+  rejected:
+    type: task
+    provider: system
+    command: echo Request rejected
+    result_path: $.rejected_output
+    end: true

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -1,0 +1,173 @@
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.core import engine
+from fdsx.models.flow import Flow, TaskState
+
+
+class TestBatchExecution:
+    def test_full_batch_flow(self):
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1\n2. Task 2\n3. Task 3",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.display_task_list", return_value=True):
+                with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        base_dir = Path(tmpdir)
+                        results = engine.run_batch(flow_path, tasks_file, base_dir)
+
+        assert len(results) == 3
+        thread_ids = [r["thread_id"] for r in results]
+        assert len(thread_ids) == len(set(thread_ids)), (
+            "All thread_ids should be unique"
+        )
+        for result in results:
+            assert result["status"] in ["completed", "failed"]
+            assert result["task_description"] is not None
+            assert result["thread_id"] is not None
+
+    def test_batch_rejection(self):
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1\n2. Task 2\n3. Task 3",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.display_task_list", return_value=False):
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    base_dir = Path(tmpdir)
+                    results = engine.run_batch(flow_path, tasks_file, base_dir)
+
+        assert results == []
+
+    def test_missing_task_splitter(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            import yaml
+
+            yaml.dump(flow.model_dump(), f)
+            flow_path = Path(f.name)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            f.write("Test task\n")
+            tasks_file = Path(f.name)
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                base_dir = Path(tmpdir)
+                with pytest.raises(engine.FlowValidationError, match="task_splitter"):
+                    engine.run_batch(flow_path, tasks_file, base_dir)
+        finally:
+            flow_path.unlink()
+            tasks_file.unlink()
+
+    def test_mutual_exclusion_validation(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "fdsx.cli.main",
+                "run",
+                "tests/fixtures/batch_flow.yaml",
+                "--input",
+                "foo=bar",
+                "--tasks",
+                "tests/fixtures/sample_tasks.md",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 2
+        assert "mutually exclusive" in result.stderr.lower()
+
+
+class TestBatchIntegrationWithMockedInput:
+    def test_batch_with_failing_task_continue(self):
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
+
+        call_count = [0]
+
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise RuntimeError("Task failed intentionally")
+            return {"result": "ok"}
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1\n2. Task 2\n3. Task 3",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.display_task_list", return_value=True):
+                with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        base_dir = Path(tmpdir)
+                        with patch("fdsx.core.engine.input", side_effect=["y", "y"]):
+                            results = engine.run_batch(flow_path, tasks_file, base_dir)
+
+        assert len(results) == 3
+
+    def test_batch_with_failing_task_stop(self):
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
+
+        call_count = [0]
+
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise RuntimeError("Task failed intentionally")
+            return {"result": "ok"}
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1\n2. Task 2\n3. Task 3",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.display_task_list", return_value=True):
+                with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        base_dir = Path(tmpdir)
+                        with patch("fdsx.core.engine.input", side_effect=["n"]):
+                            results = engine.run_batch(flow_path, tasks_file, base_dir)
+
+        assert len(results) == 2

--- a/tests/integration/test_checkpoint_resume.py
+++ b/tests/integration/test_checkpoint_resume.py
@@ -1,0 +1,281 @@
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fdsx.checkpoint.manager import CheckpointManager
+from fdsx.core import engine
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def checkpoint_flow_path():
+    return Path("tests/fixtures/checkpoint_flow.yaml")
+
+
+@pytest.fixture
+def wait_resume_flow_path():
+    return Path("tests/fixtures/wait_resume_flow.yaml")
+
+
+class TestPIDLock:
+    def test_concurrent_execution_locked(self, temp_dir, checkpoint_flow_path):
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-concurrent-lock"
+
+        manager = CheckpointManager(base_dir=base_dir)
+        assert manager.acquire_lock(thread_id) is True
+
+        with pytest.raises(RuntimeError, match="locked by PID"):
+            engine.run_flow(
+                checkpoint_flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        manager.release_lock(thread_id)
+
+    def test_stale_lock_cleanup(self, temp_dir):
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-stale-lock"
+
+        manager = CheckpointManager(base_dir=base_dir)
+        lock_path = manager._get_lock_path(thread_id)
+
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(lock_path, "w") as f:
+            f.write("99999")
+
+        assert manager.acquire_lock(thread_id) is True
+
+        with open(lock_path) as f:
+            pid = int(f.read().strip())
+        assert pid == os.getpid()
+
+
+class TestCheckpointVerify:
+    def test_verify_checkpoint_missing(self, temp_dir):
+        base_dir = temp_dir / ".fdsx"
+        manager = CheckpointManager(base_dir=base_dir)
+        assert manager.verify_checkpoint("nonexistent") is False
+
+
+class TestListThreads:
+    def test_list_threads_empty(self, temp_dir):
+        base_dir = temp_dir / ".fdsx"
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+        assert threads == []
+
+
+class TestResumeFlow:
+    def test_resume_nonexistent_thread(self, temp_dir):
+        base_dir = temp_dir / ".fdsx"
+
+        with pytest.raises(RuntimeError, match="No checkpoint found"):
+            engine.resume_flow("nonexistent-thread", base_dir)
+
+    def test_resume_corrupted_checkpoint(self, temp_dir, checkpoint_flow_path):
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-corrupt"
+
+        engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        db_path = base_dir / "checkpoints" / "checkpoints.db"
+        # Delete ALL SQLite sidecar files (WAL mode creates .db-wal and .db-shm)
+        for suffix in ["", "-wal", "-shm"]:
+            p = db_path.parent / (db_path.name + suffix)
+            if p.exists():
+                p.unlink()
+        db_path.write_text("not a valid database")
+
+        with pytest.raises(RuntimeError, match="checkpoint"):
+            engine.resume_flow(thread_id, base_dir)
+
+
+class TestCheckpointIntegrity:
+    def test_checkpoint_integrity_missing_db(self, temp_dir):
+        base_dir = temp_dir / ".fdsx"
+        manager = CheckpointManager(base_dir=base_dir)
+        assert manager.verify_checkpoint("any-thread") is False
+
+
+class TestCLICommands:
+    def test_run_with_checkpoint_flag(self, temp_dir, checkpoint_flow_path):
+        """Test that --checkpoint flag creates checkpoint directory."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-cli-checkpoint"
+
+        result = engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        assert result.get("plan_output") == "plan output"
+        assert result.get("implement_output") == "implement output"
+        assert result.get("review_output") == "review output"
+
+
+class TestCheckpointSave:
+    def test_checkpoint_save_creates_db(self, temp_dir, checkpoint_flow_path):
+        """T051: run a flow → verify checkpoints.db exists and verify_checkpoint returns True."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-save"
+
+        engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        db_path = base_dir / "checkpoints" / "checkpoints.db"
+        assert db_path.exists()
+
+        manager = CheckpointManager(base_dir=base_dir)
+        assert manager.verify_checkpoint(thread_id) is True
+
+    def test_list_threads_after_run(self, temp_dir, checkpoint_flow_path):
+        """T051: list shows correct metadata after flow run."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-list-meta"
+
+        engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+        assert len(threads) >= 1
+        thread_info = next(t for t in threads if t["thread_id"] == thread_id)
+        assert thread_info["flow_name"] == "Checkpoint Test Flow"
+        assert thread_info["status"] == "completed"
+        assert thread_info["current_state"] != ""
+        assert thread_info["started_at"] != ""
+
+
+class TestResumeSuccess:
+    def test_resume_wait_state_flow(self, temp_dir, wait_resume_flow_path):
+        """T051: interrupt at Wait → resume with resume_flow → verify completion."""
+        from unittest.mock import patch
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-resume-wait"
+
+        # Step 1: Run flow until Wait state, simulate crash at prompt
+        with pytest.raises(RuntimeError, match="Flow execution failed"):
+            with patch(
+                "fdsx.core.engine.display_wait_prompt",
+                side_effect=Exception("simulated crash"),
+            ):
+                engine.run_flow(
+                    wait_resume_flow_path,
+                    thread_id=thread_id,
+                    base_dir=base_dir,
+                )
+
+        # Verify checkpoint was saved before the crash
+        manager = CheckpointManager(base_dir=base_dir)
+        assert manager.verify_checkpoint(thread_id) is True
+
+        # Step 2: Resume from checkpoint with stdin mocked to select "1" (approve)
+        with patch("builtins.input", return_value="1"):
+            result = engine.resume_flow(thread_id, base_dir, wait_resume_flow_path)
+
+        # Verify flow completed through the approve branch
+        assert "status" in result, f"Expected 'status' in result, got: {result}"
+        assert result["status"] == "approved"
+        assert result.get("plan_output") == "plan output"
+
+
+class TestScenario4FullResume:
+    """T051 Scenario 4: Full resume from mid-execution crash (not at Wait state)."""
+
+    def test_resume_after_crash_completes_remaining_states(
+        self, temp_dir, checkpoint_flow_path
+    ):
+        """T051: crash mid-flow (implement state) → resume → all remaining states execute."""
+        from unittest.mock import patch
+        from fdsx.providers.system import SystemProvider
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-scenario4"
+
+        call_count = 0
+        original_execute = SystemProvider().execute
+
+        def crash_on_second_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise Exception("simulated crash on implement state")
+            return original_execute(*args, **kwargs)
+
+        # Step 1: Run flow until implement state crashes
+        with pytest.raises(RuntimeError, match="Flow execution failed"):
+            with patch.object(
+                SystemProvider, "execute", side_effect=crash_on_second_call
+            ):
+                engine.run_flow(
+                    checkpoint_flow_path,
+                    thread_id=thread_id,
+                    base_dir=base_dir,
+                )
+
+        # Verify checkpoint was saved (plan completed before crash)
+        manager = CheckpointManager(base_dir=base_dir)
+        assert manager.verify_checkpoint(thread_id) is True
+
+        # Step 2: Resume WITHOUT mock — implement and review should now succeed
+        result = engine.resume_flow(thread_id, base_dir, checkpoint_flow_path)
+
+        assert result.get("plan_output") == "plan output"
+        assert result.get("implement_output") == "implement output"
+        assert result.get("review_output") == "review output"
+
+    def test_list_shows_stopped_after_crash(self, temp_dir, checkpoint_flow_path):
+        """T051: crash mid-flow → fdsx list shows 'stopped' not 'waiting'."""
+        from unittest.mock import patch
+        from fdsx.providers.system import SystemProvider
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-scenario4-list"
+
+        call_count = 0
+        original_execute = SystemProvider().execute
+
+        def crash_on_second_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise Exception("simulated crash")
+            return original_execute(*args, **kwargs)
+
+        with pytest.raises(RuntimeError, match="Flow execution failed"):
+            with patch.object(
+                SystemProvider, "execute", side_effect=crash_on_second_call
+            ):
+                engine.run_flow(
+                    checkpoint_flow_path,
+                    thread_id=thread_id,
+                    base_dir=base_dir,
+                )
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+        thread_info = next((t for t in threads if t["thread_id"] == thread_id), None)
+        assert thread_info is not None
+        assert thread_info["status"] == "stopped"
+        assert thread_info["current_state"] == "implement"

--- a/tests/integration/test_cli_e2e_phase2.py
+++ b/tests/integration/test_cli_e2e_phase2.py
@@ -1,0 +1,106 @@
+import json
+import subprocess
+
+
+def get_fdsx_command():
+    """Get the fdsx command using uv to exercise the entry point."""
+    return ["uv", "run", "fdsx"]
+
+
+class TestCLIE2EPhase2:
+    """End-to-end CLI tests for Phase 2 flow types."""
+
+    def test_parallel_review_yaml_validates(self):
+        """Test parallel_review.yaml validates successfully."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "validate",
+                "tests/fixtures/parallel_review.yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_parallel_review_yaml_runs(self):
+        """Test parallel_review.yaml runs successfully via CLI."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "run",
+                "tests/fixtures/parallel_review.yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert "reviews" in output
+        assert output["decision"] == "APPROVED"
+        assert "approved_result" in output
+
+    def test_extraction_flow_yaml_validates(self):
+        """Test extraction_flow.yaml validates successfully."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "validate",
+                "tests/fixtures/extraction_flow.yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_extraction_flow_yaml_runs(self):
+        """Test extraction_flow.yaml runs successfully via CLI."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "run",
+                "tests/fixtures/extraction_flow.yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert "decision" in output
+        assert output["decision"] == "APPROVED"
+        assert "raw_output" in output
+
+    def test_loop_flow_yaml_validates(self):
+        """Test loop_flow.yaml validates successfully."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "validate",
+                "tests/fixtures/loop_flow.yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+
+    def test_loop_flow_yaml_runs(self):
+        """Test loop_flow.yaml runs successfully via CLI with loop behavior."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "run",
+                "tests/fixtures/loop_flow.yaml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        # Partial results from loop iterations must be present
+        assert "plan_output" in output
+        assert "impl_output" in output
+        assert "review_output" in output
+        # The flow should NOT reach the "done" state since review always rejects
+        assert "final_result" not in output
+        # Verify loop completion message on stderr
+        assert "Loop completed" in result.stderr

--- a/tests/integration/test_cli_e2e_phase3.py
+++ b/tests/integration/test_cli_e2e_phase3.py
@@ -1,0 +1,223 @@
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def get_fdsx_command():
+    """Get the fdsx command using uv to exercise the entry point."""
+    return ["uv", "run", "fdsx"]
+
+
+class TestCLIE2EPhase3:
+    """End-to-end CLI tests for Phase 3 (Wait state, checkpoint/resume, prompt_file)."""
+
+    def test_wait_state_flow_with_stdin_selection(self):
+        """Test fdsx run with Wait state flow - provide input via stdin."""
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "run",
+                "tests/fixtures/wait_approval.yaml",
+            ],
+            input="1\n",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert "plan_output" in output
+        assert "approval_decision" in output
+        assert output["approval_decision"] == "approve"
+
+    def test_resume_interrupted_flow(self):
+        """Test fdsx resume --thread-id with previously interrupted flow."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            flow_path = str(Path("tests/fixtures/wait_approval.yaml").resolve())
+            thread_id = "test-resume-interrupted"
+            base_dir = str(Path(tmp_dir) / ".fdsx")
+
+            first_run = subprocess.run(
+                get_fdsx_command() + ["run", flow_path, "--thread-id", thread_id],
+                input="",
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert first_run.returncode == 1, (
+                f"Expected exit 1, got {first_run.returncode}. stderr: {first_run.stderr}"
+            )
+            assert "Checkpoint saved" in first_run.stderr
+
+            resume_result = subprocess.run(
+                get_fdsx_command()
+                + [
+                    "resume",
+                    "--thread-id",
+                    thread_id,
+                    "--base-dir",
+                    base_dir,
+                ],
+                input="1\n",
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert resume_result.returncode == 0, f"stderr: {resume_result.stderr}"
+            output = json.loads(resume_result.stdout)
+            assert "approval_decision" in output
+            assert output["approval_decision"] == "approve"
+
+    def test_resume_nonexistent_thread(self):
+        """Test fdsx resume --thread-id with non-existent thread returns exit code 2."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base_dir = Path(tmp_dir) / ".fdsx"
+
+            result = subprocess.run(
+                get_fdsx_command()
+                + [
+                    "resume",
+                    "--thread-id",
+                    "nonexistent-thread-id-12345",
+                    "--base-dir",
+                    str(base_dir),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 2, (
+                f"Expected exit code 2, got {result.returncode}"
+            )
+            assert "No checkpoint found" in result.stderr
+
+    def test_list_shows_threads(self):
+        """Test fdsx list shows table output with known thread."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base_dir = Path(tmp_dir) / ".fdsx"
+            thread_id = "test-list-thread"
+            flow_path = Path("tests/fixtures/simple_flow.yaml").resolve()
+
+            run_result = subprocess.run(
+                get_fdsx_command()
+                + [
+                    "run",
+                    str(flow_path),
+                    "--thread-id",
+                    thread_id,
+                ],
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert run_result.returncode == 0, f"stderr: {run_result.stderr}"
+
+            list_result = subprocess.run(
+                get_fdsx_command()
+                + [
+                    "list",
+                    "--base-dir",
+                    str(base_dir),
+                ],
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert list_result.returncode == 0, f"stderr: {list_result.stderr}"
+            assert "THREAD_ID" in list_result.stdout
+            assert "FLOW_NAME" in list_result.stdout
+            assert "STATUS" in list_result.stdout
+            assert "CURRENT_STATE" in list_result.stdout
+            assert "STARTED_AT" in list_result.stdout
+            assert thread_id in list_result.stdout
+
+    def test_list_empty(self):
+        """Test fdsx list with no threads shows empty message."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base_dir = Path(tmp_dir) / ".fdsx"
+
+            result = subprocess.run(
+                get_fdsx_command()
+                + [
+                    "list",
+                    "--base-dir",
+                    str(base_dir),
+                ],
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, f"stderr: {result.stderr}"
+            assert "No flow executions found" in result.stdout
+
+    def test_prompt_file_validate_success(self):
+        """Test fdsx validate with prompt_file - file is loaded from disk successfully."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            prompt_path = Path(tmp_dir) / "my_prompt.txt"
+            prompt_path.write_text("Analyze this code: {code}")
+
+            flow_path = Path(tmp_dir) / "flow.yaml"
+            flow_path.write_text(
+                "name: Prompt File Validate Test\n"
+                "start_at: task1\n"
+                "version: '1.0'\n"
+                "\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: claude\n"
+                "    model: opus\n"
+                "    prompt_file: my_prompt.txt\n"
+                "    result_path: $.result\n"
+                "    end: true\n"
+            )
+
+            result = subprocess.run(
+                get_fdsx_command() + ["validate", str(flow_path)],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 0, (
+                f"Expected exit 0 (prompt_file loaded from disk), got {result.returncode}. "
+                f"stderr: {result.stderr}"
+            )
+            assert "is valid" in result.stdout
+
+    def test_prompt_file_missing_fails(self):
+        """Test fdsx run with missing prompt_file fails with exit code 2 and clear error."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            flow_path = Path(tmp_dir) / "flow.yaml"
+            flow_path.write_text(
+                "name: Missing Prompt File Test\n"
+                "start_at: task1\n"
+                "version: '1.0'\n"
+                "\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: claude\n"
+                "    model: opus\n"
+                "    prompt_file: nonexistent.txt\n"
+                "    result_path: $.result\n"
+                "    end: true\n"
+            )
+
+            result = subprocess.run(
+                get_fdsx_command() + ["run", str(flow_path)],
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert result.returncode == 2, (
+                f"Expected exit code 2 (validation error), got {result.returncode}. "
+                f"stderr: {result.stderr}"
+            )
+            assert "not found" in result.stderr.lower()

--- a/tests/integration/test_cli_e2e_phase4.py
+++ b/tests/integration/test_cli_e2e_phase4.py
@@ -1,0 +1,127 @@
+"""End-to-end CLI tests for Phase 4 batch task scenarios."""
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+from fdsx.providers.base import ProviderResult
+
+
+def get_fdsx_command():
+    """Get the fdsx command invoking the CLI module directly."""
+    return [sys.executable, "-m", "fdsx.cli.main"]
+
+
+class TestBatchCLIE2E:
+    """End-to-end CLI tests for batch task execution (T070)."""
+
+    def test_batch_full_execution_with_approval(self):
+        """Test fdsx run --tasks via CLI: approve → all tasks execute → exit 0 + JSON."""
+        runner = CliRunner()
+        flow_path = str(Path("tests/fixtures/batch_flow.yaml").resolve())
+        tasks_path = str(Path("tests/fixtures/sample_tasks.md").resolve())
+
+        mock_task_result = ProviderResult(
+            exit_code=0,
+            stdout="1. Implement user authentication feature\n2. Add search functionality\n3. Write API documentation",
+            stderr="",
+        )
+
+        class MockTaskSplitterProvider:
+            def execute(self, prompt, model=None, **kwargs):
+                return mock_task_result
+
+        with patch(
+            "fdsx.core.batch.get_provider",
+            return_value=MockTaskSplitterProvider(),
+        ):
+            with patch("fdsx.core.engine.display_task_list", return_value=True):
+                result = runner.invoke(
+                    app,
+                    ["run", flow_path, "--tasks", tasks_path],
+                )
+
+        assert result.exit_code == 0, (
+            f"output: {result.output}\nexception: {result.exception}"
+        )
+        json_text = result.output.split("\n\n")[0]
+        output = json.loads(json_text)
+        assert isinstance(output, list)
+        assert len(output) == 3
+        for item in output:
+            assert item["status"] == "completed"
+            assert "thread_id" in item
+            assert item["error"] is None
+
+    def test_input_tasks_mutual_exclusion(self):
+        """Test --input and --tasks together → exit code 2, mutual exclusion error."""
+        flow_path = str(Path("tests/fixtures/batch_flow.yaml").resolve())
+        tasks_path = str(Path("tests/fixtures/sample_tasks.md").resolve())
+
+        result = subprocess.run(
+            get_fdsx_command()
+            + [
+                "run",
+                flow_path,
+                "--input",
+                "task=foo",
+                "--tasks",
+                tasks_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 2, (
+            f"Expected exit code 2, got {result.returncode}. stderr: {result.stderr}"
+        )
+        assert "mutually exclusive" in result.stderr.lower()
+
+    def test_batch_missing_task_splitter(self):
+        """Test --tasks with flow missing task_splitter → exit code 2."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_path = Path(tmpdir) / "no_splitter_flow.yaml"
+            flow_path.write_text(
+                "name: No Splitter Flow\n"
+                "start_at: task1\n"
+                "version: '1.0'\n"
+                "\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: system\n"
+                "    command: echo hello\n"
+                "    result_path: $.result\n"
+                "    end: true\n"
+            )
+
+            tasks_path = Path(tmpdir) / "tasks.md"
+            tasks_path.write_text("Task 1\nTask 2\n")
+
+            result = subprocess.run(
+                get_fdsx_command()
+                + [
+                    "run",
+                    str(flow_path),
+                    "--tasks",
+                    str(tasks_path),
+                ],
+                input="y\n",
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=tmpdir,
+            )
+
+            assert result.returncode == 2, (
+                f"Expected exit code 2, got {result.returncode}. stderr: {result.stderr}"
+            )
+            assert "task_splitter" in result.stderr.lower()

--- a/tests/integration/test_e2e_scenarios.py
+++ b/tests/integration/test_e2e_scenarios.py
@@ -1,0 +1,379 @@
+"""Comprehensive end-to-end scenario tests with run log verification (T071, T072)."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.checkpoint.manager import CheckpointManager
+from fdsx.core import engine
+from fdsx.core.loader import load_flow
+from fdsx.providers.base import ProviderResult
+
+
+class TestScenario1LinearFlow:
+    """Scenario 1: Simple linear flow (Plan → Implement → Review)."""
+
+    def test_linear_flow_state_transitions(self, tmp_path, monkeypatch):
+        """Verify state transitions and final JSON output."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "simple_flow.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        thread_id = "test-scenario1"
+        result = engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        assert "plan" in result
+        assert "implementation" in result
+        assert "review" in result
+        assert "Plan:" in result["plan"]
+        assert "Implementation:" in result["implementation"]
+        assert "Review:" in result["review"]
+
+    def test_linear_flow_run_log_schema(self, tmp_path, monkeypatch):
+        """Verify runs/<thread_id>.json conforms to Run Log Format schema."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "simple_flow.yaml"
+        thread_id = "test-scenario1-log"
+
+        engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_log = self._read_run_log(tmp_path, thread_id)
+
+        assert run_log["thread_id"] == thread_id
+        assert run_log["flow_name"] == "Simple Plan-Implement-Review Flow"
+        assert "started_at" in run_log
+        assert run_log["status"] == "completed"
+        assert "completed_at" in run_log
+        assert "final_variables" in run_log
+        assert "states" in run_log
+        assert isinstance(run_log["states"], list)
+
+        state_names = [s["name"] for s in run_log["states"]]
+        assert "plan" in state_names
+        assert "implement" in state_names
+        assert "review" in state_names
+
+        for state in run_log["states"]:
+            assert "name" in state
+            assert "type" in state
+            assert "started_at" in state
+            assert "completed_at" in state
+            assert "duration_seconds" in state
+            assert "status" in state
+            assert "output_preview" in state
+            assert "variables_set" in state
+
+        assert run_log["final_variables"]["plan"]
+        assert run_log["final_variables"]["implementation"]
+        assert run_log["final_variables"]["review"]
+
+    def test_linear_flow_run_log_final_variables(self, tmp_path, monkeypatch):
+        """Verify final_variables contains expected keys."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "simple_flow.yaml"
+        thread_id = "test-scenario1-vars"
+
+        engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_log = self._read_run_log(tmp_path, thread_id)
+        final_vars = run_log["final_variables"]
+
+        assert "plan" in final_vars
+        assert "implementation" in final_vars
+        assert "review" in final_vars
+
+    @staticmethod
+    def _read_run_log(base_dir: Path, thread_id: str) -> dict:
+        log_path = base_dir / "runs" / f"{thread_id}.json"
+        assert log_path.exists(), f"Run log not found at {log_path}"
+        with open(log_path, "r") as f:
+            return json.load(f)
+
+
+class TestScenario2ParallelVote:
+    """Scenario 2: Parallel review + majority vote."""
+
+    def test_parallel_review_aggregation_and_routing(self, tmp_path, monkeypatch):
+        """Verify parallel execution, aggregation result, choice routing."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "parallel_review.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = engine.run_flow(path, thread_id="test-scenario2")
+
+        assert "reviews" in result
+        assert len(result["reviews"]) == 3
+        for review in result["reviews"]:
+            assert "output" in review
+
+        assert "decision" in result
+        assert result["decision"] == "APPROVED"
+        assert "approved_result" in result
+
+    def test_parallel_run_log_has_branch_details(self, tmp_path, monkeypatch):
+        """Verify parallel state entries include branch-level details."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "parallel_review.yaml"
+        thread_id = "test-scenario2-log"
+
+        engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_log = TestScenario1LinearFlow._read_run_log(tmp_path, thread_id)
+
+        parallel_states = [s for s in run_log["states"] if s["type"] == "parallel"]
+        assert len(parallel_states) >= 1
+
+        parallel_state = parallel_states[0]
+        assert "branches" in parallel_state
+        assert len(parallel_state["branches"]) == 3
+        for branch in parallel_state["branches"]:
+            assert "index" in branch
+            assert "provider" in branch
+            assert "status" in branch
+            assert "duration_seconds" in branch
+
+    def test_parallel_final_variables(self, tmp_path, monkeypatch):
+        """Verify final_variables contains parallel and aggregation results."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "parallel_review.yaml"
+        thread_id = "test-scenario2-vars"
+
+        engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_log = TestScenario1LinearFlow._read_run_log(tmp_path, thread_id)
+        final_vars = run_log["final_variables"]
+
+        assert "reviews" in final_vars
+        assert len(final_vars["reviews"]) == 3
+        assert "decision" in final_vars
+        assert final_vars["decision"] == "APPROVED"
+
+
+class TestScenario3WaitWebhook:
+    """Scenario 3: Wait state + webhook notification."""
+
+    def test_wait_webhook_routing(self, tmp_path, monkeypatch):
+        """Verify wait state + webhook → choice routing."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "wait_webhook.yaml"
+
+        with patch("fdsx.notify.webhook.send_webhook") as mock_webhook:
+            mock_webhook.return_value = True
+
+            with patch("builtins.input", return_value="1"):
+                result = engine.run_flow(path, thread_id="test-scenario3")
+
+            assert mock_webhook.call_count == 1
+            assert "plan_output" in result
+            assert "approval_decision" in result
+            assert result["approval_decision"] == "approve"
+            assert "implementation_output" in result
+
+    def test_wait_webhook_run_log(self, tmp_path, monkeypatch):
+        """Verify run log for wait state scenario."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "wait_webhook.yaml"
+        thread_id = "test-scenario3-log"
+
+        with patch("fdsx.notify.webhook.send_webhook") as mock_webhook:
+            mock_webhook.return_value = True
+
+            with patch("builtins.input", return_value="1"):
+                engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_log = TestScenario1LinearFlow._read_run_log(tmp_path, thread_id)
+
+        assert run_log["status"] == "completed"
+        state_names = [s["name"] for s in run_log["states"]]
+        assert "plan" in state_names
+        assert "approval_gate" in state_names
+        assert "implement" in state_names
+
+        wait_state = next(s for s in run_log["states"] if s["name"] == "approval_gate")
+        assert wait_state["type"] == "wait"
+
+        assert "final_variables" in run_log
+        assert run_log["final_variables"]["approval_decision"] == "approve"
+
+
+class TestScenario4CheckpointResume:
+    """Scenario 4: Checkpoint/resume with run log append."""
+
+    def test_checkpoint_resume_completes_flow(self, monkeypatch):
+        """Run flow → interrupt at implement → resume → verify completion."""
+        repo_root = Path.cwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            base_dir = Path(tmpdir) / ".fdsx"
+            thread_id = "test-scenario4"
+            flow_path = repo_root / "tests" / "fixtures" / "checkpoint_flow.yaml"
+
+            with patch(
+                "fdsx.providers.system.SystemProvider.execute",
+                side_effect=[
+                    ProviderResult(exit_code=0, stdout="plan output", stderr=""),
+                    Exception("simulated crash on implement state"),
+                ],
+            ):
+                with pytest.raises(RuntimeError, match="Flow execution failed"):
+                    engine.run_flow(
+                        flow_path,
+                        thread_id=thread_id,
+                        base_dir=base_dir,
+                    )
+
+            manager = CheckpointManager(base_dir=base_dir)
+            assert manager.verify_checkpoint(thread_id)
+
+            result = engine.resume_flow(
+                thread_id,
+                base_dir,
+                flow_path,
+            )
+
+            assert result.get("plan_output") == "plan output"
+            assert result.get("implement_output") == "implement output"
+            assert result.get("review_output") == "review output"
+
+    def test_resume_appends_to_existing_run_log(self, monkeypatch):
+        """Verify resume appends new state entries to existing run log."""
+        repo_root = Path.cwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            base_dir = Path(tmpdir) / ".fdsx"
+            thread_id = "test-scenario4-append"
+            flow_path = repo_root / "tests" / "fixtures" / "checkpoint_flow.yaml"
+
+            with patch(
+                "fdsx.providers.system.SystemProvider.execute",
+                side_effect=[
+                    ProviderResult(exit_code=0, stdout="plan output", stderr=""),
+                    Exception("simulated crash"),
+                ],
+            ):
+                with pytest.raises(RuntimeError, match="simulated crash"):
+                    engine.run_flow(
+                        flow_path,
+                        thread_id=thread_id,
+                        base_dir=base_dir,
+                    )
+
+            initial_log = TestScenario1LinearFlow._read_run_log(Path(tmpdir), thread_id)
+            initial_started_at = initial_log["started_at"]
+
+            engine.resume_flow(
+                thread_id,
+                base_dir,
+                flow_path,
+            )
+
+            resumed_log = TestScenario1LinearFlow._read_run_log(Path(tmpdir), thread_id)
+            resumed_state_names = [s["name"] for s in resumed_log["states"]]
+            resumed_started_at = resumed_log["started_at"]
+
+            assert resumed_started_at == initial_started_at, (
+                "started_at must not change on resume"
+            )
+            assert "plan" in resumed_state_names
+            assert "implement" in resumed_state_names
+            assert "review" in resumed_state_names
+            assert len(resumed_log["states"]) > len(initial_log["states"]), (
+                "Resume should append new state entries, not overwrite"
+            )
+
+            assert resumed_log["status"] == "completed"
+            assert "final_variables" in resumed_log
+            assert resumed_log["final_variables"]["review_output"] == "review output"
+
+    def test_checkpoint_resume_run_log_schema(self, monkeypatch):
+        """Verify run log schema after checkpoint/resume."""
+        repo_root = Path.cwd()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            monkeypatch.chdir(tmpdir)
+            base_dir = Path(tmpdir) / ".fdsx"
+            thread_id = "test-scenario4-schema"
+            flow_path = repo_root / "tests" / "fixtures" / "checkpoint_flow.yaml"
+
+            engine.run_flow(
+                flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+            run_log = TestScenario1LinearFlow._read_run_log(Path(tmpdir), thread_id)
+
+            assert run_log["thread_id"] == thread_id
+            assert "started_at" in run_log
+            assert "completed_at" in run_log
+            assert run_log["status"] == "completed"
+            assert "states" in run_log
+            assert "final_variables" in run_log
+
+            for state in run_log["states"]:
+                assert "name" in state
+                assert "type" in state
+                assert "status" in state
+                assert state["status"] in ("completed", "success")
+
+
+class TestScenario5ExtractionChoice:
+    """Scenario 5: Extraction + Choice routing."""
+
+    def test_extraction_drives_choice_routing(self, tmp_path, monkeypatch):
+        """Verify keyword extraction drives correct branch."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "extraction_flow.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = engine.run_flow(path, thread_id="test-scenario5")
+
+        assert "raw_output" in result
+        assert "decision" in result
+        assert result["decision"] == "APPROVED"
+        assert "approved_result" in result
+
+    def test_extraction_run_log(self, tmp_path, monkeypatch):
+        """Verify run log for extraction + choice scenario."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "extraction_flow.yaml"
+        thread_id = "test-scenario5-log"
+
+        engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_log = TestScenario1LinearFlow._read_run_log(tmp_path, thread_id)
+
+        assert run_log["status"] == "completed"
+        state_names = [s["name"] for s in run_log["states"]]
+        assert "echo_state" in state_names
+        assert "decision" in state_names
+        assert "approved_path" in state_names
+
+        echo_state = next(s for s in run_log["states"] if s["name"] == "echo_state")
+        assert echo_state["type"] == "task"
+        assert echo_state["status"] in ("completed", "success")
+        assert "output_preview" in echo_state
+        assert "variables_set" in echo_state
+
+        assert "final_variables" in run_log
+        assert run_log["final_variables"]["decision"] == "APPROVED"
+        assert run_log["final_variables"]["raw_output"]
+        assert "APPROVED" in run_log["final_variables"]["raw_output"]

--- a/tests/integration/test_extraction_flow.py
+++ b/tests/integration/test_extraction_flow.py
@@ -81,6 +81,7 @@ class TestParallelBranchExtraction:
                         ),
                     ],
                     result_path="$.parallel_results",
+                    min_success=0,
                     end=True,
                 ),
             },

--- a/tests/integration/test_loop_enforcement.py
+++ b/tests/integration/test_loop_enforcement.py
@@ -1,4 +1,3 @@
-import pytest
 from pathlib import Path
 
 from fdsx.core.engine import run_flow
@@ -8,5 +7,11 @@ class TestLoopEnforcement:
     def test_max_loop_prevents_infinite_cycle(self):
         """R2-F5: flow.max_loop must bound execution via LangGraph recursion_limit."""
         path = Path("tests/fixtures/loop_flow.yaml")
-        with pytest.raises(RuntimeError, match="(?i)(recursion|loop|limit|GraphRecursion)"):
-            run_flow(path)
+        result = run_flow(path)
+        assert isinstance(result, dict)
+        # Loop control must return partial results rather than empty dict or an exception
+        assert result != {}, "Loop control must return partial state, not empty dict"
+        # Verify that state from the last completed iteration is preserved
+        assert "plan_output" in result, (
+            "plan_output from last loop iteration must be present in partial results"
+        )

--- a/tests/integration/test_loop_flow.py
+++ b/tests/integration/test_loop_flow.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+from fdsx.core.engine import run_flow
+from fdsx.core.loader import load_flow
+
+
+class TestLoopFlow:
+    def test_loop_stops_at_max_iterations(self):
+        """Test that loop stops gracefully after max_loop iterations."""
+        path = Path("tests/fixtures/loop_flow.yaml")
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        assert flow.max_loop == 3
+
+        result = run_flow(path)
+
+        # Must return a dict (not raise), and must not be empty — partial results preserved
+        assert isinstance(result, dict)
+        assert result != {}, "Loop control must return partial state, not empty dict"
+
+    def test_loop_returns_partial_results(self):
+        """Test that loop returns results from the last iteration when max_loop is reached."""
+        path = Path("tests/fixtures/loop_flow.yaml")
+
+        result = run_flow(path)
+
+        assert isinstance(result, dict)
+        # The fixture loops plan→implement→review→decide and never reaches done,
+        # so partial results from the last completed iteration must be present.
+        assert result != {}, "Partial results must be returned (not empty dict)"
+        # At least one of the task states' result_paths must appear in the result
+        partial_keys = {"plan_output", "impl_output", "review_output"}
+        assert partial_keys.intersection(result.keys()), (
+            f"Expected at least one of {partial_keys} in result, got: {list(result.keys())}"
+        )
+
+    def test_state_variables_retained_across_iterations(self):
+        """Test that state variables from earlier loop iterations are available in later ones."""
+        path = Path("tests/fixtures/loop_flow.yaml")
+
+        result = run_flow(path)
+
+        # plan_output, impl_output, and review_output were all set in the loop body.
+        # They must all survive to the final captured state (the last iteration overwrites them,
+        # so all three should be present in partial results).
+        assert "plan_output" in result, "plan_output must be retained in partial results"
+        assert "impl_output" in result, "impl_output must be retained in partial results"
+        assert "review_output" in result, "review_output must be retained in partial results"

--- a/tests/integration/test_parallel_flow.py
+++ b/tests/integration/test_parallel_flow.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+
+import pytest
+
+from fdsx.core.engine import run_flow
+from fdsx.core.loader import load_flow
+
+
+class TestParallelFlow:
+    def test_parallel_review_majority_aggregation(self):
+        """Test parallel review with majority aggregation and choice routing."""
+        path = Path("tests/fixtures/parallel_review.yaml")
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path)
+
+        assert "reviews" in result
+        assert len(result["reviews"]) == 3
+
+        for review in result["reviews"]:
+            assert "output" in review
+            assert "exit_code" in review
+
+        assert "decision" in result
+        assert result["decision"] == "APPROVED"
+
+    def test_parallel_branch_results_have_output_field(self):
+        """Verify branch results array contains output field."""
+        path = Path("tests/fixtures/parallel_review.yaml")
+
+        result = run_flow(path)
+
+        assert "reviews" in result
+        assert len(result["reviews"]) == 3
+        for review in result["reviews"]:
+            assert "output" in review
+
+
+class TestParallelMinSuccess:
+    def test_min_success_tolerates_partial_failure(self):
+        """Test that min_success allows flow to continue with partial branch failures."""
+        path = Path("tests/fixtures/parallel_min_success.yaml")
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path)
+
+        assert "results" in result
+        assert len(result["results"]) == 3
+
+        successful = sum(1 for r in result["results"] if r.get("exit_code") == 0)
+        assert successful == 2
+
+        assert "success_check" in result
+        assert result["success_check"] == "Flow continued after partial failure"
+
+    def test_min_success_failure_raises_error(self):
+        """Test that when too many branches fail, flow raises error."""
+        from fdsx.models.flow import Flow, ParallelState, Branch
+
+        flow = Flow(
+            name="Parallel All Fail",
+            start_at="parallel_state",
+            states={
+                "parallel_state": ParallelState(
+                    type="parallel",
+                    branches=[
+                        Branch(
+                            provider="system",
+                            command="exit 1",
+                            retry=0,
+                        ),
+                        Branch(
+                            provider="system",
+                            command="exit 1",
+                            retry=0,
+                        ),
+                        Branch(
+                            provider="system",
+                            command="exit 1",
+                            retry=0,
+                        ),
+                    ],
+                    result_path="$.results",
+                    min_success=2,
+                    end=True,
+                ),
+            },
+        )
+
+        from fdsx.core.compiler import compile_flow
+
+        compiled = compile_flow(flow)
+
+        with pytest.raises(RuntimeError, match="only .* branches succeeded"):
+            compiled.graph.invoke({})

--- a/tests/integration/test_wait_resume.py
+++ b/tests/integration/test_wait_resume.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from fdsx.core.engine import run_flow
+from fdsx.core.loader import load_flow
+
+
+class TestWaitFlow:
+    def test_wait_state_loads_correctly(self):
+        """Test that wait state flow validates correctly."""
+        path = Path("tests/fixtures/wait_approval.yaml")
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+    def test_wait_state_prompt_with_approve_selection(self):
+        """Test Wait → Choice routing: select approve → verify flow takes approve branch."""
+        path = Path("tests/fixtures/wait_approval.yaml")
+
+        # Mock stdin to provide "1" (approve)
+        with patch("builtins.input", return_value="1"):
+            result = run_flow(path)
+
+        assert "plan_output" in result
+        assert "approval_decision" in result
+        assert result["approval_decision"] == "approve"
+        assert "implementation_output" in result
+
+    def test_wait_state_prompt_with_reject_selection(self):
+        """Test Wait → Choice routing: select reject → verify flow takes reject branch."""
+        path = Path("tests/fixtures/wait_approval.yaml")
+
+        # Mock stdin to provide "2" (reject)
+        with patch("builtins.input", return_value="2"):
+            result = run_flow(path)
+
+        assert "plan_output" in result
+        assert "approval_decision" in result
+        assert result["approval_decision"] == "reject"
+        assert "rejected_output" in result
+
+    def test_wait_state_prompt_with_invalid_input_then_valid(self):
+        """Test Wait state re-prompt on invalid input."""
+        path = Path("tests/fixtures/wait_approval.yaml")
+
+        # Mock stdin to provide invalid input first, then "1" (approve)
+        with patch("builtins.input", side_effect=["invalid", "5", "1"]):
+            result = run_flow(path)
+
+        assert "approval_decision" in result
+        assert result["approval_decision"] == "approve"
+
+    def test_wait_webhook_notification_sent(self):
+        """Test webhook notification: verify POST is sent when notify is configured."""
+        path = Path("tests/fixtures/wait_webhook.yaml")
+
+        with patch("fdsx.notify.webhook.send_webhook") as mock_webhook:
+            mock_webhook.return_value = True
+
+            with patch("builtins.input", return_value="1"):
+                result = run_flow(path)
+
+            # Verify webhook was called
+            assert mock_webhook.called
+            call_args = mock_webhook.call_args
+            assert call_args[0][0] == "https://example.com/webhook"
+            assert "Approval needed" in call_args[0][1]
+            assert "plan_output" in result
+            assert result["approval_decision"] == "approve"
+
+    def test_wait_webhook_sent_exactly_once_on_approve(self):
+        """Regression: webhook must fire exactly once, not on every resume cycle.
+
+        Before the fix, send_notification() was called before interrupt() in the same
+        node function.  LangGraph re-executes the entire node on resume, so the webhook
+        fired twice per approval cycle (call_count=2 instead of 1).
+        Fix: split into notify-pre node (checkpointed) + interrupt node.
+        """
+        path = Path("tests/fixtures/wait_webhook.yaml")
+
+        with patch("fdsx.notify.webhook.send_webhook") as mock_webhook:
+            mock_webhook.return_value = True
+
+            with patch("builtins.input", return_value="1"):
+                result = run_flow(path)
+
+        assert result["approval_decision"] == "approve"
+        assert mock_webhook.call_count == 1, (
+            f"Expected webhook called exactly once, got {mock_webhook.call_count}"
+        )
+
+    def test_wait_webhook_failure_does_not_block_flow(self):
+        """Test webhook failure: verify flow continues normally (warning logged, prompt still shown)."""
+        path = Path("tests/fixtures/wait_webhook.yaml")
+
+        with patch("fdsx.notify.webhook.send_webhook") as mock_webhook:
+            # Webhook fails but flow should continue
+            mock_webhook.return_value = False
+
+            with patch("builtins.input", return_value="1"):
+                result = run_flow(path)
+
+            # Verify webhook was called
+            assert mock_webhook.called
+            # Flow should still complete successfully
+            assert result["approval_decision"] == "approve"
+            assert "implementation_output" in result

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1,0 +1,327 @@
+import pytest
+
+from fdsx.core.compiler import _aggregate
+from fdsx.models.flow import AggregateRule
+
+
+class TestAggregateMajority:
+    def test_majority_2_of_3_match_returns_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "APPROVED"
+
+    def test_majority_2_of_3_match_returns_match_value_direct(self):
+        """Test with data passed directly (without source path resolution)."""
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "APPROVED"
+
+    def test_majority_1_of_3_match_returns_no_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+    def test_majority_0_of_3_match_returns_no_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+    def test_majority_tie_2_of_4_returns_no_match(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+
+class TestAggregateAll:
+    def test_all_3_of_3_match_returns_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="all",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "APPROVED"
+
+    def test_all_2_of_3_match_returns_no_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="all",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+
+class TestAggregateAny:
+    def test_any_1_of_3_match_returns_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="any",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "APPROVED"
+
+    def test_any_0_of_3_match_returns_no_match_value(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="any",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+            {"decision": "REJECTED"},
+        ]
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+
+class TestAggregateEmptySource:
+    def test_empty_source_array_returns_no_match(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = []
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+    def test_source_field_missing_returns_no_match(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="any",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [{"other": "value"}, {"other": "value2"}]
+        result = _aggregate(source_data, rule)
+        assert result == "REJECTED"
+
+
+class TestAggregateStrategyValidation:
+    def test_invalid_strategy_raises_error(self):
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="invalid",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [{"decision": "APPROVED"}]
+        with pytest.raises(ValueError, match="Unknown aggregation strategy"):
+            _aggregate(source_data, rule)
+
+
+class TestAggregateFailedBranchSecurity:
+    """Regression tests for security finding: failed branches must count as no_match.
+
+    Previously, _aggregate() used len(values) (only items with the field) as
+    the denominator. This allowed bypassing a dissenting reviewer by knocking out
+    their branch: APPROVED, APPROVED, <failed> → 2/2 APPROVED instead of 2/3.
+    The fix uses len(source_data) (total branches) as denominator so failed/missing
+    branches always count against the match threshold.
+    """
+
+    def test_majority_failed_branch_counts_against_match(self):
+        """APPROVED, APPROVED, <failed-no-field> must NOT achieve majority of 3."""
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        # Two APPROVED + one failed branch (no decision field)
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"output": "", "exit_code": 1, "error": "branch failed"},  # no 'decision'
+        ]
+        result = _aggregate(source_data, rule)
+        # 2/3 APPROVED — 2 > 3/2 = 1.5 → majority APPROVED
+        assert result == "APPROVED"
+
+    def test_majority_requires_true_majority_with_failures(self):
+        """1 APPROVED + 2 failed branches must not pass majority gate."""
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="majority",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"output": "", "exit_code": 1, "error": "failed"},
+            {"output": "", "exit_code": 1, "error": "failed"},
+        ]
+        result = _aggregate(source_data, rule)
+        # 1/3 APPROVED — 1 is NOT > 1.5 → no_match
+        assert result == "REJECTED"
+
+    def test_all_requires_all_including_missing_field(self):
+        """strategy=all: any branch missing the field must return no_match."""
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="all",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"decision": "APPROVED"},
+            {"output": "", "exit_code": 1, "error": "failed"},  # no 'decision'
+        ]
+        result = _aggregate(source_data, rule)
+        # match_count=2, total=3: 2 != 3 → no_match
+        assert result == "REJECTED"
+
+    def test_any_still_matches_even_with_failed_branch(self):
+        """strategy=any: at least one match returns match even if another branch fails."""
+        rule = AggregateRule(
+            source="$.reviews",
+            field="decision",
+            strategy="any",
+            match="APPROVED",
+            no_match="REJECTED",
+            result_path="$.decision",
+        )
+        source_data = [
+            {"decision": "APPROVED"},
+            {"output": "", "exit_code": 1, "error": "failed"},
+        ]
+        result = _aggregate(source_data, rule)
+        # 1 match > 0 → match
+        assert result == "APPROVED"
+
+
+class TestMinSuccessDefault:
+    """Regression tests for T028: min_success defaults to all branches (not open/None)."""
+
+    def test_min_success_default_enforces_all_branches(self):
+        """When min_success is not set, all branches must succeed."""
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import Branch, Flow, ParallelState
+
+        flow = Flow(
+            name="Min Success Default Test",
+            start_at="parallel_state",
+            states={
+                "parallel_state": ParallelState(
+                    type="parallel",
+                    branches=[
+                        Branch(provider="system", command="echo ok", retry=0),
+                        Branch(provider="system", command="exit 1", retry=0),
+                    ],
+                    result_path="$.results",
+                    min_success=None,  # Default: must enforce all branches
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+
+        # With min_success=None (default=all), one failed branch should raise
+        with pytest.raises(RuntimeError, match="only .* branches succeeded"):
+            compiled.graph.invoke({})

--- a/tests/unit/test_backoff.py
+++ b/tests/unit/test_backoff.py
@@ -1,0 +1,237 @@
+from unittest.mock import MagicMock, patch
+
+from fdsx.providers.base import ProviderResult
+
+
+class TestExponentialBackoff:
+    """T064: Unit tests for exponential backoff in retry loops."""
+
+    def test_backoff_delays_for_retries(self):
+        """Verify backoff delays (1, 2, 4 seconds) for 3 retries."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        state_dict = {}
+        state = MagicMock()
+        state.provider = "openai"
+        state.model = "gpt-4"
+        state.prompt_template = "test"
+        state.timeout_seconds = 30
+        state.retry = 3
+        state.extract = None
+        state.result_path = "result"
+
+        flow = MagicMock(spec=Flow)
+
+        call_count = 0
+        sleep_times = []
+
+        def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 4:
+                return ProviderResult(exit_code=1, stdout="", stderr="error")
+            return ProviderResult(exit_code=0, stdout="success", stderr="")
+
+        with patch.object(compiler, "get_provider") as mock_get_provider:
+            mock_provider = MagicMock()
+            mock_provider.execute = mock_execute
+            mock_get_provider.return_value = mock_provider
+
+            original_sleep = compiler.time.sleep
+            compiler.time.sleep = lambda s: sleep_times.append(s)
+
+            try:
+                compiler._create_task_node("test_state", state, flow, None)(state_dict)
+            except RuntimeError:
+                pass
+            finally:
+                compiler.time.sleep = original_sleep
+
+            assert len(sleep_times) == 3
+            assert sleep_times == [1, 2, 4]
+
+    def test_first_attempt_has_no_delay(self):
+        """Verify first attempt has no delay."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        state_dict = {}
+        state = MagicMock()
+        state.provider = "openai"
+        state.model = "gpt-4"
+        state.prompt_template = "test"
+        state.timeout_seconds = 30
+        state.retry = 1
+        state.extract = None
+        state.result_path = "result"
+
+        flow = MagicMock(spec=Flow)
+
+        call_count = 0
+        sleep_times = []
+
+        def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return ProviderResult(exit_code=1, stdout="", stderr="error")
+            return ProviderResult(exit_code=0, stdout="success", stderr="")
+
+        with patch.object(compiler, "get_provider") as mock_get_provider:
+            mock_provider = MagicMock()
+            mock_provider.execute = mock_execute
+            mock_get_provider.return_value = mock_provider
+
+            original_sleep = compiler.time.sleep
+            compiler.time.sleep = lambda s: sleep_times.append(s)
+
+            try:
+                compiler._create_task_node("test_state", state, flow, None)(state_dict)
+            except RuntimeError:
+                pass
+            finally:
+                compiler.time.sleep = original_sleep
+
+            assert len(sleep_times) == 1
+
+    def test_exception_triggers_retry_with_backoff(self):
+        """Verify timeout exception triggers retry with backoff."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        state_dict = {}
+        state = MagicMock()
+        state.provider = "openai"
+        state.model = "gpt-4"
+        state.prompt_template = "test"
+        state.timeout_seconds = 30
+        state.retry = 2
+        state.extract = None
+        state.result_path = "result"
+
+        flow = MagicMock(spec=Flow)
+
+        call_count = 0
+        sleep_times = []
+
+        def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                raise TimeoutError("Command timed out")
+            return ProviderResult(exit_code=0, stdout="success", stderr="")
+
+        with patch.object(compiler, "get_provider") as mock_get_provider:
+            mock_provider = MagicMock()
+            mock_provider.execute = mock_execute
+            mock_get_provider.return_value = mock_provider
+
+            original_sleep = compiler.time.sleep
+            compiler.time.sleep = lambda s: sleep_times.append(s)
+
+            try:
+                compiler._create_task_node("test_state", state, flow, None)(state_dict)
+            except RuntimeError:
+                pass
+            finally:
+                compiler.time.sleep = original_sleep
+
+            assert len(sleep_times) == 2
+            assert sleep_times == [1, 2]
+
+    def test_backoff_capped_at_30_seconds(self):
+        """Verify cap at 30s for high retry counts."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        state_dict = {}
+        state = MagicMock()
+        state.provider = "openai"
+        state.model = "gpt-4"
+        state.prompt_template = "test"
+        state.timeout_seconds = 30
+        state.retry = 10
+        state.extract = None
+        state.result_path = "result"
+
+        flow = MagicMock(spec=Flow)
+
+        call_count = 0
+        sleep_times = []
+
+        def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return ProviderResult(exit_code=1, stdout="", stderr="error")
+
+        with patch.object(compiler, "get_provider") as mock_get_provider:
+            mock_provider = MagicMock()
+            mock_provider.execute = mock_execute
+            mock_get_provider.return_value = mock_provider
+
+            original_sleep = compiler.time.sleep
+            compiler.time.sleep = lambda s: sleep_times.append(s)
+
+            try:
+                compiler._create_task_node("test_state", state, flow, None)(state_dict)
+            except RuntimeError:
+                pass
+            finally:
+                compiler.time.sleep = original_sleep
+
+            assert len(sleep_times) == 10
+            for i in range(1, 10):
+                expected = min(2 ** (i - 1), 30)
+                assert sleep_times[i - 1] == expected
+
+    def test_branch_executor_backoff(self):
+        """Verify branch executor also uses exponential backoff."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        state_dict = {"_branch_index": 0}
+        branch = MagicMock()
+        branch.provider = "openai"
+        branch.model = "gpt-4"
+        branch.prompt_template = "test"
+        branch.timeout_seconds = 30
+        branch.retry = 2
+        branch.extract = None
+        branch.command = None
+
+        parallel_state = MagicMock()
+        parallel_state.branches = [branch]
+
+        flow = MagicMock(spec=Flow)
+
+        call_count = 0
+        sleep_times = []
+
+        def mock_execute(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 3:
+                return ProviderResult(exit_code=1, stdout="", stderr="error")
+            return ProviderResult(exit_code=0, stdout="success", stderr="")
+
+        with patch.object(compiler, "get_provider") as mock_get_provider:
+            mock_provider = MagicMock()
+            mock_provider.execute = mock_execute
+            mock_get_provider.return_value = mock_provider
+
+            original_sleep = compiler.time.sleep
+            compiler.time.sleep = lambda s: sleep_times.append(s)
+
+            try:
+                compiler._create_branch_executor(
+                    "test_state", parallel_state, flow, None
+                )(state_dict)
+            except (RuntimeError, KeyError, TypeError):
+                pass
+            finally:
+                compiler.time.sleep = original_sleep
+
+            assert len(sleep_times) == 2
+            assert sleep_times[0] == 1
+            assert sleep_times[1] == 2

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -1,0 +1,316 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from fdsx.core.batch import (
+    split_tasks,
+    display_task_list,
+    display_batch_summary,
+    _parse_task_list,
+    _build_task_split_prompt,
+    _extract_input_variables,
+)
+from fdsx.models.flow import Flow, TaskState, TaskSplitter
+
+
+class TestSplitTasks:
+    def test_split_tasks_parses_numbered_list(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        task_splitter = TaskSplitter(
+            provider="claude", model="claude-3-5-sonnet-20241022"
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. First task\n2. Second task\n3. Third task",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            tasks = split_tasks("test content", flow, task_splitter)
+
+        assert len(tasks) == 3
+        assert tasks[0] == "First task"
+        assert tasks[1] == "Second task"
+        assert tasks[2] == "Third task"
+
+    def test_split_tasks_empty_response(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        task_splitter = TaskSplitter(
+            provider="claude", model="claude-3-5-sonnet-20241022"
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            tasks = split_tasks("test content", flow, task_splitter)
+
+        assert tasks == []
+
+    def test_split_tasks_provider_failure(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        task_splitter = TaskSplitter(
+            provider="claude", model="claude-3-5-sonnet-20241022"
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=1,
+            stdout="",
+            stderr="Provider error",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with pytest.raises(RuntimeError, match="Task splitter failed"):
+                split_tasks("test content", flow, task_splitter)
+
+
+class TestDisplayTaskList:
+    def test_display_task_list_approve(self):
+        tasks = ["First task", "Second task", "Third task"]
+
+        with patch("builtins.input", return_value="y"):
+            result = display_task_list(tasks)
+
+        assert result is True
+
+    def test_display_task_list_reject(self):
+        tasks = ["First task", "Second task", "Third task"]
+
+        with patch("builtins.input", return_value="n"):
+            result = display_task_list(tasks)
+
+        assert result is False
+
+    def test_display_task_list_invalid_then_approve(self):
+        tasks = ["First task"]
+
+        inputs = iter(["invalid", "y"])
+        with patch("builtins.input", lambda x: next(inputs)):
+            result = display_task_list(tasks)
+
+        assert result is True
+
+
+class TestDisplayBatchSummary:
+    def test_display_batch_summary(self, capsys):
+        results = [
+            {
+                "task_index": 0,
+                "task_description": "First task",
+                "thread_id": "thread-1",
+                "status": "completed",
+                "error": None,
+            },
+            {
+                "task_index": 1,
+                "task_description": "Second task",
+                "thread_id": "thread-2",
+                "status": "failed",
+                "error": "Something went wrong",
+            },
+        ]
+
+        display_batch_summary(results)
+
+        captured = capsys.readouterr()
+        assert "BATCH EXECUTION SUMMARY" in captured.err
+        assert "Succeeded: 1" in captured.err
+        assert "Failed: 1" in captured.err
+
+
+class TestParseTaskList:
+    def test_parse_numbered_list(self):
+        response = "1. First task\n2. Second task\n3. Third task"
+        tasks = _parse_task_list(response)
+
+        assert len(tasks) == 3
+        assert tasks[0] == "First task"
+        assert tasks[1] == "Second task"
+        assert tasks[2] == "Third task"
+
+    def test_parse_unnumbered_lines(self):
+        response = "First task\nSecond task\nThird task"
+        tasks = _parse_task_list(response)
+
+        assert len(tasks) == 3
+
+    def test_parse_empty_response(self):
+        response = ""
+        tasks = _parse_task_list(response)
+
+        assert tasks == []
+
+    def test_parse_with_empty_lines(self):
+        response = "1. First task\n\n2. Second task\n\n"
+        tasks = _parse_task_list(response)
+
+        assert len(tasks) == 2
+
+
+class TestBuildTaskSplitPrompt:
+    def test_build_prompt(self):
+        prompt = _build_task_split_prompt(
+            "test content", ["plan", "implement"], {"task"}
+        )
+
+        assert "test content" in prompt
+        assert "plan, implement" in prompt
+        assert "task" in prompt
+
+
+class TestExtractInputVariables:
+    def test_extract_from_task_states_with_prompt_template(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="claude",
+                    model="claude-3-5-sonnet-20241022",
+                    prompt_template="Analyze {user_request} and create a plan",
+                    result_path="$.plan",
+                    next="implement",
+                ),
+                "implement": TaskState(
+                    type="task",
+                    provider="claude",
+                    model="claude-3-5-sonnet-20241022",
+                    prompt_template="Implement the plan: {plan}",
+                    result_path="$.implementation",
+                    end=True,
+                ),
+            },
+        )
+
+        input_vars = _extract_input_variables(flow)
+
+        assert "task" in input_vars
+        assert "user_request" in input_vars
+        assert "plan" in input_vars
+
+    def test_extract_returns_task_by_default(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                ),
+            },
+        )
+
+        input_vars = _extract_input_variables(flow)
+
+        assert "task" in input_vars
+
+    def test_extract_from_parallel_branches(self):
+        from fdsx.models.flow import Branch, ParallelState
+
+        flow = Flow(
+            name="Test Flow",
+            start_at="review",
+            states={
+                "review": ParallelState(
+                    type="parallel",
+                    branches=[
+                        Branch(
+                            provider="claude",
+                            model="claude-3-5-sonnet-20241022",
+                            prompt_template="Review {task} for quality",
+                        ),
+                        Branch(
+                            provider="claude",
+                            model="claude-3-5-sonnet-20241022",
+                            prompt_template="Check {task} for security issues with {context}",
+                        ),
+                    ],
+                    result_path="$.reviews",
+                    end=True,
+                ),
+            },
+        )
+
+        input_vars = _extract_input_variables(flow)
+
+        assert "task" in input_vars
+        assert "context" in input_vars
+
+    def test_extract_dotted_variable_references(self):
+        flow = Flow(
+            name="Test Flow",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="claude",
+                    model="claude-3-5-sonnet-20241022",
+                    prompt_template="Analyze {review.summary} and fix {issue.description}",
+                    result_path="$.result",
+                    end=True,
+                ),
+            },
+        )
+
+        input_vars = _extract_input_variables(flow)
+
+        assert "task" in input_vars
+        assert "review" in input_vars
+        assert "issue" in input_vars
+
+
+class TestTaskSplitterValidation:
+    def test_task_splitter_rejects_system_provider(self):
+        with pytest.raises(ValueError, match="task_splitter provider must be one of"):
+            TaskSplitter(provider="system", model="default")
+
+    def test_task_splitter_accepts_valid_llm_providers(self):
+        for provider in ["claude", "opencode", "codex"]:
+            ts = TaskSplitter(provider=provider, model="test-model")
+            assert ts.provider == provider

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -1,0 +1,147 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.checkpoint.manager import CheckpointManager
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def manager(temp_dir):
+    return CheckpointManager(base_dir=temp_dir)
+
+
+class TestCheckpointManager:
+    def test_default_base_dir(self):
+        manager = CheckpointManager()
+        assert manager.base_dir == Path(".fdsx")
+        assert manager.checkpoints_dir == Path(".fdsx/checkpoints")
+        assert manager.locks_dir == Path(".fdsx/locks")
+
+    def test_custom_base_dir(self, temp_dir):
+        manager = CheckpointManager(base_dir=temp_dir)
+        assert manager.base_dir == temp_dir
+
+    def test_directory_creation(self, manager):
+        assert manager.checkpoints_dir.exists()
+        assert manager.locks_dir.exists()
+        assert manager.checkpoints_dir.is_dir()
+        assert manager.locks_dir.is_dir()
+
+    def test_get_checkpointer(self, manager):
+        checkpointer = manager.get_checkpointer()
+        assert checkpointer is not None
+        db_path = manager.checkpoints_dir / "checkpoints.db"
+        assert db_path.exists()
+
+    def test_acquire_lock_new_thread(self, manager):
+        result = manager.acquire_lock("test-thread-1")
+        assert result is True
+        lock_path = manager._get_lock_path("test-thread-1")
+        assert lock_path.exists()
+
+    def test_acquire_lock_same_thread_same_pid(self, manager):
+        result1 = manager.acquire_lock("test-thread-2")
+        assert result1 is True
+        result2 = manager.acquire_lock("test-thread-2")
+        assert result2 is False
+
+    def test_acquire_lock_stale_lock_dead_pid(self, manager):
+        lock_path = manager._get_lock_path("test-thread-3")
+        with open(lock_path, "w") as f:
+            f.write("99999")
+        result = manager.acquire_lock("test-thread-3")
+        assert result is True
+        with open(lock_path) as f:
+            pid = int(f.read().strip())
+        assert pid == os.getpid()
+
+    def test_release_lock(self, manager):
+        manager.acquire_lock("test-thread-4")
+        manager.release_lock("test-thread-4")
+        lock_path = manager._get_lock_path("test-thread-4")
+        assert not lock_path.exists()
+
+    def test_is_locked_locked_thread(self, manager):
+        manager.acquire_lock("test-thread-5")
+        is_locked, pid = manager.is_locked("test-thread-5")
+        assert is_locked is True
+        assert pid == os.getpid()
+
+    def test_is_locked_unlocked_thread(self, manager):
+        is_locked, pid = manager.is_locked("nonexistent-thread")
+        assert is_locked is False
+        assert pid is None
+
+    def test_is_locked_stale_lock(self, manager):
+        lock_path = manager._get_lock_path("test-thread-6")
+        with open(lock_path, "w") as f:
+            f.write("99999")
+        is_locked, pid = manager.is_locked("test-thread-6")
+        assert is_locked is False
+        assert pid is None
+
+    def test_verify_checkpoint_missing_db(self, manager):
+        result = manager.verify_checkpoint("test-thread")
+        assert result is False
+
+    def test_verify_checkpoint_corrupt_db(self, manager):
+        db_path = manager.checkpoints_dir / "checkpoints.db"
+        db_path.write_text("not a valid database")
+        result = manager.verify_checkpoint("any-thread")
+        assert result is False
+
+    def test_verify_checkpoint_valid_checkpoint(self, manager):
+        """T044: verify_checkpoint returns True for a valid checkpoint."""
+        import sqlite3
+
+        db_path = manager.checkpoints_dir / "checkpoints.db"
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS checkpoints (
+                thread_id TEXT PRIMARY KEY,
+                checkpoint BLOB,
+                metadata BLOB
+            )
+            """
+        )
+        cursor.execute(
+            "INSERT INTO checkpoints (thread_id, checkpoint, metadata) VALUES (?, ?, ?)",
+            ("valid-thread", b"fake-checkpoint", b"fake-metadata"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = manager.verify_checkpoint("valid-thread")
+        assert result is True
+
+    def test_list_threads_empty(self, manager):
+        threads = manager.list_threads()
+        assert threads == []
+
+
+class TestCheckpointManagerWithMock:
+    def test_acquire_lock_concurrent_execution(self, manager):
+        with patch("os.kill") as mock_kill:
+            mock_kill.side_effect = OSError("Process not found")
+            lock_path = manager._get_lock_path("concurrent-thread")
+            with open(lock_path, "w") as f:
+                f.write("12345")
+            result = manager.acquire_lock("concurrent-thread")
+            assert result is True
+
+    def test_verify_checkpoint_corrupt_db(self, manager):
+        db_path = manager.checkpoints_dir / "checkpoints.db"
+        db_path.write_text("not a valid database")
+        result = manager.verify_checkpoint("any-thread")
+        assert result is False

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -12,6 +12,7 @@ from fdsx.models.flow import (
     PassState,
     TaskState,
     WaitState,
+    WebhookConfig,
 )
 
 
@@ -475,3 +476,76 @@ class TestExtractPathValidation:
                     strategy=["keyword"], pattern="A|B", result_path="$.output[0]"
                 ),
             )
+
+
+class TestWaitStateValidation:
+    """CQ-2: Regression tests for WaitState.choices validation."""
+
+    def test_wait_state_rejects_empty_choices(self):
+        """CQ-2: WaitState with empty choices list must raise ValidationError."""
+        with pytest.raises(ValidationError, match="too_short|at least 1"):
+            WaitState(
+                type="wait",
+                mode="prompt",
+                message="Continue?",
+                choices=[],
+                result_path="$.choice",
+            )
+
+    def test_wait_state_accepts_single_choice(self):
+        """WaitState with one choice must be accepted."""
+        state = WaitState(
+            type="wait",
+            mode="prompt",
+            message="Continue?",
+            choices=["yes"],
+            result_path="$.choice",
+        )
+        assert state.choices == ["yes"]
+
+    def test_wait_state_accepts_multiple_choices(self):
+        """WaitState with multiple choices must be accepted."""
+        state = WaitState(
+            type="wait",
+            mode="prompt",
+            message="Choose:",
+            choices=["approve", "reject", "retry"],
+            result_path="$.choice",
+        )
+        assert len(state.choices) == 3
+
+
+class TestWebhookConfigValidation:
+    """SEC-3: Regression tests for WebhookConfig URL validation."""
+
+    def test_webhook_rejects_http_non_localhost(self):
+        """SEC-3: Webhook URL with http:// (non-localhost) must raise ValidationError."""
+        with pytest.raises(ValidationError, match="HTTPS"):
+            WebhookConfig(
+                url="http://evil.com/hook",
+                template="Test",
+            )
+
+    def test_webhook_accepts_https(self):
+        """SEC-3: Webhook URL with https:// must be accepted."""
+        config = WebhookConfig(
+            url="https://hooks.example.com/services/TOKEN",
+            template="Test message",
+        )
+        assert config.url == "https://hooks.example.com/services/TOKEN"
+
+    def test_webhook_accepts_http_localhost(self):
+        """SEC-3: Webhook URL with http://localhost must be accepted for testing."""
+        config = WebhookConfig(
+            url="http://localhost:8080/webhook",
+            template="Test",
+        )
+        assert config.url == "http://localhost:8080/webhook"
+
+    def test_webhook_accepts_http_127_0_0_1(self):
+        """SEC-3: Webhook URL with http://127.0.0.1 must be accepted for testing."""
+        config = WebhookConfig(
+            url="http://127.0.0.1:9000/webhook",
+            template="Test",
+        )
+        assert config.url == "http://127.0.0.1:9000/webhook"

--- a/tests/unit/test_prompt_file.py
+++ b/tests/unit/test_prompt_file.py
@@ -1,0 +1,147 @@
+import tempfile
+from pathlib import Path
+
+from fdsx.core.loader import load_flow
+
+
+class TestPromptFileWithVariables:
+    def test_prompt_file_variable_substitution(self):
+        """prompt_file content should have variable references resolved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            prompt_file = Path(tmpdir) / "prompt.txt"
+
+            prompt_file.write_text("Hello {name}, you are {age} years old.")
+            flow_yaml.write_text(
+                "name: test\n"
+                "start_at: task1\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: claude\n"
+                "    model: opus\n"
+                "    prompt_file: prompt.txt\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is not None, f"Flow loading failed: {errors}"
+
+            task = flow.states["task1"]
+            assert task.prompt_template == "Hello {name}, you are {age} years old."
+            assert task.prompt_file is None
+
+    def test_prompt_file_not_found(self):
+        """prompt_file that doesn't exist should produce an error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            flow_yaml.write_text(
+                "name: test\n"
+                "start_at: task1\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: claude\n"
+                "    model: opus\n"
+                "    prompt_file: nonexistent.txt\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is None
+            assert any("not found" in e for e in errors)
+
+
+class TestPromptFileParallelBranch:
+    def test_prompt_file_in_parallel_branch(self):
+        """prompt_file in parallel branch should be loaded correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            branch_prompt = Path(tmpdir) / "branch_prompt.txt"
+
+            branch_prompt.write_text("Branch prompt content")
+            flow_yaml.write_text(
+                "name: test\n"
+                "start_at: parallel1\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  parallel1:\n"
+                "    type: parallel\n"
+                "    result_path: '$.results'\n"
+                "    branches:\n"
+                "      - name: branch1\n"
+                "        provider: claude\n"
+                "        model: opus\n"
+                "        prompt_file: branch_prompt.txt\n"
+                "    next: end\n"
+                "  end:\n"
+                "    type: pass\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is not None, f"Flow loading failed: {errors}"
+
+            parallel_state = flow.states["parallel1"]
+            branch = parallel_state.branches[0]
+            assert branch.prompt_template == "Branch prompt content"
+
+
+class TestPromptFileEdgeCases:
+    def test_prompt_file_empty_content(self):
+        """prompt_file with empty content should work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            empty_prompt = Path(tmpdir) / "empty.txt"
+
+            empty_prompt.write_text("")
+            flow_yaml.write_text(
+                "name: test\n"
+                "start_at: task1\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: claude\n"
+                "    model: opus\n"
+                "    prompt_file: empty.txt\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is not None, f"Flow loading failed: {errors}"
+
+            task = flow.states["task1"]
+            assert task.prompt_template == ""
+
+    def test_prompt_file_with_special_characters(self):
+        """prompt_file with special characters should be loaded correctly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            special_prompt = Path(tmpdir) / "special.txt"
+
+            special_prompt.write_text("Line 1\nLine 2\nLine 3\nSpecial: ${{var}}")
+            flow_yaml.write_text(
+                "name: test\n"
+                "start_at: task1\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  task1:\n"
+                "    type: task\n"
+                "    provider: claude\n"
+                "    model: opus\n"
+                "    prompt_file: special.txt\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is not None, f"Flow loading failed: {errors}"
+
+            task = flow.states["task1"]
+            assert task.prompt_template == "Line 1\nLine 2\nLine 3\nSpecial: ${{var}}"

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -1,0 +1,470 @@
+import json
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from fdsx.logging.recorder import RunRecorder, OUTPUT_PREVIEW_MAX_LENGTH
+
+
+class TestRunRecorder:
+    def test_init(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+            flow_version="1.0",
+        )
+
+        assert recorder.thread_id == "test-123"
+        assert recorder.flow_name == "test_flow"
+        assert recorder.flow_version == "1.0"
+        assert recorder.status == "running"
+        assert recorder.states == []
+        assert recorder.started_at is not None
+
+        dt = datetime.fromisoformat(recorder.started_at.replace("Z", "+00:00"))
+        assert dt.tzinfo is not None
+
+    def test_init_without_version(self):
+        recorder = RunRecorder(
+            thread_id="test-456",
+            flow_name="another_flow",
+        )
+
+        assert recorder.flow_version is None
+
+    def test_record_state_start(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_start("planner", "task")
+
+        assert len(recorder.states) == 1
+        state = recorder.states[0]
+        assert state["name"] == "planner"
+        assert state["type"] == "task"
+        assert state["started_at"] is not None
+
+    def test_record_state_complete(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_start("planner", "task")
+        recorder.record_state_complete(
+            "planner",
+            "success",
+            "Test output",
+            ["$.plan"],
+        )
+
+        state = recorder.states[0]
+        assert state["completed_at"] is not None
+        assert state["duration_seconds"] >= 0
+        assert state["status"] == "success"
+        assert state["output_preview"] == "Test output"
+        assert state["variables_set"] == ["$.plan"]
+
+    def test_output_preview_truncation(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        long_output = "x" * (OUTPUT_PREVIEW_MAX_LENGTH + 100)
+        recorder.record_state_start("planner", "task")
+        recorder.record_state_complete(
+            "planner",
+            "success",
+            long_output,
+            ["$.plan"],
+        )
+
+        state = recorder.states[0]
+        assert len(state["output_preview"]) == OUTPUT_PREVIEW_MAX_LENGTH
+
+    def test_record_state_error(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_start("planner", "task")
+        recorder.record_state_error("planner", "Something went wrong")
+
+        state = recorder.states[0]
+        assert state["status"] == "error"
+        assert state["error"] == "Something went wrong"
+        assert state["completed_at"] is not None
+        assert "duration_seconds" in state
+        assert "output_preview" in state
+        assert "variables_set" in state
+        assert state["variables_set"] == []
+
+    def test_record_state_complete_with_branches(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        branches = [
+            {
+                "index": 0,
+                "provider": "claude",
+                "status": "success",
+                "duration_seconds": 10,
+            },
+            {
+                "index": 1,
+                "provider": "opencode",
+                "status": "success",
+                "duration_seconds": 5,
+            },
+        ]
+
+        recorder.record_state_start("parallel_review", "parallel")
+        recorder.record_state_complete(
+            "parallel_review",
+            "success",
+            "",
+            ["$.reviews"],
+            branches,
+        )
+
+        state = recorder.states[0]
+        assert state["branches"] == branches
+
+    def test_finalize(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.finalize({"plan": "my plan"}, "completed")
+
+        assert recorder.completed_at is not None
+        assert recorder.status == "completed"
+        assert recorder.final_variables == {"plan": "my plan"}
+
+    def test_finalize_with_error_status(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.finalize({}, "error")
+
+        assert recorder.status == "error"
+
+    def test_save(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                thread_id="test-123",
+                flow_name="test_flow",
+            )
+
+            recorder.record_state_start("planner", "task")
+            recorder.record_state_complete(
+                "planner",
+                "success",
+                "Test output",
+                ["$.plan"],
+            )
+            recorder.finalize({"plan": "my plan"}, "completed")
+
+            file_path = recorder.save(base_dir=Path(tmpdir))
+
+            assert file_path == Path(tmpdir) / "runs" / "test-123.json"
+            assert file_path.exists()
+
+            with open(file_path, "r") as f:
+                data = json.load(f)
+
+            assert data["thread_id"] == "test-123"
+            assert data["flow_name"] == "test_flow"
+            assert data["status"] == "completed"
+            assert len(data["states"]) == 1
+            assert data["final_variables"] == {"plan": "my plan"}
+
+    def test_save_creates_runs_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                thread_id="test-123",
+                flow_name="test_flow",
+            )
+
+            recorder.save(base_dir=Path(tmpdir))
+
+            runs_dir = Path(tmpdir) / "runs"
+            assert runs_dir.exists()
+            assert runs_dir.is_dir()
+
+    def test_save_resume_append(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runs_dir = Path(tmpdir) / "runs"
+            runs_dir.mkdir()
+
+            existing_log = {
+                "thread_id": "test-123",
+                "flow_name": "test_flow",
+                "started_at": "2026-03-14T10:00:00Z",
+                "status": "running",
+                "states": [
+                    {
+                        "name": "planner",
+                        "type": "task",
+                        "started_at": "2026-03-14T10:00:00Z",
+                        "completed_at": "2026-03-14T10:01:00Z",
+                        "duration_seconds": 60,
+                        "status": "success",
+                        "output_preview": "Old output",
+                        "variables_set": ["$.plan"],
+                    }
+                ],
+            }
+
+            existing_file = runs_dir / "test-123.json"
+            with open(existing_file, "w") as f:
+                json.dump(existing_log, f)
+
+            recorder = RunRecorder(
+                thread_id="test-123",
+                flow_name="test_flow",
+            )
+
+            recorder.record_state_start("implementer", "task")
+            recorder.record_state_complete(
+                "implementer",
+                "success",
+                "New output",
+                ["$.implementation"],
+            )
+            recorder.finalize(
+                {"plan": "my plan", "implementation": "code"}, "completed"
+            )
+
+            recorder.save(base_dir=Path(tmpdir))
+
+            with open(existing_file, "r") as f:
+                data = json.load(f)
+
+            assert len(data["states"]) == 2
+            assert data["states"][0]["name"] == "planner"
+            assert data["states"][1]["name"] == "implementer"
+            assert data["started_at"] == "2026-03-14T10:00:00Z"
+
+    def test_to_dict(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+            flow_version="1.0",
+        )
+
+        recorder.record_state_start("planner", "task")
+        recorder.record_state_complete(
+            "planner",
+            "success",
+            "Test output",
+            ["$.plan"],
+        )
+        recorder.finalize({"plan": "my plan"}, "completed")
+
+        data = recorder.to_dict()
+
+        assert data["thread_id"] == "test-123"
+        assert data["flow_name"] == "test_flow"
+        assert data["flow_version"] == "1.0"
+        assert data["status"] == "completed"
+        assert "started_at" in data
+        assert "completed_at" in data
+        assert len(data["states"]) == 1
+        assert data["final_variables"] == {"plan": "my plan"}
+
+    def test_to_dict_without_finalize(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_start("planner", "task")
+
+        data = recorder.to_dict()
+
+        assert "completed_at" not in data
+        assert "final_variables" not in data
+
+    def test_record_state_complete_updates_existing(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_start("planner", "task")
+        recorder.record_state_complete(
+            "planner",
+            "success",
+            "Test output",
+            ["$.plan"],
+        )
+
+        assert len(recorder.states) == 1
+
+    def test_record_state_error_updates_existing(self):
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_start("planner", "task")
+        recorder.record_state_error("planner", "Error message")
+
+        assert len(recorder.states) == 1
+        assert recorder.states[0]["status"] == "error"
+
+
+class TestRunRecorderSecurity:
+    def test_invalid_thread_id_with_dot_dot_slash(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            RunRecorder(
+                thread_id="../../../etc/passwd",
+                flow_name="test_flow",
+            )
+
+    def test_invalid_thread_id_with_slash(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            RunRecorder(
+                thread_id="test/thread",
+                flow_name="test_flow",
+            )
+
+    def test_invalid_thread_id_with_dot(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            RunRecorder(
+                thread_id="test.thread",
+                flow_name="test_flow",
+            )
+
+    def test_valid_thread_id_with_hyphen_underscore(self):
+        recorder = RunRecorder(
+            thread_id="test-thread_123",
+            flow_name="test_flow",
+        )
+        assert recorder.thread_id == "test-thread_123"
+
+    def test_save_creates_secure_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                thread_id="test-123",
+                flow_name="test_flow",
+            )
+            recorder.finalize({"key": "value"}, "completed")
+
+            file_path = recorder.save(base_dir=Path(tmpdir))
+
+            import os
+
+            stat_info = os.stat(file_path)
+            mode = stat_info.st_mode & 0o777
+            assert mode == 0o600
+
+    def test_save_directory_secure_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            recorder = RunRecorder(
+                thread_id="test-123",
+                flow_name="test_flow",
+            )
+            recorder.finalize({"key": "value"}, "completed")
+
+            recorder.save(base_dir=Path(tmpdir))
+
+            runs_dir = Path(tmpdir) / "runs"
+            import os
+
+            stat_info = os.stat(runs_dir)
+            mode = stat_info.st_mode & 0o777
+            assert mode == 0o700
+
+    def test_save_hardens_preexisting_directory(self):
+        """Regression: existing runs/ dir with 0o755 must be tightened to 0o700."""
+        import os
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            runs_dir = Path(tmpdir) / "runs"
+            runs_dir.mkdir(mode=0o755)
+            assert (os.stat(runs_dir).st_mode & 0o777) == 0o755
+
+            recorder = RunRecorder(
+                thread_id="test-hardendir",
+                flow_name="test_flow",
+            )
+            recorder.finalize({"key": "value"}, "completed")
+            recorder.save(base_dir=Path(tmpdir))
+
+            stat_info = os.stat(runs_dir)
+            mode = stat_info.st_mode & 0o777
+            assert mode == 0o700
+
+    def test_record_state_complete_state_type_fallback(self):
+        """Regression: record_state_complete without prior start uses state_type param, not 'unknown'."""
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        recorder.record_state_complete(
+            "approval",
+            "success",
+            "approved",
+            ["$.result"],
+            state_type="wait",
+        )
+
+        assert len(recorder.states) == 1
+        assert recorder.states[0]["type"] == "wait"
+
+    def test_wait_state_no_duplicate_entry_on_normal_path(self):
+        """Regression: notify start + interrupt complete must produce exactly one wait entry."""
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        # Simulate notify node: record_state_start
+        recorder.record_state_start("approval", "wait")
+        # Simulate interrupt node: record_state_complete only (no second start)
+        recorder.record_state_complete(
+            "approval",
+            "success",
+            "yes",
+            ["$.answer"],
+            state_type="wait",
+        )
+
+        assert len(recorder.states) == 1
+        state = recorder.states[0]
+        assert state["name"] == "approval"
+        assert state["type"] == "wait"
+        assert state["status"] == "success"
+
+    def test_wait_state_resume_path_synthesizes_correct_type(self):
+        """Regression: on resume (no notify), complete with state_type='wait' sets type correctly."""
+        recorder = RunRecorder(
+            thread_id="test-123",
+            flow_name="test_flow",
+        )
+
+        # On resume path, no notify node ran — only interrupt node calls complete
+        recorder.record_state_complete(
+            "approval",
+            "success",
+            "yes",
+            ["$.answer"],
+            state_type="wait",
+        )
+
+        assert len(recorder.states) == 1
+        assert recorder.states[0]["type"] == "wait"

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -1,7 +1,13 @@
 from io import StringIO
 from unittest.mock import patch
 
-from fdsx.display.terminal import display_wait_prompt
+from fdsx.display.terminal import (
+    display_branch_complete,
+    display_branch_failed,
+    display_branch_start,
+    display_parallel_results,
+    display_wait_prompt,
+)
 
 
 class TestDisplayWaitPrompt:
@@ -133,3 +139,327 @@ class TestDisplayWaitPrompt:
         assert "\x1b" not in stderr_text, "ANSI escape in state_name leaked to terminal"
         # The visible text content must still appear in the header
         assert "malicious_state" in stderr_text
+
+
+class TestDisplayBranchStart:
+    """Tests for display_branch_start function."""
+
+    def test_displays_branch_start_with_model(self):
+        """Branch start shows provider/model format."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_start(
+                state_name="review",
+                branch_index=0,
+                provider="claude",
+                model="sonnet",
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "[branch-1]" in stderr_text
+        assert "claude/sonnet" in stderr_text
+        assert "⏳ running..." in stderr_text
+
+    def test_displays_branch_start_without_model(self):
+        """Branch start shows provider only when model is None."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_start(
+                state_name="review",
+                branch_index=1,
+                provider="openai",
+                model=None,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "[branch-2]" in stderr_text
+        assert "openai" in stderr_text
+        assert "⏳ running..." in stderr_text
+        assert "/None" not in stderr_text
+
+    def test_branch_index_is_1_indexed(self):
+        """Branch index should be 1-indexed in display."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_start(
+                state_name="parallel",
+                branch_index=2,
+                provider="test",
+                model=None,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "branch-3" in stderr_text
+
+    def test_ansi_escape_sequences_stripped_from_model(self):
+        """Regression: ANSI escape sequences in model must be stripped.
+
+        A crafted branch with ANSI escape codes in the model field could
+        spoof terminal output or manipulate the operator's terminal.
+        """
+        ansi_model = "\x1b[31mmalicious_model\x1b[0m"
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_start(
+                state_name="review",
+                branch_index=0,
+                provider="test",
+                model=ansi_model,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        # ESC byte must not appear in terminal output
+        assert "\x1b" not in stderr_text, "ANSI escape in model leaked to terminal"
+        # Visible text content must still be present
+        assert "malicious_model" in stderr_text
+
+
+class TestDisplayBranchComplete:
+    """Tests for display_branch_complete function."""
+
+    def test_displays_branch_complete_with_model(self):
+        """Branch completion shows provider/model and duration."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_complete(
+                state_name="review",
+                branch_index=0,
+                provider="claude",
+                model="sonnet",
+                duration=5.5,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "[branch-1]" in stderr_text
+        assert "claude/sonnet" in stderr_text
+        assert "✓ completed" in stderr_text
+        assert "(5s)" in stderr_text
+
+    def test_displays_branch_complete_without_model(self):
+        """Branch completion shows provider only when model is None."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_complete(
+                state_name="review",
+                branch_index=0,
+                provider="claude",
+                model=None,
+                duration=5.5,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "[branch-1]" in stderr_text
+        assert "claude" in stderr_text
+        assert "✓ completed" in stderr_text
+        assert "(5s)" in stderr_text
+
+    def test_duration_is_truncated_to_integer(self):
+        """Duration should be truncated to integer second (int() behavior)."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_complete(
+                state_name="review",
+                branch_index=0,
+                provider="test",
+                model=None,
+                duration=3.7,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "(3s)" in stderr_text
+
+    def test_ansi_escape_sequences_stripped_from_model(self):
+        """Regression: ANSI escape sequences in model must be stripped."""
+        ansi_model = "\x1b[31mmalicious_model\x1b[0m"
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_complete(
+                state_name="review",
+                branch_index=0,
+                provider="test",
+                model=ansi_model,
+                duration=5.0,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "\x1b" not in stderr_text, "ANSI escape in model leaked to terminal"
+        assert "malicious_model" in stderr_text
+
+
+class TestDisplayBranchFailed:
+    """Tests for display_branch_failed function."""
+
+    def test_displays_branch_failed_with_model(self):
+        """Branch failure shows provider/model and failure marker."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_failed(
+                state_name="review",
+                branch_index=1,
+                provider="openai",
+                model="gpt-4",
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "[branch-2]" in stderr_text
+        assert "openai/gpt-4" in stderr_text
+        assert "✗ failed" in stderr_text
+
+    def test_displays_branch_failed_without_model(self):
+        """Branch failure shows provider only when model is None."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_failed(
+                state_name="review",
+                branch_index=1,
+                provider="openai",
+                model=None,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "[branch-2]" in stderr_text
+        assert "openai" in stderr_text
+        assert "✗ failed" in stderr_text
+
+    def test_ansi_escape_sequences_stripped_from_model(self):
+        """Regression: ANSI escape sequences in model must be stripped."""
+        ansi_model = "\x1b[31mmalicious_model\x1b[0m"
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            display_branch_failed(
+                state_name="review",
+                branch_index=0,
+                provider="test",
+                model=ansi_model,
+            )
+
+        stderr_text = captured_stderr.getvalue()
+        assert "\x1b" not in stderr_text, "ANSI escape in model leaked to terminal"
+        assert "malicious_model" in stderr_text
+
+
+class TestDisplayParallelResults:
+    """Tests for display_parallel_results function."""
+
+    def test_displays_all_branch_outputs(self):
+        """All branch results should be displayed with headers."""
+        captured_stderr = StringIO()
+
+        branch_results = [
+            {
+                "index": 0,
+                "provider": "claude",
+                "model": "sonnet",
+                "output": "first output",
+                "exit_code": 0,
+            },
+            {
+                "index": 1,
+                "provider": "openai",
+                "model": "gpt-4",
+                "output": "second output",
+                "exit_code": 0,
+            },
+        ]
+
+        with patch("sys.stderr", captured_stderr):
+            display_parallel_results("parallel_state", branch_results)
+
+        stderr_text = captured_stderr.getvalue()
+        assert "--- branch-1 (claude/sonnet) ---" in stderr_text
+        assert "first output" in stderr_text
+        assert "--- branch-2 (openai/gpt-4) ---" in stderr_text
+        assert "second output" in stderr_text
+
+    def test_displays_failed_branch(self):
+        """Failed branches should show FAILED marker in header."""
+        captured_stderr = StringIO()
+
+        branch_results = [
+            {
+                "index": 0,
+                "provider": "claude",
+                "model": "sonnet",
+                "output": "error occurred",
+                "exit_code": 1,
+            },
+        ]
+
+        with patch("sys.stderr", captured_stderr):
+            display_parallel_results("parallel_state", branch_results)
+
+        stderr_text = captured_stderr.getvalue()
+        assert "--- branch-1 (claude/sonnet) FAILED ---" in stderr_text
+        assert "error occurred" in stderr_text
+
+    def test_multiline_output_preserved(self):
+        """Multiline output should be preserved in display."""
+        captured_stderr = StringIO()
+
+        branch_results = [
+            {
+                "index": 0,
+                "provider": "test",
+                "output": "line 1\nline 2\nline 3",
+                "exit_code": 0,
+            },
+        ]
+
+        with patch("sys.stderr", captured_stderr):
+            display_parallel_results("parallel_state", branch_results)
+
+        stderr_text = captured_stderr.getvalue()
+        assert "line 1" in stderr_text
+        assert "line 2" in stderr_text
+        assert "line 3" in stderr_text
+
+    def test_empty_output_handled(self):
+        """Empty output should not cause issues."""
+        captured_stderr = StringIO()
+
+        branch_results = [
+            {"index": 0, "provider": "test", "output": "", "exit_code": 0},
+        ]
+
+        with patch("sys.stderr", captured_stderr):
+            display_parallel_results("parallel_state", branch_results)
+
+        stderr_text = captured_stderr.getvalue()
+        assert "--- branch-1 (test) ---" in stderr_text
+
+    def test_ansi_escape_sequences_stripped_from_output(self):
+        """Regression: ANSI escape sequences in branch output must be stripped.
+
+        Branch output comes from provider stdout, so attacker-controlled LLM output
+        could inject ANSI sequences to spoof prompts, alter terminal state, or
+        leak sensitive values into CI/logs.
+        """
+        ansi_output = "\x1b[31mMalicious\x1b[0m output\x1b]0;spoof title\x07"
+        captured_stderr = StringIO()
+
+        branch_results = [
+            {"index": 0, "provider": "test", "output": ansi_output, "exit_code": 0},
+        ]
+
+        with patch("sys.stderr", captured_stderr):
+            display_parallel_results("parallel_state", branch_results)
+
+        stderr_text = captured_stderr.getvalue()
+        # ESC byte must not appear in terminal output
+        assert "\x1b" not in stderr_text, "ANSI escape in output leaked to terminal"
+        # BEL byte must not appear
+        assert "\x07" not in stderr_text, "BEL byte leaked to terminal"
+        # Visible text content must still be present
+        assert "Malicious" in stderr_text
+        assert "output" in stderr_text

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -1,0 +1,135 @@
+from io import StringIO
+from unittest.mock import patch
+
+from fdsx.display.terminal import display_wait_prompt
+
+
+class TestDisplayWaitPrompt:
+    """Regression tests for display_wait_prompt CLI contract compliance."""
+
+    def test_prompt_text_goes_to_stderr_not_stdout(self):
+        """Regression: 'Select (1-N):' prompt must appear on stderr, not stdout.
+
+        Before the fix, `input(f"Select (1-{N}): ")` wrote the prompt to stdout,
+        corrupting JSON output when piped (e.g., `fdsx run flow.yaml | jq .`).
+        """
+        captured_stdout = StringIO()
+        captured_stderr = StringIO()
+
+        with patch("sys.stdout", captured_stdout):
+            with patch("sys.stderr", captured_stderr):
+                with patch("builtins.input", return_value="1"):
+                    result = display_wait_prompt(
+                        "review", "Please review the plan.", ["approve", "reject"]
+                    )
+
+        assert result == "approve"
+        # stdout must be completely empty — no prompt text
+        assert captured_stdout.getvalue() == ""
+        # prompt must appear on stderr with 2-space indent
+        stderr_text = captured_stderr.getvalue()
+        assert "  Select (1-2): " in stderr_text
+
+    def test_prompt_has_two_space_indent(self):
+        """Regression: prompt must be indented with exactly two spaces per CLI contract."""
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            with patch("builtins.input", return_value="1"):
+                display_wait_prompt("review", "Approve?", ["yes", "no"])
+
+        stderr_text = captured_stderr.getvalue()
+        assert "  Select (1-2): " in stderr_text
+
+    def test_returns_correct_choice_string(self):
+        """Valid numeric input returns the corresponding choice string."""
+        with patch("builtins.input", return_value="2"):
+            result = display_wait_prompt("review", "Choose:", ["approve", "reject"])
+        assert result == "reject"
+
+    def test_multiline_message_all_lines_indented(self):
+        """Regression: multi-line message must indent all lines, not just first."""
+        multi_line_message = (
+            "Please review the plan.\nPlan: Implement feature X\nand deploy to prod."
+        )
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            with patch("builtins.input", return_value="1"):
+                display_wait_prompt("review", multi_line_message, ["approve", "reject"])
+
+        stderr_text = captured_stderr.getvalue()
+        lines = stderr_text.splitlines()
+        message_lines = [
+            line
+            for line in lines
+            if "review the plan" in line or "Plan:" in line or "and deploy" in line
+        ]
+        for line in message_lines:
+            assert line.startswith("  "), f"Line not indented: {line!r}"
+
+    def test_invalid_then_valid_input_loops(self):
+        """Invalid input re-prompts; valid input is accepted on subsequent attempt."""
+        with patch("builtins.input", side_effect=["0", "abc", "2"]):
+            result = display_wait_prompt("review", "Choose:", ["approve", "reject"])
+        assert result == "reject"
+
+    def test_ansi_escape_sequences_stripped_from_message(self):
+        """Regression: ANSI/OSC escape sequences in LLM-derived message must be stripped.
+
+        A crafted message containing ANSI escape codes could spoof the approval screen
+        or manipulate the operator's terminal (terminal injection / ANSI injection).
+        The existing _sanitize_output function must be applied before display.
+        """
+        ansi_message = "\x1b[31mDangerous\x1b[0m content\x1b]0;spoof title\x07"
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            with patch("builtins.input", return_value="1"):
+                result = display_wait_prompt(
+                    "review", ansi_message, ["approve", "reject"]
+                )
+
+        assert result == "approve"
+        stderr_text = captured_stderr.getvalue()
+        # ESC byte (\x1b) must not appear in terminal output
+        assert "\x1b" not in stderr_text, "ANSI escape sequence leaked to terminal"
+        # BEL byte (\x07) must not appear
+        assert "\x07" not in stderr_text, "BEL byte leaked to terminal"
+        # Visible text content must still be present
+        assert "Dangerous" in stderr_text
+        assert "content" in stderr_text
+
+    def test_ansi_escape_sequences_stripped_from_choices(self):
+        """Regression: ANSI escape sequences in choices must be stripped before display."""
+        ansi_choices = ["\x1b[32mapprove\x1b[0m", "reject"]
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            with patch("builtins.input", return_value="1"):
+                result = display_wait_prompt("review", "Choose:", ansi_choices)
+
+        assert result == "\x1b[32mapprove\x1b[0m"  # original choice string returned
+        stderr_text = captured_stderr.getvalue()
+        # ESC must not appear in the rendered choice lines
+        assert "\x1b" not in stderr_text, "ANSI escape in choice leaked to terminal"
+        # Visible text must still appear
+        assert "approve" in stderr_text
+
+    def test_ansi_escape_sequences_stripped_from_state_name(self):
+        """Regression: ANSI escape sequences in state_name must be stripped from header."""
+        ansi_state_name = "\x1b[31mmalicious_state\x1b[0m"
+        captured_stderr = StringIO()
+
+        with patch("sys.stderr", captured_stderr):
+            with patch("builtins.input", return_value="1"):
+                result = display_wait_prompt(
+                    ansi_state_name, "Choose:", ["approve", "reject"]
+                )
+
+        assert result == "approve"
+        stderr_text = captured_stderr.getvalue()
+        # ESC byte must not appear in terminal output
+        assert "\x1b" not in stderr_text, "ANSI escape in state_name leaked to terminal"
+        # The visible text content must still appear in the header
+        assert "malicious_state" in stderr_text

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -1,0 +1,255 @@
+from unittest.mock import MagicMock, patch
+
+from fdsx.notify.webhook import send_notification, send_webhook
+from fdsx.models.flow import NotifyConfig, WebhookConfig
+
+
+class TestSendWebhook:
+    def test_successful_post_returns_true(self):
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.return_value = mock_response
+
+            result = send_webhook("https://example.com/webhook", "test message")
+
+            assert result is True
+            mock_client.return_value.post.assert_called_once_with(
+                "https://example.com/webhook", json={"text": "test message"}
+            )
+
+    def test_network_error_returns_false(self):
+        from httpx import HTTPError
+
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.side_effect = HTTPError("Connection failed")
+
+            result = send_webhook("https://example.com/webhook", "test message")
+
+            assert result is False
+
+    def test_non_2xx_status_returns_false(self):
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 500
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.return_value = mock_response
+
+            result = send_webhook("https://example.com/webhook", "test message")
+
+            assert result is False
+
+    def test_timeout_returns_false(self):
+        from httpx import TimeoutException
+
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.side_effect = TimeoutException(
+                "Request timeout"
+            )
+
+            result = send_webhook("https://example.com/webhook", "test message")
+
+            assert result is False
+
+    def test_timeout_logs_webhook_timeout_event_not_http_error(self):
+        """Regression: TimeoutException must use 'webhook_timeout' log event, not 'webhook_http_error'.
+
+        Before the fix, TimeoutException (a subclass of HTTPError) was caught by
+        the broader `except HTTPError` handler, silently logging the wrong event.
+        """
+        import structlog.testing
+        from httpx import TimeoutException
+
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.side_effect = TimeoutException(
+                "Request timeout"
+            )
+
+            with structlog.testing.capture_logs() as log_output:
+                result = send_webhook("https://example.com/webhook", "test message")
+
+        assert result is False
+        assert len(log_output) == 1
+        assert log_output[0]["event"] == "webhook_timeout"
+        assert "timeout" in log_output[0]
+
+    def test_logs_do_not_expose_raw_url_or_message_body(self):
+        """Regression: log events must not contain raw webhook URL or message body.
+
+        Webhook URLs often contain bearer tokens in the path/query.  The resolved
+        message is derived from workflow state and may contain sensitive content.
+        Both must be redacted/omitted from all log events.
+        """
+        import structlog.testing
+        from httpx import TimeoutException
+
+        secret_url = "https://hooks.example.com/services/TOKEN123/SECRET456"
+        sensitive_message = "Confidential plan: deploy API key abc123"
+
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.side_effect = TimeoutException("timeout")
+
+            with structlog.testing.capture_logs() as log_output:
+                send_webhook(secret_url, sensitive_message)
+
+        assert len(log_output) == 1
+        log_entry = log_output[0]
+        # Raw URL must not appear in any log field
+        for value in log_entry.values():
+            assert secret_url not in str(value), (
+                f"Raw URL leaked in log field: {value!r}"
+            )
+        # Message body must not appear in any log field
+        for value in log_entry.values():
+            assert sensitive_message not in str(value), (
+                f"Message body leaked in log field: {value!r}"
+            )
+        # Redacted URL (scheme+host only) must be present
+        assert "hooks.example.com" in str(log_entry.get("url", ""))
+        assert "TOKEN123" not in str(log_entry.get("url", ""))
+
+    def test_non_2xx_log_does_not_expose_url_or_message(self):
+        """Regression: non-2xx warning must redact URL and omit message body."""
+        import structlog.testing
+
+        secret_url = "https://hooks.example.com/services/SECRETTOKEN"
+
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_response = MagicMock()
+            mock_response.status_code = 403
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.return_value = mock_response
+
+            with structlog.testing.capture_logs() as log_output:
+                send_webhook(secret_url, "sensitive data")
+
+        assert len(log_output) == 1
+        log_entry = log_output[0]
+        assert "SECRETTOKEN" not in str(log_entry)
+        assert "sensitive data" not in str(log_entry)
+        assert log_entry["event"] == "webhook_non_2xx_response"
+        assert log_entry["status_code"] == 403
+
+
+class TestRedactUrl:
+    """Unit tests for the _redact_url helper."""
+
+    def test_hides_path_and_query(self):
+        from fdsx.notify.webhook import _redact_url
+
+        result = _redact_url("https://hooks.example.com/services/TOKEN/SECRET?foo=bar")
+        assert result == "https://hooks.example.com/***"
+        assert "TOKEN" not in result
+        assert "SECRET" not in result
+        assert "foo" not in result
+
+    def test_preserves_scheme_and_host(self):
+        from fdsx.notify.webhook import _redact_url
+
+        result = _redact_url("https://example.com/webhook")
+        assert result.startswith("https://example.com/")
+
+    def test_handles_malformed_url_gracefully(self):
+        from fdsx.notify.webhook import _redact_url
+
+        result = _redact_url("not-a-url")
+        assert "not-a-url" not in result or result == "not-a-url/***"
+        # Must not raise
+
+
+class TestSendNotification:
+    def test_template_variables_are_resolved_before_sending(self):
+        with patch("fdsx.notify.webhook.send_webhook") as mock_send:
+            mock_send.return_value = True
+
+            notify = NotifyConfig(
+                webhook=WebhookConfig(
+                    url="https://example.com/webhook",
+                    template="Approval needed for {task_name} by {assignee}",
+                )
+            )
+            state_dict = {
+                "task_name": "Fix bug #123",
+                "assignee": "alice",
+            }
+
+            send_notification(notify, state_dict)
+
+            mock_send.assert_called_once_with(
+                "https://example.com/webhook",
+                "Approval needed for Fix bug #123 by alice",
+            )
+
+    def test_webhook_failure_does_not_raise_exception(self):
+        with patch("fdsx.notify.webhook.send_webhook") as mock_send:
+            mock_send.return_value = False
+
+            notify = NotifyConfig(
+                webhook=WebhookConfig(
+                    url="https://example.com/webhook",
+                    template="Test message",
+                )
+            )
+            state_dict = {}
+
+            result = send_notification(notify, state_dict)
+
+            assert result is None
+            mock_send.assert_called_once()
+
+    def test_http_error_message_not_in_logs(self):
+        """Regression: HTTPError str() must not appear in logs - may contain secrets.
+
+        HTTPError exceptions often embed the full request URL which may contain
+        bearer tokens or other secrets.
+        """
+        import structlog.testing
+        from httpx import HTTPError
+
+        secret_url = "https://hooks.example.com/services/TOKEN123/SECRET"
+
+        with patch("fdsx.notify.webhook.Client") as mock_client:
+            mock_client.return_value.__enter__ = MagicMock(
+                return_value=mock_client.return_value
+            )
+            mock_client.return_value.__exit__ = MagicMock(return_value=False)
+            mock_client.return_value.post.side_effect = HTTPError(
+                f"GET {secret_url} failed"
+            )
+
+            with structlog.testing.capture_logs() as log_output:
+                send_webhook(secret_url, "test message")
+
+        assert len(log_output) == 1
+        log_entry = log_output[0]
+        # The error field must contain only the exception type name, not str(e)
+        assert log_entry["error"] == "HTTPError"
+        # The secret URL must not appear in any log field
+        for value in log_entry.values():
+            assert "TOKEN123" not in str(value), f"Secret leaked in log: {value!r}"

--- a/uv.lock
+++ b/uv.lock
@@ -202,7 +202,7 @@ wheels = [
 [[package]]
 name = "fdsx"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "langgraph" },


### PR DESCRIPTION
## Summary

Complete implementation of Phases 6–16 of the fdsx framework, covering:

- **Phase 6 (US3)**: Parallel execution, aggregation, and loop control (T025-T033)
- **Phase 7**: CLI e2e tests (T034-T035)
- **Phase 8 (US4)**: Wait state + webhook notifications (T036-T042)
- **Phase 9 (US5)**: Checkpoint/resume + list + prompt_file (T043-T051)
- **Phase 10**: Polish & cross-cutting (T052-T053)
- **Phase 11 (US6)**: Structured logging — RunRecorder (T054-T056)
- **Phase 12 (US7)**: Batch task execution (T057-T062)
- **Phase 13**: Edge case hardening — exponential backoff (T063-T064)
- **Phase 14**: Parallel display improvements (T065-T066)
- **Phase 15**: PyPI packaging + README (T067-T068)
- **Phase 16**: Polish — lint/type verification + comprehensive e2e tests (T069-T072)

### Latest commit (Phase 16 — T069-T072):
- Verified ruff and mypy pass on all Phase 4 code (0 errors)
- Added 3 CLI e2e tests for batch task execution
- Added 13 comprehensive e2e scenario tests covering all 5 flows
- Added structured run log verification to e2e tests
- Fixed `recorder.save()` base_dir passthrough in engine.py
- **356 tests passing** (340 pre-existing + 16 new)

## Test Plan

- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run mypy src/fdsx/` — Success: no issues found in 26 source files
- [x] `uv run pytest tests/ -x -q` — 356 passed in ~13s

🤖 Generated with [Claude Code](https://claude.com/claude-code)