### PR TITLE
feat: UUIDv7 run IDs, Claude & Codex provider streaming, stdin fallback, quiet mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,4 @@ build/
 
 # fdsx runtime data
 .fdsx/
-runs/
 specs/

--- a/.takt/facets/instructions/fix.md
+++ b/.takt/facets/instructions/fix.md
@@ -29,3 +29,8 @@ Use reports in the Report Directory and fix the issues raised by the reviewer.
 | persists (carried over, not addressed this iteration) | {N} |
 ## Evidence
 - {List key points from files checked/searches/diffs/logs}
+
+**Routing tag (required — output exactly one):**
+- All fixes applied, build and tests pass → `[STEP:1]`
+- Fixes attempted but build or tests fail → `[STEP:2]`
+- Cannot fix — issues beyond this agent's capability → `[STEP:3]`

--- a/.takt/facets/instructions/replan.md
+++ b/.takt/facets/instructions/replan.md
@@ -21,6 +21,9 @@ Create a targeted fix plan based on review feedback, classify complexity, and ro
 - If ANY finding is complex → output `[STEP:2]` (route to capable model)
 - If findings reveal fundamental design issues requiring major rework → output `[STEP:3]` (blocked)
 
+**Scope boundary — plan report:**
+Read {report_dir}/plan.md for the **Out of Scope** section. Any review finding that targets files or areas listed as out of scope MUST be placed in your "Out of Scope" table — do NOT create fix instructions for them, even if the reviewer flagged them as blocking. The plan's scope boundary takes precedence over reviewer findings.
+
 **Important:**
 - Do NOT expand scope beyond what the review findings require
 - The fix agent works best with specific, concrete instructions. Write exact code patterns, not vague guidance like "handle concurrency properly"

--- a/.takt/facets/instructions/review-code-quality.md
+++ b/.takt/facets/instructions/review-code-quality.md
@@ -11,13 +11,20 @@ Review {report:coder-decisions.md} to understand the recorded design decisions.
 - Do not flag intentionally documented decisions as FP
 - However, also evaluate whether the design decisions themselves are sound, and flag any problems
 
+**Scope boundary — plan report:**
+Review {report:plan.md} for the **Out of Scope** section.
+- Issues in files or areas listed as out of scope MUST NOT be flagged as blocking
+- Even if an out-of-scope area has a real issue, it is deferred to a later phase by design
+- Only review code within the plan's stated scope (files listed in File Change Summary)
+
 ## Judgment Procedure
 
 1. Review the change diff and detect issues based on the code quality criteria above
-2. For each detected issue, classify as blocking/non-blocking:
+2. Cross-check each finding against the plan's Out of Scope table — discard any finding that falls in deferred scope
+3. For each remaining issue, classify as blocking/non-blocking:
    - **Blocking**: Bugs, DRY violations creating maintenance risk, unhandled error cases, dead code
    - **Non-blocking**: Style preferences, minor naming suggestions
-3. If there is even one blocking issue, judge as REJECT
+4. If there is even one blocking issue, judge as REJECT
 
 ## Output
 

--- a/.takt/facets/instructions/review-security.md
+++ b/.takt/facets/instructions/review-security.md
@@ -10,9 +10,16 @@ Review {report:coder-decisions.md} to understand the recorded design decisions.
 - Do not flag intentionally documented decisions as FP
 - However, also evaluate whether the design decisions themselves are sound, and flag any problems
 
+**Scope boundary — plan report:**
+Review {report:plan.md} for the **Out of Scope** section.
+- Vulnerabilities in files or areas listed as out of scope MUST NOT be flagged as blocking
+- Even if an out-of-scope area has a real vulnerability, it is deferred to a later phase by design
+- Only review code within the plan's stated scope (files listed in File Change Summary)
+
 ## Judgment Procedure
 
 1. Review the change diff and detect issues based on the security criteria above
    - Cross-check changes against REJECT criteria tables defined in knowledge
-2. For each detected issue, classify as blocking/non-blocking based on Policy's scope determination table and judgment rules
-3. If there is even one blocking issue, judge as REJECT
+2. Cross-check each finding against the plan's Out of Scope table — discard any finding that falls in deferred scope
+3. For each remaining issue, classify as blocking/non-blocking based on Policy's scope determination table and judgment rules
+4. If there is even one blocking issue, judge as REJECT

--- a/.takt/pieces/full-impl.yaml
+++ b/.takt/pieces/full-impl.yaml
@@ -57,14 +57,16 @@ movements:
           The planner has identified blockers.
           Please provide clarification and re-run.
 
-  # 2. Implementation (OpenCode / opencode-go/minimax-m2.5)
+  # 2. Implementation (OpenCode / opencode-go/minimax-m2.7)
   - name: implement
     persona: coder
     instruction: implement
     edit: true
     required_permission_mode: edit
-    provider: opencode
-    model: opencode-go/minimax-m2.5
+#    provider: opencode
+#    model: opencode-go/minimax-m2.7
+    provider: claude
+    model: claude-sonnet-4-6
     output_contracts:
       report:
         - name: implementation.md
@@ -82,8 +84,10 @@ movements:
         persona: code-quality-reviewer
         instruction: review-code-quality
         edit: false
-        provider: codex
-        model: gpt-5.4
+#        provider: codex
+#        model: gpt-5.4
+        provider: claude
+        model: claude-opus-4-6
         rules:
           - condition: approved
           - condition: needs_fix
@@ -92,8 +96,10 @@ movements:
         persona: security-reviewer
         instruction: review-security
         edit: false
-        provider: codex
-        model: gpt-5.4
+#        provider: codex
+#        model: gpt-5.4
+        provider: claude
+        model: claude-opus-4-6
         rules:
           - condition: approved
           - condition: needs_fix
@@ -132,8 +138,10 @@ movements:
     instruction: fix
     edit: true
     required_permission_mode: edit
-    provider: opencode
-    model: opencode-go/minimax-m2.5
+#    provider: opencode
+#    model: opencode-go/minimax-m2.7
+    provider: claude
+    model: claude-sonnet-4-6
     rules:
       - condition: "Fixes applied successfully"
         next: review

--- a/.takt/pieces/full-impl.yaml
+++ b/.takt/pieces/full-impl.yaml
@@ -1,6 +1,6 @@
 name: full-impl
-description: Full pipeline — plan → implement → parallel review (code quality, security) → replan (Claude, routes by complexity) → fix-simple (minimax) / fix-complex (Sonnet) → finalize with PR creation
-max_movements: 15
+description: Full pipeline — plan → implement → parallel review (code quality, security) → replan (Claude, routes by complexity) → fix-simple (minimax, escalates to fix-complex on failure) / fix-complex (Sonnet) → finalize with PR creation
+max_movements: 25
 initial_movement: plan
 
 piece_config:
@@ -57,14 +57,14 @@ movements:
           The planner has identified blockers.
           Please provide clarification and re-run.
 
-  # 2. Implementation (OpenCode / opencode/minimax-m2.5-free)
+  # 2. Implementation (OpenCode / opencode-go/minimax-m2.5)
   - name: implement
     persona: coder
     instruction: implement
     edit: true
     required_permission_mode: edit
     provider: opencode
-    model: opencode/minimax-m2.5-free
+    model: opencode-go/minimax-m2.5
     output_contracts:
       report:
         - name: implementation.md
@@ -133,10 +133,16 @@ movements:
     edit: true
     required_permission_mode: edit
     provider: opencode
-    model: opencode/minimax-m2.5-free
+    model: opencode-go/minimax-m2.5
     rules:
-      - condition: "Fixes applied"
+      - condition: "Fixes applied successfully"
         next: review
+      - condition: "Fixes attempted but build or tests fail"
+        next: review
+      - condition: "Cannot fix — beyond capability"
+        next: fix-complex
+      - condition: "Agent produced no output or an unrecognizable response"
+        next: fix-complex
 
   # 5b. Fix — complex (Sonnet, capable)
   - name: fix-complex
@@ -147,8 +153,16 @@ movements:
     provider: claude
     model: sonnet
     rules:
-      - condition: "Fixes applied"
+      - condition: "Fixes applied successfully"
         next: review
+      - condition: "Fixes attempted but build or tests fail"
+        next: review
+      - condition: "Cannot fix — fundamental issues"
+        next: ABORT
+        requires_user_input: true
+        appendix: |
+          The fix agent could not resolve the issues even with the capable model.
+          Please review the fix report and provide guidance.
 
   # 6. Finalize (Claude — commit → push → PR)
   - name: finalize
@@ -196,6 +210,8 @@ loop_monitors:
           next: fix-complex
         - condition: "Fundamentally unfixable — abort"
           next: ABORT
+        - condition: "Code-quality approved, only non-actionable findings remain — skip to finalize"
+          next: finalize
 
   - cycle: [review, replan, fix-complex]
     threshold: 2
@@ -219,3 +235,5 @@ loop_monitors:
           next: fix-complex
         - condition: "Stalled or too complex to converge"
           next: ABORT
+        - condition: "Code-quality approved, only non-actionable findings remain — skip to finalize"
+          next: finalize

--- a/examples/workflows/plan-implement-review.yaml
+++ b/examples/workflows/plan-implement-review.yaml
@@ -1,5 +1,5 @@
 name: Plan-Implement-Review Loop
-comment: >
+description: >
   Full-featured example: Plan (Claude) -> Implement (opencode) ->
   Parallel Review (Codex x2: implementation + security) -> Aggregate ->
   Choice -> Wait (human approval) -> System command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "typer>=0.9",
     "httpx>=0.27",
     "structlog>=24",
+    "uuid-utils>=0.9",
 ]
 
 [project.urls]

--- a/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
+++ b/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
@@ -55,8 +55,8 @@
 
 ## Phase 6: Polish & Backward Compatibility
 
-- [ ] T39: Backward compat — Ensure `--tasks` (in-memory batch) still works. Reads task_splitter from config instead of flow in `src/fdsx/core/engine.py`
-- [ ] T40: Error messages — Clear errors for: no workflows found, invalid task file, no config, missing description
-- [ ] T41: Help text — Update all command help text and `--help` output in `src/fdsx/cli/main.py`
-- [ ] T42: Edge cases — Empty tasks dir, all tasks completed (no-op), single task file, invalid YAML task files
-- [ ] T43: End-to-end test — Full flow: split → edit → run → crash → resume → complete
+- [x] T39: Backward compat — Ensure `--tasks` (in-memory batch) still works. Reads task_splitter from config instead of flow in `src/fdsx/core/engine.py`
+- [x] T40: Error messages — Clear errors for: no workflows found, invalid task file, no config, missing description
+- [x] T41: Help text — Update all command help text and `--help` output in `src/fdsx/cli/main.py`
+- [x] T42: Edge cases — Empty tasks dir, all tasks completed (no-op), single task file, invalid YAML task files
+- [x] T43: End-to-end test — Full flow: split → edit → run → crash → resume → complete

--- a/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
+++ b/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Batch Task Persistence & Workflow Auto-Selection
+
+## Phase 1: Config System & Task File Model
+
+- [x] T1: Config model — Create `FdsxConfig`, `TaskSplitterConfig`, `WorkflowSelectorConfig` pydantic models with validation in `src/fdsx/core/config.py` (NEW)
+- [x] T2: Config loader — Implement `load_config()`: resolve XDG path, load global + project YAML, merge, return `FdsxConfig` in `src/fdsx/core/config.py`
+- [x] T3: Config defaults — Built-in defaults when no config file exists (provider: claude, model: claude-sonnet-4-6) in `src/fdsx/core/config.py`
+- [x] T4: TaskEntry model — Create `TaskEntry` pydantic model with status enum validation in `src/fdsx/models/task.py` (NEW)
+- [x] T5: TaskFile model — Create `TaskFile` model supporting single-task (flat) and multi-task (list) formats in `src/fdsx/models/task.py`
+- [x] T6: TaskFile I/O — `load_task_file(path)` and `save_task_file(path, task_file)` functions
+- [x] T7: Unit tests — TDD tests for config loading (global, project, merge, defaults) and task file parsing/serialization in `tests/unit/test_config.py` (NEW) and `tests/unit/test_task_model.py` (NEW)
+
+## Phase 2: Flow Model Changes
+
+- [ ] T8: Add description field — Add required `description: str` to `Flow` model in `src/fdsx/models/flow.py`
+- [ ] T9: Remove task_splitter — Remove `task_splitter` field from `Flow`. Handle gracefully if present in YAML (custom error) in `src/fdsx/models/flow.py`
+- [ ] T10: Update loader errors — Customize validation error for missing `description` with actionable guidance in `src/fdsx/core/loader.py`
+- [ ] T11: Update example workflow — Add `description` to `examples/workflows/plan-implement-review.yaml`
+- [ ] T12: Update tests — Fix broken tests from model changes, add tests for new validation in `tests/unit/test_models.py` and `tests/unit/test_loader.py`
+
+## Phase 3: Split Command
+
+- [ ] T13: Refactor split prompt — Update `_build_task_split_prompt()` to request JSON with dependency groups in `src/fdsx/core/batch.py`
+- [ ] T14: JSON parser — New `_parse_structured_tasks()` replacing `_parse_task_list()`, returns `list[list[TaskEntry]]` in `src/fdsx/core/batch.py`
+- [ ] T15: File writer — New `write_task_files(groups, tasks_dir)` — creates numbered YAML files from groups in `src/fdsx/core/batch.py`
+- [ ] T16: Split CLI command — Add `split` command to typer app with `task-file` arg and `--force` flag in `src/fdsx/cli/main.py`
+- [ ] T17: Non-empty dir guard — Check `.fdsx/tasks/` is empty, error or clear with `--force`
+- [ ] T18: Config integration — Split command reads task_splitter config from `load_config()` instead of flow
+- [ ] T19: Unit tests — TDD: JSON parsing, file writing, non-empty dir guard in `tests/unit/test_batch.py`
+- [ ] T20: Integration test — End-to-end split with mock provider, verify file output in `tests/integration/test_split.py` (NEW)
+
+## Phase 4: Tasks-Dir Run Mode
+
+- [ ] T21: Tasks-dir loader — Read and sort task files from directory, parse each as `TaskFile` in `src/fdsx/core/engine.py`
+- [ ] T22: Status filter — Skip `completed` entries; mark `failed`/`running` as retriable in `src/fdsx/core/engine.py`
+- [ ] T23: Status persistence — After each task execution, update status + thread_id/error in YAML file in `src/fdsx/core/engine.py`
+- [ ] T24: Per-entry tracking — For multi-task files, track and update per-entry status in `src/fdsx/core/engine.py`
+- [ ] T25: Run orchestrator — `run_tasks_dir()` — iterate files, execute entries, handle errors, display summary in `src/fdsx/core/engine.py`
+- [ ] T26: CLI integration — Add `--tasks-dir` option, mutual exclusivity with `--tasks`/`--input`, make `workflow` argument optional in `src/fdsx/cli/main.py`
+- [ ] T27: Resume test — Integration test: run partial batch, simulate crash, resume and verify skip/retry logic in `tests/integration/test_tasks_dir.py` (NEW)
+- [ ] T28: Summary display — Update batch summary to show skipped (completed), retried, new tasks in `src/fdsx/core/batch.py`
+
+## Phase 5: Workflow Auto-Selection
+
+- [ ] T29: Workflow discovery — `discover_workflows(dir)` — glob `*.yaml` files, load each, return list of `(path, description)` in `src/fdsx/core/selector.py` (NEW)
+- [ ] T30: Selection prompt — Build LLM prompt with task description + workflow descriptions, request workflow filename in `src/fdsx/core/selector.py`
+- [ ] T31: Select function — `select_workflow(task_desc, workflows, config)` — single workflow = auto, multiple = LLM call in `src/fdsx/core/selector.py`
+- [ ] T32: Confirm mode UX — Present selected workflow, prompt for approval. On rejection, show full list for manual pick in `src/fdsx/cli/main.py`
+- [ ] T33: Auto mode — `--auto-workflow` flag and `auto_workflow` config — skip confirmation in `src/fdsx/cli/main.py`
+- [ ] T34: CLI flags — Add `--auto-workflow` / `--confirm-workflow` flags, CLI overrides config in `src/fdsx/cli/main.py`
+- [ ] T35: Integration with run — Wire selector into `run_tasks_dir()` for per-task workflow selection in `src/fdsx/core/engine.py`
+- [ ] T36: FR-6.3 batch confirm — In confirm mode with tasks-dir, present all workflow selections before execution
+- [ ] T37: Unit tests — TDD: discovery, selection logic, single-workflow shortcut, no-workflows error in `tests/unit/test_selector.py` (NEW)
+- [ ] T38: Integration test — End-to-end auto-selection with mock provider in `tests/integration/test_auto_select.py` (NEW)
+
+## Phase 6: Polish & Backward Compatibility
+
+- [ ] T39: Backward compat — Ensure `--tasks` (in-memory batch) still works. Reads task_splitter from config instead of flow in `src/fdsx/core/engine.py`
+- [ ] T40: Error messages — Clear errors for: no workflows found, invalid task file, no config, missing description
+- [ ] T41: Help text — Update all command help text and `--help` output in `src/fdsx/cli/main.py`
+- [ ] T42: Edge cases — Empty tasks dir, all tasks completed (no-op), single task file, invalid YAML task files
+- [ ] T43: End-to-end test — Full flow: split → edit → run → crash → resume → complete

--- a/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
+++ b/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
@@ -20,14 +20,14 @@
 
 ## Phase 3: Split Command
 
-- [ ] T13: Refactor split prompt — Update `_build_task_split_prompt()` to request JSON with dependency groups in `src/fdsx/core/batch.py`
-- [ ] T14: JSON parser — New `_parse_structured_tasks()` replacing `_parse_task_list()`, returns `list[list[TaskEntry]]` in `src/fdsx/core/batch.py`
-- [ ] T15: File writer — New `write_task_files(groups, tasks_dir)` — creates numbered YAML files from groups in `src/fdsx/core/batch.py`
-- [ ] T16: Split CLI command — Add `split` command to typer app with `task-file` arg and `--force` flag in `src/fdsx/cli/main.py`
-- [ ] T17: Non-empty dir guard — Check `.fdsx/tasks/` is empty, error or clear with `--force`
-- [ ] T18: Config integration — Split command reads task_splitter config from `load_config()` instead of flow
-- [ ] T19: Unit tests — TDD: JSON parsing, file writing, non-empty dir guard in `tests/unit/test_batch.py`
-- [ ] T20: Integration test — End-to-end split with mock provider, verify file output in `tests/integration/test_split.py` (NEW)
+- [x] T13: Refactor split prompt — Update `_build_task_split_prompt()` to request JSON with dependency groups in `src/fdsx/core/batch.py`
+- [x] T14: JSON parser — New `_parse_structured_tasks()` replacing `_parse_task_list()`, returns `list[list[TaskEntry]]` in `src/fdsx/core/batch.py`
+- [x] T15: File writer — New `write_task_files(groups, tasks_dir)` — creates numbered YAML files from groups in `src/fdsx/core/batch.py`
+- [x] T16: Split CLI command — Add `split` command to typer app with `task-file` arg and `--force` flag in `src/fdsx/cli/main.py`
+- [x] T17: Non-empty dir guard — Check `.fdsx/tasks/` is empty, error or clear with `--force`
+- [x] T18: Config integration — Split command reads task_splitter config from `load_config()` instead of flow
+- [x] T19: Unit tests — TDD: JSON parsing, file writing, non-empty dir guard in `tests/unit/test_batch.py`
+- [x] T20: Integration test — End-to-end split with mock provider, verify file output in `tests/integration/test_split.py` (NEW)
 
 ## Phase 4: Tasks-Dir Run Mode
 

--- a/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
+++ b/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
@@ -42,16 +42,16 @@
 
 ## Phase 5: Workflow Auto-Selection
 
-- [ ] T29: Workflow discovery — `discover_workflows(dir)` — glob `*.yaml` files, load each, return list of `(path, description)` in `src/fdsx/core/selector.py` (NEW)
-- [ ] T30: Selection prompt — Build LLM prompt with task description + workflow descriptions, request workflow filename in `src/fdsx/core/selector.py`
-- [ ] T31: Select function — `select_workflow(task_desc, workflows, config)` — single workflow = auto, multiple = LLM call in `src/fdsx/core/selector.py`
-- [ ] T32: Confirm mode UX — Present selected workflow, prompt for approval. On rejection, show full list for manual pick in `src/fdsx/cli/main.py`
-- [ ] T33: Auto mode — `--auto-workflow` flag and `auto_workflow` config — skip confirmation in `src/fdsx/cli/main.py`
-- [ ] T34: CLI flags — Add `--auto-workflow` / `--confirm-workflow` flags, CLI overrides config in `src/fdsx/cli/main.py`
-- [ ] T35: Integration with run — Wire selector into `run_tasks_dir()` for per-task workflow selection in `src/fdsx/core/engine.py`
-- [ ] T36: FR-6.3 batch confirm — In confirm mode with tasks-dir, present all workflow selections before execution
-- [ ] T37: Unit tests — TDD: discovery, selection logic, single-workflow shortcut, no-workflows error in `tests/unit/test_selector.py` (NEW)
-- [ ] T38: Integration test — End-to-end auto-selection with mock provider in `tests/integration/test_auto_select.py` (NEW)
+- [x] T29: Workflow discovery — `discover_workflows(dir)` — glob `*.yaml` files, load each, return list of `(path, description)` in `src/fdsx/core/selector.py` (NEW)
+- [x] T30: Selection prompt — Build LLM prompt with task description + workflow descriptions, request workflow filename in `src/fdsx/core/selector.py`
+- [x] T31: Select function — `select_workflow(task_desc, workflows, config)` — single workflow = auto, multiple = LLM call in `src/fdsx/core/selector.py`
+- [x] T32: Confirm mode UX — Present selected workflow, prompt for approval. On rejection, show full list for manual pick in `src/fdsx/cli/main.py`
+- [x] T33: Auto mode — `--auto-workflow` flag and `auto_workflow` config — skip confirmation in `src/fdsx/cli/main.py`
+- [x] T34: CLI flags — Add `--auto-workflow` / `--confirm-workflow` flags, CLI overrides config in `src/fdsx/cli/main.py`
+- [x] T35: Integration with run — Wire selector into `run_tasks_dir()` for per-task workflow selection in `src/fdsx/core/engine.py`
+- [x] T36: FR-6.3 batch confirm — In confirm mode with tasks-dir, present all workflow selections before execution
+- [x] T37: Unit tests — TDD: discovery, selection logic, single-workflow shortcut, no-workflows error in `tests/unit/test_selector.py` (NEW)
+- [x] T38: Integration test — End-to-end auto-selection with mock provider in `tests/integration/test_auto_select.py` (NEW)
 
 ## Phase 6: Polish & Backward Compatibility
 

--- a/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
+++ b/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
@@ -12,11 +12,11 @@
 
 ## Phase 2: Flow Model Changes
 
-- [ ] T8: Add description field — Add required `description: str` to `Flow` model in `src/fdsx/models/flow.py`
-- [ ] T9: Remove task_splitter — Remove `task_splitter` field from `Flow`. Handle gracefully if present in YAML (custom error) in `src/fdsx/models/flow.py`
-- [ ] T10: Update loader errors — Customize validation error for missing `description` with actionable guidance in `src/fdsx/core/loader.py`
-- [ ] T11: Update example workflow — Add `description` to `examples/workflows/plan-implement-review.yaml`
-- [ ] T12: Update tests — Fix broken tests from model changes, add tests for new validation in `tests/unit/test_models.py` and `tests/unit/test_loader.py`
+- [x] T8: Add description field — Add required `description: str` to `Flow` model in `src/fdsx/models/flow.py`
+- [x] T9: Remove task_splitter — Remove `task_splitter` field from `Flow`. Handle gracefully if present in YAML (custom error) in `src/fdsx/models/flow.py`
+- [x] T10: Update loader errors — Customize validation error for missing `description` with actionable guidance in `src/fdsx/core/loader.py`
+- [x] T11: Update example workflow — Add `description` to `examples/workflows/plan-implement-review.yaml`
+- [x] T12: Update tests — Fix broken tests from model changes, add tests for new validation in `tests/unit/test_models.py` and `tests/unit/test_loader.py`
 
 ## Phase 3: Split Command
 

--- a/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
+++ b/specs/20260319120000-batch-persistence-workflow-autoselect/tasks.md
@@ -31,14 +31,14 @@
 
 ## Phase 4: Tasks-Dir Run Mode
 
-- [ ] T21: Tasks-dir loader — Read and sort task files from directory, parse each as `TaskFile` in `src/fdsx/core/engine.py`
-- [ ] T22: Status filter — Skip `completed` entries; mark `failed`/`running` as retriable in `src/fdsx/core/engine.py`
-- [ ] T23: Status persistence — After each task execution, update status + thread_id/error in YAML file in `src/fdsx/core/engine.py`
-- [ ] T24: Per-entry tracking — For multi-task files, track and update per-entry status in `src/fdsx/core/engine.py`
-- [ ] T25: Run orchestrator — `run_tasks_dir()` — iterate files, execute entries, handle errors, display summary in `src/fdsx/core/engine.py`
-- [ ] T26: CLI integration — Add `--tasks-dir` option, mutual exclusivity with `--tasks`/`--input`, make `workflow` argument optional in `src/fdsx/cli/main.py`
-- [ ] T27: Resume test — Integration test: run partial batch, simulate crash, resume and verify skip/retry logic in `tests/integration/test_tasks_dir.py` (NEW)
-- [ ] T28: Summary display — Update batch summary to show skipped (completed), retried, new tasks in `src/fdsx/core/batch.py`
+- [x] T21: Tasks-dir loader — Read and sort task files from directory, parse each as `TaskFile` in `src/fdsx/core/engine.py`
+- [x] T22: Status filter — Skip `completed` entries; mark `failed`/`running` as retriable in `src/fdsx/core/engine.py`
+- [x] T23: Status persistence — After each task execution, update status + thread_id/error in YAML file in `src/fdsx/core/engine.py`
+- [x] T24: Per-entry tracking — For multi-task files, track and update per-entry status in `src/fdsx/core/engine.py`
+- [x] T25: Run orchestrator — `run_tasks_dir()` — iterate files, execute entries, handle errors, display summary in `src/fdsx/core/engine.py`
+- [x] T26: CLI integration — Add `--tasks-dir` option, mutual exclusivity with `--tasks`/`--input`, make `workflow` argument optional in `src/fdsx/cli/main.py`
+- [x] T27: Resume test — Integration test: run partial batch, simulate crash, resume and verify skip/retry logic in `tests/integration/test_tasks_dir.py` (NEW)
+- [x] T28: Summary display — Update batch summary to show skipped (completed), retried, new tasks in `src/fdsx/core/batch.py`
 
 ## Phase 5: Workflow Auto-Selection
 

--- a/specs/20260320120000-ux-reliability-improvements/tasks.md
+++ b/specs/20260320120000-ux-reliability-improvements/tasks.md
@@ -65,12 +65,12 @@
 **Goal**: Display the resume command on all errors and SIGINT interrupts.
 **Test criteria**: `pytest tests/unit/test_resume_display.py tests/integration/test_resume_interrupt.py -x` passes; resume command displayed on errors and Ctrl+C.
 
-- [ ] T021 [US3] TDD: Write tests for `display_resume_command` output format for single-flow, tasks-dir, and with extra args in `tests/unit/test_resume_display.py`
-- [ ] T022 [US3] Implement `display_resume_command()` in `src/fdsx/display/terminal.py` with box-formatted output showing the full resume command
-- [ ] T023 [US3] In `src/fdsx/cli/main.py` `run()`, catch exceptions from engine calls and display resume command before re-raising
-- [ ] T024 [US3] In `src/fdsx/cli/main.py` `run()`, catch `KeyboardInterrupt` from engine calls and display resume command
-- [ ] T025 [US3] For tasks-dir mode, display `fdsx run --tasks-dir <path>` instead of `fdsx resume --thread-id` (tasks-dir has built-in resume) in `src/fdsx/cli/main.py`
-- [ ] T026 [US3] Write integration tests for error and SIGINT scenarios displaying correct resume commands in `tests/integration/test_resume_interrupt.py`
+- [x] T021 [US3] TDD: Write tests for `display_resume_command` output format for single-flow, tasks-dir, and with extra args in `tests/unit/test_resume_display.py`
+- [x] T022 [US3] Implement `display_resume_command()` in `src/fdsx/display/terminal.py` with box-formatted output showing the full resume command
+- [x] T023 [US3] In `src/fdsx/cli/main.py` `run()`, catch exceptions from engine calls and display resume command before re-raising
+- [x] T024 [US3] In `src/fdsx/cli/main.py` `run()`, catch `KeyboardInterrupt` from engine calls and display resume command
+- [x] T025 [US3] For tasks-dir mode, display `fdsx run --tasks-dir <path>` instead of `fdsx resume --thread-id` (tasks-dir has built-in resume) in `src/fdsx/cli/main.py`
+- [x] T026 [US3] Write integration tests for error and SIGINT scenarios displaying correct resume commands in `tests/integration/test_resume_interrupt.py`
 
 ---
 

--- a/specs/20260320120000-ux-reliability-improvements/tasks.md
+++ b/specs/20260320120000-ux-reliability-improvements/tasks.md
@@ -49,14 +49,14 @@
 **Goal**: Replace the existing basic confirm prompt with a numbered-list interactive CUI and persist workflow assignments.
 **Test criteria**: `pytest tests/unit/test_workflow_cui.py tests/integration/test_workflow_persistence.py -x` passes; CUI displays table, accepts number input to change workflow, confirms/cancels, auto-confirms in non-TTY.
 
-- [ ] T013 [US2] TDD: Write CUI unit tests covering table display, number input to change workflow, confirm ('c'), cancel ('q'), non-TTY auto-confirm in `tests/unit/test_workflow_cui.py`
-- [ ] T014 [US2] Implement `confirm_workflow_assignments_interactive()` in `src/fdsx/display/terminal.py` — numbered table, type number to change workflow, 'c' to confirm, 'q' to cancel
-- [ ] T015 [US2] Implement unassigned task handling — tasks where auto-selection failed show "(unassigned)"; block confirm until all assigned in `src/fdsx/display/terminal.py`
-- [ ] T016 [US2] Replace `_display_batch_workflow_confirm` + raw `input()` calls in `run_tasks_dir` (`src/fdsx/core/engine.py`) with new CUI function
-- [ ] T017 [US2] Implement workflow persistence — on CUI confirmation, write `workflow` field to each task YAML via `save_task_file()` in `src/fdsx/core/engine.py`
-- [ ] T018 [US2] Verify tasks with `entry.workflow` already set skip auto-selection in `run_tasks_dir` (`src/fdsx/core/engine.py`) — add test if missing
-- [ ] T019 [US2] Implement non-TTY auto-confirm — in non-TTY mode, CUI auto-confirms and persists without interaction in `src/fdsx/display/terminal.py`
-- [ ] T020 [US2] Write end-to-end integration tests: auto-select → CUI confirm → verify YAML has workflow field → re-run skips selection in `tests/integration/test_workflow_persistence.py`
+- [x] T013 [US2] TDD: Write CUI unit tests covering table display, number input to change workflow, confirm ('c'), cancel ('q'), non-TTY auto-confirm in `tests/unit/test_workflow_cui.py`
+- [x] T014 [US2] Implement `confirm_workflow_assignments_interactive()` in `src/fdsx/display/terminal.py` — numbered table, type number to change workflow, 'c' to confirm, 'q' to cancel
+- [x] T015 [US2] Implement unassigned task handling — tasks where auto-selection failed show "(unassigned)"; block confirm until all assigned in `src/fdsx/display/terminal.py`
+- [x] T016 [US2] Replace `_display_batch_workflow_confirm` + raw `input()` calls in `run_tasks_dir` (`src/fdsx/core/engine.py`) with new CUI function
+- [x] T017 [US2] Implement workflow persistence — on CUI confirmation, write `workflow` field to each task YAML via `save_task_file()` in `src/fdsx/core/engine.py`
+- [x] T018 [US2] Verify tasks with `entry.workflow` already set skip auto-selection in `run_tasks_dir` (`src/fdsx/core/engine.py`) — add test if missing
+- [x] T019 [US2] Implement non-TTY auto-confirm — in non-TTY mode, CUI auto-confirms and persists without interaction in `src/fdsx/display/terminal.py`
+- [x] T020 [US2] Write end-to-end integration tests: auto-select → CUI confirm → verify YAML has workflow field → re-run skips selection in `tests/integration/test_workflow_persistence.py`
 
 ---
 

--- a/specs/20260320120000-ux-reliability-improvements/tasks.md
+++ b/specs/20260320120000-ux-reliability-improvements/tasks.md
@@ -38,9 +38,9 @@
 **Goal**: Wire spinner into `fdsx split` and `fdsx run` workflow auto-selection.
 **Test criteria**: `pytest tests/integration/test_split_spinner.py -x` passes; spinner starts/stops correctly during split and auto-selection.
 
-- [ ] T010 [US1] Wrap LLM call in `split_tasks_to_groups` (`src/fdsx/core/batch.py`) and `split` CLI command (`src/fdsx/cli/main.py`) with Spinner
-- [ ] T011 [US1] Wrap workflow auto-selection loop in `run_tasks_dir` (`src/fdsx/core/engine.py`) with Spinner showing progress (e.g., "Assigned workflow for 3/5 tasks...")
-- [ ] T012 [US1] Write integration tests for spinner during split and auto-selection operations in `tests/integration/test_split_spinner.py`
+- [x] T010 [US1] Wrap LLM call in `split_tasks_to_groups` (`src/fdsx/core/batch.py`) and `split` CLI command (`src/fdsx/cli/main.py`) with Spinner
+- [x] T011 [US1] Wrap workflow auto-selection loop in `run_tasks_dir` (`src/fdsx/core/engine.py`) with Spinner showing progress (e.g., "Assigned workflow for 3/5 tasks...")
+- [x] T012 [US1] Write integration tests for spinner during split and auto-selection operations in `tests/integration/test_split_spinner.py`
 
 ---
 

--- a/specs/20260320120000-ux-reliability-improvements/tasks.md
+++ b/specs/20260320120000-ux-reliability-improvements/tasks.md
@@ -79,9 +79,9 @@
 **Goal**: Ensure all features work together, edge cases handled.
 **Test criteria**: Full test suite passes (`pytest tests/ -x`); help text updated; edge cases covered.
 
-- [ ] T027 Update `--help` output for `run` and `split` commands to mention spinner and CUI behavior in `src/fdsx/cli/main.py`
-- [ ] T028 Handle edge cases: empty tasks dir, all tasks completed, spinner during zero-task split, CUI with single task — in relevant source files
-- [ ] T029 Write end-to-end test: split (with spinner) → auto-select (with spinner) → CUI confirm → persist → re-run (skip selection) → error → resume command displayed in `tests/integration/`
+- [x] T027 Update `--help` output for `run` and `split` commands to mention spinner and CUI behavior in `src/fdsx/cli/main.py`
+- [x] T028 Handle edge cases: empty tasks dir, all tasks completed, spinner during zero-task split, CUI with single task — in relevant source files
+- [x] T029 Write end-to-end test: split (with spinner) → auto-select (with spinner) → CUI confirm → persist → re-run (skip selection) → error → resume command displayed in `tests/integration/`
 
 ---
 

--- a/specs/20260320120000-ux-reliability-improvements/tasks.md
+++ b/specs/20260320120000-ux-reliability-improvements/tasks.md
@@ -1,0 +1,143 @@
+# Tasks: UX & Reliability Improvements
+
+**Feature**: UX & Reliability Improvements
+**Spec**: `specs/20260320120000-ux-reliability-improvements/spec.md`
+**Plan**: `specs/20260320120000-ux-reliability-improvements/plan.md`
+**Branch**: `feat/phase-1-config-system-task-model`
+**Generated**: 2026-03-20
+
+---
+
+## Phase 1: Bug Fixes (Template Rendering + PassState Validation)
+
+**Goal**: Fix the two bugs first — smallest scope, independent of other changes.
+**Test criteria**: `pytest tests/unit/test_variables.py -x` passes with new test cases for list/dict template rendering and PassState variable recognition.
+
+- [x] T001 TDD: Write tests for `resolve_template` with list/dict values expecting JSON output in `tests/unit/test_variables.py`
+- [x] T002 Fix template rendering in `src/fdsx/core/variables.py` — use `json.dumps(value, indent=2, ensure_ascii=False)` when value is `list` or `dict` in `resolve_template` and `resolve_template_shell_safe`
+- [x] T003 TDD: Write tests for `get_result_paths` with PassState having `parameters` and `aggregate.result_path` in `tests/unit/test_variables.py`
+- [x] T004 Add `elif isinstance(state, PassState)` branch in `get_result_paths()` in `src/fdsx/core/variables.py` to register each key in `state.parameters` and `state.aggregate.result_path`
+- [x] T005 Write integration test for `analyze_variable_references` with a flow using PassState parameters referenced by subsequent states in `tests/unit/test_variables.py`
+
+---
+
+## Phase 2: Spinner & Non-TTY Fallback
+
+**Goal**: Add animated spinner with non-TTY fallback to display module. Uses stdlib `threading.Thread` daemon + ANSI braille chars on stderr — zero new dependencies.
+**Test criteria**: `pytest tests/unit/test_spinner.py -x` passes with spinner start/stop/update, context manager, and non-TTY fallback tests.
+
+- [x] T006 TDD: Write spinner unit tests covering start/stop/update, context manager, non-TTY fallback in `tests/unit/test_spinner.py`
+- [x] T007 Implement `Spinner` class in `src/fdsx/display/terminal.py` with daemon thread, braille animation (`SPINNER_CHARS = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"`), `\r` overwrite on stderr
+- [x] T008 Implement `is_interactive()` helper function in `src/fdsx/display/terminal.py` wrapping `sys.stderr.isatty()`
+- [x] T009 Implement non-TTY mode in `Spinner` — print plain log lines instead of animation when `is_interactive()` returns False
+
+---
+
+## Phase 3: Spinner Integration (Split + Workflow Selection)
+
+**Goal**: Wire spinner into `fdsx split` and `fdsx run` workflow auto-selection.
+**Test criteria**: `pytest tests/integration/test_split_spinner.py -x` passes; spinner starts/stops correctly during split and auto-selection.
+
+- [ ] T010 [US1] Wrap LLM call in `split_tasks_to_groups` (`src/fdsx/core/batch.py`) and `split` CLI command (`src/fdsx/cli/main.py`) with Spinner
+- [ ] T011 [US1] Wrap workflow auto-selection loop in `run_tasks_dir` (`src/fdsx/core/engine.py`) with Spinner showing progress (e.g., "Assigned workflow for 3/5 tasks...")
+- [ ] T012 [US1] Write integration tests for spinner during split and auto-selection operations in `tests/integration/test_split_spinner.py`
+
+---
+
+## Phase 4: Interactive Workflow CUI & Persistence
+
+**Goal**: Replace the existing basic confirm prompt with a numbered-list interactive CUI and persist workflow assignments.
+**Test criteria**: `pytest tests/unit/test_workflow_cui.py tests/integration/test_workflow_persistence.py -x` passes; CUI displays table, accepts number input to change workflow, confirms/cancels, auto-confirms in non-TTY.
+
+- [ ] T013 [US2] TDD: Write CUI unit tests covering table display, number input to change workflow, confirm ('c'), cancel ('q'), non-TTY auto-confirm in `tests/unit/test_workflow_cui.py`
+- [ ] T014 [US2] Implement `confirm_workflow_assignments_interactive()` in `src/fdsx/display/terminal.py` — numbered table, type number to change workflow, 'c' to confirm, 'q' to cancel
+- [ ] T015 [US2] Implement unassigned task handling — tasks where auto-selection failed show "(unassigned)"; block confirm until all assigned in `src/fdsx/display/terminal.py`
+- [ ] T016 [US2] Replace `_display_batch_workflow_confirm` + raw `input()` calls in `run_tasks_dir` (`src/fdsx/core/engine.py`) with new CUI function
+- [ ] T017 [US2] Implement workflow persistence — on CUI confirmation, write `workflow` field to each task YAML via `save_task_file()` in `src/fdsx/core/engine.py`
+- [ ] T018 [US2] Verify tasks with `entry.workflow` already set skip auto-selection in `run_tasks_dir` (`src/fdsx/core/engine.py`) — add test if missing
+- [ ] T019 [US2] Implement non-TTY auto-confirm — in non-TTY mode, CUI auto-confirms and persists without interaction in `src/fdsx/display/terminal.py`
+- [ ] T020 [US2] Write end-to-end integration tests: auto-select → CUI confirm → verify YAML has workflow field → re-run skips selection in `tests/integration/test_workflow_persistence.py`
+
+---
+
+## Phase 5: Resume Command on Error & Interrupt
+
+**Goal**: Display the resume command on all errors and SIGINT interrupts.
+**Test criteria**: `pytest tests/unit/test_resume_display.py tests/integration/test_resume_interrupt.py -x` passes; resume command displayed on errors and Ctrl+C.
+
+- [ ] T021 [US3] TDD: Write tests for `display_resume_command` output format for single-flow, tasks-dir, and with extra args in `tests/unit/test_resume_display.py`
+- [ ] T022 [US3] Implement `display_resume_command()` in `src/fdsx/display/terminal.py` with box-formatted output showing the full resume command
+- [ ] T023 [US3] In `src/fdsx/cli/main.py` `run()`, catch exceptions from engine calls and display resume command before re-raising
+- [ ] T024 [US3] In `src/fdsx/cli/main.py` `run()`, catch `KeyboardInterrupt` from engine calls and display resume command
+- [ ] T025 [US3] For tasks-dir mode, display `fdsx run --tasks-dir <path>` instead of `fdsx resume --thread-id` (tasks-dir has built-in resume) in `src/fdsx/cli/main.py`
+- [ ] T026 [US3] Write integration tests for error and SIGINT scenarios displaying correct resume commands in `tests/integration/test_resume_interrupt.py`
+
+---
+
+## Phase 6: Polish & Edge Cases
+
+**Goal**: Ensure all features work together, edge cases handled.
+**Test criteria**: Full test suite passes (`pytest tests/ -x`); help text updated; edge cases covered.
+
+- [ ] T027 Update `--help` output for `run` and `split` commands to mention spinner and CUI behavior in `src/fdsx/cli/main.py`
+- [ ] T028 Handle edge cases: empty tasks dir, all tasks completed, spinner during zero-task split, CUI with single task — in relevant source files
+- [ ] T029 Write end-to-end test: split (with spinner) → auto-select (with spinner) → CUI confirm → persist → re-run (skip selection) → error → resume command displayed in `tests/integration/`
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (Bug Fixes) ──────────────────────────────────────┐
+  │                                                        │
+Phase 2 (Spinner & Non-TTY) ← independent of Phase 1,     │
+  │                            but ordered for incremental │
+  │                            delivery                    │
+  │                                                        │
+Phase 3 (Spinner Integration) ← depends on Phase 2        │
+  │                              (Spinner class)           │
+  │                                                        │
+Phase 4 (CUI & Persistence) ← depends on Phase 2          │
+  │                            (is_interactive helper)     │
+  │                                                        │
+Phase 5 (Resume Command) ← independent, but ordered       │
+  │                         after CUI for clean integration│
+  │                                                        │
+Phase 6 (Polish) ← depends on all above ──────────────────┘
+```
+
+**Story completion order**: Phase 1 → Phase 2 → Phase 3 → Phase 4 → Phase 5 → Phase 6
+
+---
+
+## Implementation Strategy
+
+1. **MVP**: Phase 1 (Bug Fixes) — immediately improves reliability with zero UX changes
+2. **Core UX**: Phase 2 + Phase 3 — spinner feedback eliminates "frozen" perception
+3. **Power UX**: Phase 4 — interactive CUI + persistence for workflow management
+4. **Resilience**: Phase 5 — resume command on errors/interrupts
+5. **Complete**: Phase 6 — polish, edge cases, end-to-end validation
+
+---
+
+## Suggested takt Usage
+
+```bash
+# Phase 1: Bug Fixes
+takt run implement "Phase 1: Fix template rendering for list/dict values and PassState variable recognition in src/fdsx/core/variables.py with TDD tests in tests/unit/test_variables.py"
+
+# Phase 2: Spinner & Non-TTY
+takt run implement "Phase 2: Implement Spinner class with daemon thread braille animation and is_interactive() helper in src/fdsx/display/terminal.py with TDD tests in tests/unit/test_spinner.py"
+
+# Phase 3: Spinner Integration
+takt run implement "Phase 3: Wire Spinner into fdsx split (src/fdsx/core/batch.py, src/fdsx/cli/main.py) and fdsx run workflow auto-selection (src/fdsx/core/engine.py) with integration tests"
+
+# Phase 4: CUI & Persistence
+takt run implement "Phase 4: Implement numbered-list CUI for workflow approval in src/fdsx/display/terminal.py, wire into engine.py, add workflow persistence via save_task_file(), with TDD tests"
+
+# Phase 5: Resume Command
+takt run implement "Phase 5: Implement display_resume_command() in src/fdsx/display/terminal.py, add error/SIGINT handling in src/fdsx/cli/main.py with TDD tests"
+
+# Phase 6: Polish
+takt run implement "Phase 6: Update help text in cli/main.py, handle edge cases (empty tasks dir, single task CUI, zero-task split), write end-to-end integration test"
+```

--- a/specs/20260320140000-provider-robustness/tasks.md
+++ b/specs/20260320140000-provider-robustness/tasks.md
@@ -44,8 +44,8 @@
 
 **Goal**: Add provider options to workflow YAML schema (`Flow`, `TaskState`, `Branch`).
 
-- [ ] T012 Write unit tests for Flow model with providers field in `tests/unit/test_models.py` — test flow with/without providers, task state with provider_options, branch with provider_options, unknown provider names accepted at parse time
-- [ ] T013 Implement `Flow.providers`, `TaskState.provider_options`, `Branch.provider_options` in `src/fdsx/models/flow.py` — `Flow.providers: dict[str, dict[str, Any]] | None`, `TaskState.provider_options: dict[str, Any] | None`, `Branch.provider_options: dict[str, Any] | None`
+- [x] T012 Write unit tests for Flow model with providers field in `tests/unit/test_models.py` — test flow with/without providers, task state with provider_options, branch with provider_options, unknown provider names accepted at parse time
+- [x] T013 Implement `Flow.providers`, `TaskState.provider_options`, `Branch.provider_options` in `src/fdsx/models/flow.py` — `Flow.providers: dict[str, dict[str, Any]] | None`, `TaskState.provider_options: dict[str, Any] | None`, `Branch.provider_options: dict[str, Any] | None`
 
 ---
 

--- a/specs/20260320140000-provider-robustness/tasks.md
+++ b/specs/20260320140000-provider-robustness/tasks.md
@@ -53,12 +53,12 @@
 
 **Goal**: Wire config merging in compiler, provider construction with options, and engine config passthrough.
 
-- [ ] T014 Write unit tests for `get_provider()` with options in `tests/unit/test_provider_options.py` — test claude/codex/opencode with and without options, system provider ignores options, unknown provider raises
-- [ ] T015 Implement `get_provider(name, options=None)` and provider constructors in `src/fdsx/providers/base.py`, `src/fdsx/providers/claude.py`, `src/fdsx/providers/codex.py`, `src/fdsx/providers/opencode.py` — add `__init__(self, options)` to each provider, modify `execute()` to append `self.options.to_cli_flags()`
-- [ ] T016 Write unit tests for `_merge_provider_options()` in `tests/unit/test_compiler_merge.py` — test config-only, workflow overrides config, task overrides workflow, full 4-level merge, all-None, different providers across levels
-- [ ] T017 Implement `_merge_provider_options()` and update `compile_flow()` in `src/fdsx/core/compiler.py` — add merge utility, accept `config: FdsxConfig | None`, modify `_create_task_node()` and `_create_branch_executor()` to resolve and pass options to `get_provider()`
-- [ ] T018 Update engine to pass config to compiler in `src/fdsx/core/engine.py` — modify `run_flow()`, `resume_flow()`, `run_batch()`, `run_tasks_dir()` to load and pass config to `compile_flow()`
-- [ ] T019 Write integration tests for end-to-end workflow with provider options in `tests/integration/test_provider_options.py` — test claude with permission_mode, config + workflow merge, task-level override, unchanged workflows without options, parallel branches with mixed providers
+- [x] T014 Write unit tests for `get_provider()` with options in `tests/unit/test_provider_options.py` — test claude/codex/opencode with and without options, system provider ignores options, unknown provider raises
+- [x] T015 Implement `get_provider(name, options=None)` and provider constructors in `src/fdsx/providers/base.py`, `src/fdsx/providers/claude.py`, `src/fdsx/providers/codex.py`, `src/fdsx/providers/opencode.py` — add `__init__(self, options)` to each provider, modify `execute()` to append `self.options.to_cli_flags()`
+- [x] T016 Write unit tests for `_merge_provider_options()` in `tests/unit/test_compiler_merge.py` — test config-only, workflow overrides config, task overrides workflow, full 4-level merge, all-None, different providers across levels
+- [x] T017 Implement `_merge_provider_options()` and update `compile_flow()` in `src/fdsx/core/compiler.py` — add merge utility, accept `config: FdsxConfig | None`, modify `_create_task_node()` and `_create_branch_executor()` to resolve and pass options to `get_provider()`
+- [x] T018 Update engine to pass config to compiler in `src/fdsx/core/engine.py` — modify `run_flow()`, `resume_flow()`, `run_batch()`, `run_tasks_dir()` to load and pass config to `compile_flow()`
+- [x] T019 Write integration tests for end-to-end workflow with provider options in `tests/integration/test_provider_options.py` — test claude with permission_mode, config + workflow merge, task-level override, unchanged workflows without options, parallel branches with mixed providers
 
 ---
 

--- a/specs/20260320140000-provider-robustness/tasks.md
+++ b/specs/20260320140000-provider-robustness/tasks.md
@@ -22,10 +22,10 @@
 
 **Goal**: Create typed Pydantic models for each provider's configuration options with `to_cli_flags()` methods.
 
-- [ ] T004 Write unit tests for `ClaudeOptions` model and `to_cli_flags()` in `tests/unit/test_provider_options.py` — test defaults, valid/invalid enum values, flag output for permission_mode, dangerously_skip_permissions, allowed_tools, disallowed_tools, empty flags, extra fields rejected
-- [ ] T005 Implement `ClaudeOptions(BaseModel)` in `src/fdsx/providers/claude.py` — fields: `permission_mode` (Literal), `dangerously_skip_permissions` (bool), `allowed_tools` (list[str]), `disallowed_tools` (list[str]), `to_cli_flags()`, `extra = "forbid"`
-- [ ] T006 [P] Write unit tests and implement `CodexOptions(BaseModel)` in `tests/unit/test_provider_options.py` and `src/fdsx/providers/codex.py` — fields: `sandbox` (Literal), `approval_policy` (Literal), `full_auto` (bool), `dangerously_bypass_approvals_and_sandbox` (bool), `to_cli_flags()`, `extra = "forbid"`
-- [ ] T007 [P] Write unit tests and implement `OpenCodeOptions(BaseModel)` in `tests/unit/test_provider_options.py` and `src/fdsx/providers/opencode.py` — empty options model with `to_cli_flags()` returning `[]`, `extra = "forbid"`
+- [x] T004 Write unit tests for `ClaudeOptions` model and `to_cli_flags()` in `tests/unit/test_provider_options.py` — test defaults, valid/invalid enum values, flag output for permission_mode, dangerously_skip_permissions, allowed_tools, disallowed_tools, empty flags, extra fields rejected
+- [x] T005 Implement `ClaudeOptions(BaseModel)` in `src/fdsx/providers/claude.py` — fields: `permission_mode` (Literal), `dangerously_skip_permissions` (bool), `allowed_tools` (list[str]), `disallowed_tools` (list[str]), `to_cli_flags()`, `extra = "forbid"`
+- [x] T006 [P] Write unit tests and implement `CodexOptions(BaseModel)` in `tests/unit/test_provider_options.py` and `src/fdsx/providers/codex.py` — fields: `sandbox` (Literal), `approval_policy` (Literal), `full_auto` (bool), `dangerously_bypass_approvals_and_sandbox` (bool), `to_cli_flags()`, `extra = "forbid"`
+- [x] T007 [P] Write unit tests and implement `OpenCodeOptions(BaseModel)` in `tests/unit/test_provider_options.py` and `src/fdsx/providers/opencode.py` — empty options model with `to_cli_flags()` returning `[]`, `extra = "forbid"`
 
 ---
 

--- a/specs/20260320140000-provider-robustness/tasks.md
+++ b/specs/20260320140000-provider-robustness/tasks.md
@@ -33,10 +33,10 @@
 
 **Goal**: Add `providers` section to `FdsxConfig` with deep merge support.
 
-- [ ] T008 Write unit tests for `_deep_merge()` utility in `tests/unit/test_config.py` — test flat dict override, nested recursive merge, scalar-to-dict override, empty override preserves base, providers merge across levels
-- [ ] T009 Implement `_deep_merge(base, override)` and update `load_config()` in `src/fdsx/core/config.py` — replace shallow dict merge with recursive deep merge
-- [ ] T010 Write unit tests for `FdsxConfig` with `providers` section in `tests/unit/test_config.py` — test valid provider options parsed, invalid enum rejected at load, extra fields rejected, deep merge across global/project, backward compatibility without providers
-- [ ] T011 Implement `ProviderConfigs(BaseModel)` and add `providers` field to `FdsxConfig` in `src/fdsx/core/config.py` — fields: `claude: ClaudeOptions | None`, `codex: CodexOptions | None`, `opencode: OpenCodeOptions | None`, `extra = "forbid"`
+- [x] T008 Write unit tests for `_deep_merge()` utility in `tests/unit/test_config.py` — test flat dict override, nested recursive merge, scalar-to-dict override, empty override preserves base, providers merge across levels
+- [x] T009 Implement `_deep_merge(base, override)` and update `load_config()` in `src/fdsx/core/config.py` — replace shallow dict merge with recursive deep merge
+- [x] T010 Write unit tests for `FdsxConfig` with `providers` section in `tests/unit/test_config.py` — test valid provider options parsed, invalid enum rejected at load, extra fields rejected, deep merge across global/project, backward compatibility without providers
+- [x] T011 Implement `ProviderConfigs(BaseModel)` and add `providers` field to `FdsxConfig` in `src/fdsx/core/config.py` — fields: `claude: ClaudeOptions | None`, `codex: CodexOptions | None`, `opencode: OpenCodeOptions | None`, `extra = "forbid"`
 
 ---
 

--- a/specs/20260320140000-provider-robustness/tasks.md
+++ b/specs/20260320140000-provider-robustness/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: Provider Robustness — ARG_MAX Fix & Permission Configuration
+
+**Feature**: Provider Robustness
+**Spec**: [spec.md](./spec.md)
+**Plan**: [impl-plan.md](./impl-plan.md)
+**Branch**: `feat/phase-1-config-system-task-model`
+**Total Tasks**: 19
+
+---
+
+## Phase 1: ARG_MAX Stdin Fallback
+
+**Goal**: Fix large command overflow in system provider by automatically piping commands >= 128KB via stdin to `sh`.
+
+- [x] T001 Write unit tests for `_run_subprocess` stdin fallback in `tests/unit/test_subprocess_stdin.py` — test small command uses `sh -c`, large command uses stdin piping, identical output/exit codes, shell features preserved, boundary at 131,072 bytes
+- [x] T002 Implement stdin fallback in `_run_subprocess()` shell=True branch in `src/fdsx/providers/base.py` — check `len(args[0].encode('utf-8')) >= 131072`, use `cmd = ['sh']` with `stdin_data = args[0]` when exceeded, add debug log
+- [x] T003 Write integration test for large command in workflow in `tests/integration/test_large_command.py` — test system provider task with command exceeding 128KB via variable interpolation completes successfully
+
+---
+
+## Phase 2: Provider Options Models
+
+**Goal**: Create typed Pydantic models for each provider's configuration options with `to_cli_flags()` methods.
+
+- [ ] T004 Write unit tests for `ClaudeOptions` model and `to_cli_flags()` in `tests/unit/test_provider_options.py` — test defaults, valid/invalid enum values, flag output for permission_mode, dangerously_skip_permissions, allowed_tools, disallowed_tools, empty flags, extra fields rejected
+- [ ] T005 Implement `ClaudeOptions(BaseModel)` in `src/fdsx/providers/claude.py` — fields: `permission_mode` (Literal), `dangerously_skip_permissions` (bool), `allowed_tools` (list[str]), `disallowed_tools` (list[str]), `to_cli_flags()`, `extra = "forbid"`
+- [ ] T006 [P] Write unit tests and implement `CodexOptions(BaseModel)` in `tests/unit/test_provider_options.py` and `src/fdsx/providers/codex.py` — fields: `sandbox` (Literal), `approval_policy` (Literal), `full_auto` (bool), `dangerously_bypass_approvals_and_sandbox` (bool), `to_cli_flags()`, `extra = "forbid"`
+- [ ] T007 [P] Write unit tests and implement `OpenCodeOptions(BaseModel)` in `tests/unit/test_provider_options.py` and `src/fdsx/providers/opencode.py` — empty options model with `to_cli_flags()` returning `[]`, `extra = "forbid"`
+
+---
+
+## Phase 3: Config System Extension
+
+**Goal**: Add `providers` section to `FdsxConfig` with deep merge support.
+
+- [ ] T008 Write unit tests for `_deep_merge()` utility in `tests/unit/test_config.py` — test flat dict override, nested recursive merge, scalar-to-dict override, empty override preserves base, providers merge across levels
+- [ ] T009 Implement `_deep_merge(base, override)` and update `load_config()` in `src/fdsx/core/config.py` — replace shallow dict merge with recursive deep merge
+- [ ] T010 Write unit tests for `FdsxConfig` with `providers` section in `tests/unit/test_config.py` — test valid provider options parsed, invalid enum rejected at load, extra fields rejected, deep merge across global/project, backward compatibility without providers
+- [ ] T011 Implement `ProviderConfigs(BaseModel)` and add `providers` field to `FdsxConfig` in `src/fdsx/core/config.py` — fields: `claude: ClaudeOptions | None`, `codex: CodexOptions | None`, `opencode: OpenCodeOptions | None`, `extra = "forbid"`
+
+---
+
+## Phase 4: Flow Model Extension
+
+**Goal**: Add provider options to workflow YAML schema (`Flow`, `TaskState`, `Branch`).
+
+- [ ] T012 Write unit tests for Flow model with providers field in `tests/unit/test_models.py` — test flow with/without providers, task state with provider_options, branch with provider_options, unknown provider names accepted at parse time
+- [ ] T013 Implement `Flow.providers`, `TaskState.provider_options`, `Branch.provider_options` in `src/fdsx/models/flow.py` — `Flow.providers: dict[str, dict[str, Any]] | None`, `TaskState.provider_options: dict[str, Any] | None`, `Branch.provider_options: dict[str, Any] | None`
+
+---
+
+## Phase 5: Provider Construction & Compiler Integration
+
+**Goal**: Wire config merging in compiler, provider construction with options, and engine config passthrough.
+
+- [ ] T014 Write unit tests for `get_provider()` with options in `tests/unit/test_provider_options.py` — test claude/codex/opencode with and without options, system provider ignores options, unknown provider raises
+- [ ] T015 Implement `get_provider(name, options=None)` and provider constructors in `src/fdsx/providers/base.py`, `src/fdsx/providers/claude.py`, `src/fdsx/providers/codex.py`, `src/fdsx/providers/opencode.py` — add `__init__(self, options)` to each provider, modify `execute()` to append `self.options.to_cli_flags()`
+- [ ] T016 Write unit tests for `_merge_provider_options()` in `tests/unit/test_compiler_merge.py` — test config-only, workflow overrides config, task overrides workflow, full 4-level merge, all-None, different providers across levels
+- [ ] T017 Implement `_merge_provider_options()` and update `compile_flow()` in `src/fdsx/core/compiler.py` — add merge utility, accept `config: FdsxConfig | None`, modify `_create_task_node()` and `_create_branch_executor()` to resolve and pass options to `get_provider()`
+- [ ] T018 Update engine to pass config to compiler in `src/fdsx/core/engine.py` — modify `run_flow()`, `resume_flow()`, `run_batch()`, `run_tasks_dir()` to load and pass config to `compile_flow()`
+- [ ] T019 Write integration tests for end-to-end workflow with provider options in `tests/integration/test_provider_options.py` — test claude with permission_mode, config + workflow merge, task-level override, unchanged workflows without options, parallel branches with mixed providers
+
+---
+
+## Dependencies
+
+```
+Phase 1 (T001-T003) ──── standalone, no dependencies
+Phase 2 (T004-T007) ──── standalone, no dependencies
+Phase 3 (T008-T011) ──── depends on Phase 2 (imports provider options models)
+Phase 4 (T012-T013) ──── standalone, no dependencies
+Phase 5 (T014-T019) ──── depends on Phase 2, 3, 4
+```
+
+**Parallel opportunities**:
+- Phase 1 and Phase 2 can run in parallel (independent)
+- Phase 4 can run in parallel with Phase 1, 2, 3 (independent)
+- Within Phase 2: T006 and T007 can run in parallel with each other (after T004-T005)
+- Within Phase 5: T014 and T016 can run in parallel (different test files)
+
+---
+
+## Implementation Strategy
+
+1. **MVP**: Phase 1 (ARG_MAX fix) — immediately solves the crash bug, zero config changes
+2. **Incremental**: Phase 2-4 build the config/model layer without touching runtime behavior
+3. **Integration**: Phase 5 wires everything together and validates end-to-end
+4. **Zero breaking changes**: All new fields are optional with None defaults; existing workflows unchanged
+
+---
+
+## Suggested takt Usage
+
+```bash
+# Phase 1: ARG_MAX Stdin Fallback
+takt run coder "Phase 1: Implement ARG_MAX stdin fallback — T001-T003. Write tests first (T001), then implement stdin fallback in _run_subprocess (T002), then integration test (T003). See specs/20260320140000-provider-robustness/impl-plan.md Phase 1."
+
+# Phase 2: Provider Options Models
+takt run coder "Phase 2: Create provider options Pydantic models — T004-T007. TDD: tests first then implementation. ClaudeOptions, CodexOptions, OpenCodeOptions with to_cli_flags(). See specs/20260320140000-provider-robustness/impl-plan.md Phase 2."
+
+# Phase 3: Config System Extension
+takt run coder "Phase 3: Extend config system with providers section — T008-T011. TDD: tests first. Add _deep_merge(), ProviderConfigs, FdsxConfig.providers. See specs/20260320140000-provider-robustness/impl-plan.md Phase 3."
+
+# Phase 4: Flow Model Extension
+takt run coder "Phase 4: Add provider options to Flow/TaskState/Branch models — T012-T013. TDD: tests first. See specs/20260320140000-provider-robustness/impl-plan.md Phase 4."
+
+# Phase 5: Provider Construction & Compiler Integration
+takt run coder "Phase 5: Wire provider options through compiler and engine — T014-T019. TDD: tests first. Modify get_provider, compile_flow, engine. Integration tests. See specs/20260320140000-provider-robustness/impl-plan.md Phase 5."
+```

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: Workflow Enhancements Bundle
+
+**Feature**: Workflow Enhancements Bundle (FR-1 through FR-5)
+**Spec**: `specs/20260321120000-workflow-enhancements/spec.md`
+**Plan**: `specs/20260321120000-workflow-enhancements/plan.md`
+**Branch**: `feat/phase-1-config-system-task-model`
+
+---
+
+## Phase 1: Setup
+
+**Goal**: No dedicated setup phase needed — this feature modifies existing infrastructure with zero new dependencies.
+
+---
+
+## Phase 2: Foundational — Runs Directory Relocation (FR-4)
+
+**Goal**: Move run storage from `runs/` to `.fdsx/runs/` with directory-based layout. This is foundational because FR-2 (streaming logs) depends on the new directory structure.
+
+**Independent Test Criteria**: Run `fdsx run` and verify run data is written to `.fdsx/runs/<thread-id>/run.json`. Verify `fdsx resume` reads from the new location. Verify old `runs/` is no longer used.
+
+- [x] T001 Update RunRecorder to directory-based layout under `.fdsx/runs/<thread-id>/run.json` in `src/fdsx/logging/recorder.py` (TDD: `tests/unit/test_recorder.py`)
+- [x] T002 Update `resume_flow` to read run data from `.fdsx/runs/<thread-id>/run.json` in `src/fdsx/core/engine.py` (TDD: `tests/unit/test_engine.py` or `tests/integration/test_resume_interrupt.py`)
+- [x] T003 [P] Update `CheckpointManager.list_threads` to scan `.fdsx/runs/` directories in `src/fdsx/checkpoint/manager.py` (TDD: `tests/unit/test_checkpoint.py`)
+- [x] T004 [P] Update `.gitignore` to add `.fdsx/runs/` and remove old `runs/` entry
+
+---
+
+## Phase 3: Simplified Completion Output (FR-1)
+
+**Goal**: Replace raw JSON dump with human-readable completion message. Suppress JSON from terminal output in all modes.
+
+**Independent Test Criteria**: Run a workflow and see `✓ Workflow 'name' completed successfully in Xs` on stderr. On failure, see `✗ Workflow 'name' failed at state 'X' — error`. No JSON printed to stdout or stderr.
+
+- [ ] T005 Add `display_completion_summary()` function to `src/fdsx/display/terminal.py` with success and failure formatting (TDD: `tests/unit/test_terminal.py`)
+- [ ] T006 Wire `display_completion_summary()` into `run_flow()` in `src/fdsx/core/engine.py` — call on success and failure paths, calculate elapsed time from recorder timestamps (TDD: `tests/unit/test_engine.py`)
+- [ ] T007 Suppress `typer.echo(json.dumps(...))` for all modes (single-flow, batch, tasks-dir) in `src/fdsx/cli/main.py` (TDD: integration test verifying no JSON on terminal)
+
+---
+
+## Phase 4: Live Agent Output Streaming + Per-State Logs (FR-2)
+
+**Goal**: Stream provider output in real-time with `[StateName]` labels to stderr; write per-state log files to `.fdsx/runs/<thread-id>/logs/`.
+
+**Independent Test Criteria**: Run a workflow and see labeled, real-time output like `[Planner] ...` on stderr. Verify per-state `.log` files exist under `.fdsx/runs/<thread-id>/logs/`. No log file created for states with no output.
+
+- [ ] T008 Refactor `_run_subprocess` in `src/fdsx/providers/base.py` to add `stderr_callback` parameter with line-by-line stderr streaming (TDD: `tests/unit/test_subprocess_stdin.py`)
+- [ ] T009 Add `stderr_callback` parameter to `execute()` in ProviderBase protocol and all providers: `src/fdsx/providers/base.py`, `claude.py`, `opencode.py`, `codex.py`, `system.py` (TDD: unit tests per provider)
+- [ ] T010 Create `StreamLogger` class in `src/fdsx/logging/stream_logger.py` with `on_stdout(line)`/`on_stderr(line)` callbacks, `[state_name]` prefixing to stderr, per-state log file writing, lazy file creation, and ANSI passthrough (TDD: `tests/unit/test_stream_logger.py`)
+- [ ] T011 Wire StreamLogger into compiler in `src/fdsx/core/compiler.py` — create StreamLogger instances in `_create_task_node` and `_create_branch_executor`, pass callbacks as `output_callback`/`stderr_callback` (TDD: integration test verifying log files and prefixed output)
+- [ ] T012 [P] Verify parallel branch labeling works correctly — each branch's StreamLogger uses its own state name, output is interleaved with distinct labels (TDD: `tests/integration/test_parallel_flow.py`)
+
+---
+
+## Phase 5: Completed Tasks Directory (FR-3)
+
+**Goal**: Move successful task files to `tasks/completed/`; scan both directories for next index.
+
+**Independent Test Criteria**: After batch run, completed task files are in `tasks/completed/`. Failed tasks remain in `tasks/`. New task index scans both directories. Collision raises error, move failure logs warning but doesn't abort.
+
+- [ ] T013 Add `move_task_to_completed()` utility in `src/fdsx/core/batch.py` — auto-create `tasks/completed/`, collision detection, warning on failure (TDD: `tests/unit/test_batch.py`)
+- [ ] T014 Wire `move_task_to_completed()` into `run_tasks_dir` loop in `src/fdsx/core/engine.py` — move file only when ALL entries have status="completed" (TDD: `tests/integration/test_tasks_dir.py`)
+- [ ] T015 Update task index scanning in `src/fdsx/core/batch.py` to scan both `tasks/` and `tasks/completed/` for max existing index in `write_task_files` (TDD: `tests/unit/test_batch.py`)
+
+---
+
+## Phase 6: Hooks System — Models & Config (FR-5, part 1)
+
+**Goal**: Define hook data models and add hooks fields to Flow, state types, and FdsxConfig.
+
+**Independent Test Criteria**: Hook models validate correctly. YAML with `hooks` field parses without error on Flow and all state types. Config merging handles hooks with list concatenation.
+
+- [ ] T016 Define `HookEntry` and `HookConfig` Pydantic models in `src/fdsx/models/flow.py` (TDD: `tests/unit/test_models.py`)
+- [ ] T017 [P] Add `hooks: HookConfig | None = None` field to `Flow`, `TaskState`, `ChoiceState`, `ParallelState`, `PassState`, `WaitState` in `src/fdsx/models/flow.py` (TDD: `tests/unit/test_models.py`)
+- [ ] T018 [P] Add `hooks: HookConfig | None = None` to `FdsxConfig` in `src/fdsx/core/config.py` with correct `_deep_merge` handling for hook list concatenation (TDD: `tests/unit/test_config.py`)
+
+---
+
+## Phase 7: Hooks System — Executor & Collector (FR-5, part 2)
+
+**Goal**: Implement hook execution engine and multi-level hook collection.
+
+**Independent Test Criteria**: Hook commands execute with correct positional args and env vars. Abort-on-failure stops execution. Warn-on-failure logs and continues. Hooks collected in correct order: global → project → flow → state.
+
+- [ ] T019 Create hook executor `execute_hooks()` in `src/fdsx/core/hooks.py` — iterate hooks, set env vars (FDSX_STATE_NAME, FDSX_STATUS, FDSX_DATA_PATH, FDSX_THREAD_ID, FDSX_FLOW_NAME), run subprocess, handle abort/warn failure policies (TDD: `tests/unit/test_hooks.py`)
+- [ ] T020 Add hook data file generation in `src/fdsx/core/hooks.py` — write per-state JSON to `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` and `output.json` with `0o600`/`0o700` permissions (TDD: `tests/unit/test_hooks.py`)
+- [ ] T021 Create hook collector `collect_hooks()` in `src/fdsx/core/hooks.py` — merge hooks across global → project → flow → state levels, return concatenated list (TDD: `tests/unit/test_hooks.py`)
+
+---
+
+## Phase 8: Hooks System — Wiring (FR-5, part 3)
+
+**Goal**: Wire hooks into the compiler via wrapper/decorator pattern.
+
+**Independent Test Criteria**: End-to-end flow with hooks configured at multiple levels fires hooks in correct order. Abort-hook failure halts workflow. Warn-hook failure continues. ParallelState hooks wrap dispatch/collector, not individual branches.
+
+- [ ] T022 Create `_wrap_with_hooks()` in `src/fdsx/core/compiler.py` — wrapper function that calls `execute_hooks(on_start)` before node execution and `execute_hooks(on_complete)` after (TDD: `tests/integration/test_hooks_integration.py`)
+- [ ] T023 Apply `_wrap_with_hooks()` in `compile_flow()` for all node types in `src/fdsx/core/compiler.py` — use `collect_hooks()` at compile time, handle ParallelState dispatch/collector wrapping (TDD: `tests/integration/test_hooks_integration.py`)
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Goal**: Final integration verification and cleanup.
+
+- [ ] T024 Run full test suite (`uv run pytest tests/ -x`) and fix any regressions across all phases
+- [ ] T025 Manual smoke test: run a multi-state workflow and verify all features work together — completion message, streaming labels, log files, run directory layout
+- [ ] T026 [P] Verify hook + streaming interaction: hooks fire correctly around states that produce streaming output
+
+---
+
+## Dependencies
+
+```
+Phase 2 (FR-4: Runs Relocation)
+  └── Phase 3 (FR-1: Completion Output) — depends on new run directory for JSON writes
+  └── Phase 4 (FR-2: Streaming) — depends on new run directory for log files
+        └── Phase 8 (FR-5 wiring) — hooks wrap nodes that now have streaming
+
+Phase 5 (FR-3: Completed Tasks) — independent, can run after Phase 2
+
+Phase 6 (FR-5 models) → Phase 7 (FR-5 executor) → Phase 8 (FR-5 wiring)
+```
+
+## Parallel Execution Opportunities
+
+Within each phase, tasks marked `[P]` can run in parallel with the preceding task:
+- **Phase 2**: T003 and T004 can run in parallel after T002
+- **Phase 4**: T012 can run in parallel with T011
+- **Phase 5**: All 3 tasks are sequential (dependency chain)
+- **Phase 6**: T017 and T018 can run in parallel after T016
+
+## Implementation Strategy
+
+1. **MVP**: Phase 2 + Phase 3 (runs relocation + completion output) — immediate usability improvement
+2. **Incremental**: Phase 4 (streaming) adds real-time visibility
+3. **Independent**: Phase 5 (completed tasks) can be done at any point after Phase 2
+4. **Complex last**: Phases 6-8 (hooks) build incrementally on each other
+
+## Suggested takt Usage
+
+```bash
+# Phase 2: Runs Directory Relocation
+takt run coder "Implement FR-4: Update RunRecorder, resume_flow, and CheckpointManager to use .fdsx/runs/ directory-based layout (T001-T004)"
+
+# Phase 3: Simplified Completion Output
+takt run coder "Implement FR-1: Add display_completion_summary, wire into engine, suppress JSON output (T005-T007)"
+
+# Phase 4: Live Agent Output Streaming
+takt run coder "Implement FR-2: Add stderr streaming to providers, create StreamLogger, wire into compiler (T008-T012)"
+
+# Phase 5: Completed Tasks Directory
+takt run coder "Implement FR-3: Add move_task_to_completed, wire into run_tasks_dir, update index scanning (T013-T015)"
+
+# Phase 6: Hooks Models & Config
+takt run coder "Implement FR-5 models: Define HookEntry/HookConfig, add hooks field to Flow/states/config (T016-T018)"
+
+# Phase 7: Hooks Executor & Collector
+takt run coder "Implement FR-5 executor: Create execute_hooks, hook data files, collect_hooks (T019-T021)"
+
+# Phase 8: Hooks Wiring
+takt run coder "Implement FR-5 wiring: Create _wrap_with_hooks, apply in compile_flow for all node types (T022-T023)"
+
+# Phase 9: Polish
+takt run coder "Run full test suite, manual smoke test, verify hook+streaming interaction (T024-T026)"
+```
+
+## Summary
+
+- **Total tasks**: 26
+- **Phase 2 (FR-4 Runs Relocation)**: 4 tasks
+- **Phase 3 (FR-1 Completion Output)**: 3 tasks
+- **Phase 4 (FR-2 Streaming)**: 5 tasks
+- **Phase 5 (FR-3 Completed Tasks)**: 3 tasks
+- **Phase 6 (FR-5 Models)**: 3 tasks
+- **Phase 7 (FR-5 Executor)**: 3 tasks
+- **Phase 8 (FR-5 Wiring)**: 2 tasks
+- **Phase 9 (Polish)**: 3 tasks

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -103,9 +103,9 @@
 
 **Goal**: Final integration verification and cleanup.
 
-- [ ] T024 Run full test suite (`uv run pytest tests/ -x`) and fix any regressions across all phases
-- [ ] T025 Manual smoke test: run a multi-state workflow and verify all features work together — completion message, streaming labels, log files, run directory layout
-- [ ] T026 [P] Verify hook + streaming interaction: hooks fire correctly around states that produce streaming output
+- [x] T024 Run full test suite (`uv run pytest tests/ -x`) and fix any regressions across all phases
+- [x] T025 Manual smoke test: run a multi-state workflow and verify all features work together — completion message, streaming labels, log files, run directory layout
+- [x] T026 [P] Verify hook + streaming interaction: hooks fire correctly around states that produce streaming output
 
 ---
 

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -58,9 +58,9 @@
 
 **Independent Test Criteria**: After batch run, completed task files are in `tasks/completed/`. Failed tasks remain in `tasks/`. New task index scans both directories. Collision raises error, move failure logs warning but doesn't abort.
 
-- [ ] T013 Add `move_task_to_completed()` utility in `src/fdsx/core/batch.py` — auto-create `tasks/completed/`, collision detection, warning on failure (TDD: `tests/unit/test_batch.py`)
-- [ ] T014 Wire `move_task_to_completed()` into `run_tasks_dir` loop in `src/fdsx/core/engine.py` — move file only when ALL entries have status="completed" (TDD: `tests/integration/test_tasks_dir.py`)
-- [ ] T015 Update task index scanning in `src/fdsx/core/batch.py` to scan both `tasks/` and `tasks/completed/` for max existing index in `write_task_files` (TDD: `tests/unit/test_batch.py`)
+- [x] T013 Add `move_task_to_completed()` utility in `src/fdsx/core/batch.py` — auto-create `tasks/completed/`, collision detection, warning on failure (TDD: `tests/unit/test_batch.py`)
+- [x] T014 Wire `move_task_to_completed()` into `run_tasks_dir` loop in `src/fdsx/core/engine.py` — move file only when ALL entries have status="completed" (TDD: `tests/integration/test_tasks_dir.py`)
+- [x] T015 Update task index scanning in `src/fdsx/core/batch.py` to scan both `tasks/` and `tasks/completed/` for max existing index in `write_task_files` (TDD: `tests/unit/test_batch.py`)
 
 ---
 

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -82,9 +82,9 @@
 
 **Independent Test Criteria**: Hook commands execute with correct positional args and env vars. Abort-on-failure stops execution. Warn-on-failure logs and continues. Hooks collected in correct order: global → project → flow → state.
 
-- [ ] T019 Create hook executor `execute_hooks()` in `src/fdsx/core/hooks.py` — iterate hooks, set env vars (FDSX_STATE_NAME, FDSX_STATUS, FDSX_DATA_PATH, FDSX_THREAD_ID, FDSX_FLOW_NAME), run subprocess, handle abort/warn failure policies (TDD: `tests/unit/test_hooks.py`)
-- [ ] T020 Add hook data file generation in `src/fdsx/core/hooks.py` — write per-state JSON to `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` and `output.json` with `0o600`/`0o700` permissions (TDD: `tests/unit/test_hooks.py`)
-- [ ] T021 Create hook collector `collect_hooks()` in `src/fdsx/core/hooks.py` — merge hooks across global → project → flow → state levels, return concatenated list (TDD: `tests/unit/test_hooks.py`)
+- [x] T019 Create hook executor `execute_hooks()` in `src/fdsx/core/hooks.py` — iterate hooks, set env vars (FDSX_STATE_NAME, FDSX_STATUS, FDSX_DATA_PATH, FDSX_THREAD_ID, FDSX_FLOW_NAME), run subprocess, handle abort/warn failure policies (TDD: `tests/unit/test_hooks.py`)
+- [x] T020 Add hook data file generation in `src/fdsx/core/hooks.py` — write per-state JSON to `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` and `output.json` with `0o600`/`0o700` permissions (TDD: `tests/unit/test_hooks.py`)
+- [x] T021 Create hook collector `collect_hooks()` in `src/fdsx/core/hooks.py` — merge hooks across global → project → flow → state levels, return concatenated list (TDD: `tests/unit/test_hooks.py`)
 
 ---
 

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -44,11 +44,11 @@
 
 **Independent Test Criteria**: Run a workflow and see labeled, real-time output like `[Planner] ...` on stderr. Verify per-state `.log` files exist under `.fdsx/runs/<thread-id>/logs/`. No log file created for states with no output.
 
-- [ ] T008 Refactor `_run_subprocess` in `src/fdsx/providers/base.py` to add `stderr_callback` parameter with line-by-line stderr streaming (TDD: `tests/unit/test_subprocess_stdin.py`)
-- [ ] T009 Add `stderr_callback` parameter to `execute()` in ProviderBase protocol and all providers: `src/fdsx/providers/base.py`, `claude.py`, `opencode.py`, `codex.py`, `system.py` (TDD: unit tests per provider)
-- [ ] T010 Create `StreamLogger` class in `src/fdsx/logging/stream_logger.py` with `on_stdout(line)`/`on_stderr(line)` callbacks, `[state_name]` prefixing to stderr, per-state log file writing, lazy file creation, and ANSI passthrough (TDD: `tests/unit/test_stream_logger.py`)
-- [ ] T011 Wire StreamLogger into compiler in `src/fdsx/core/compiler.py` — create StreamLogger instances in `_create_task_node` and `_create_branch_executor`, pass callbacks as `output_callback`/`stderr_callback` (TDD: integration test verifying log files and prefixed output)
-- [ ] T012 [P] Verify parallel branch labeling works correctly — each branch's StreamLogger uses its own state name, output is interleaved with distinct labels (TDD: `tests/integration/test_parallel_flow.py`)
+- [x] T008 Refactor `_run_subprocess` in `src/fdsx/providers/base.py` to add `stderr_callback` parameter with line-by-line stderr streaming (TDD: `tests/unit/test_subprocess_stdin.py`)
+- [x] T009 Add `stderr_callback` parameter to `execute()` in ProviderBase protocol and all providers: `src/fdsx/providers/base.py`, `claude.py`, `opencode.py`, `codex.py`, `system.py` (TDD: unit tests per provider)
+- [x] T010 Create `StreamLogger` class in `src/fdsx/logging/stream_logger.py` with `on_stdout(line)`/`on_stderr(line)` callbacks, `[state_name]` prefixing to stderr, per-state log file writing, lazy file creation, and ANSI passthrough (TDD: `tests/unit/test_stream_logger.py`)
+- [x] T011 Wire StreamLogger into compiler in `src/fdsx/core/compiler.py` — create StreamLogger instances in `_create_task_node` and `_create_branch_executor`, pass callbacks as `output_callback`/`stderr_callback` (TDD: integration test verifying log files and prefixed output)
+- [x] T012 [P] Verify parallel branch labeling works correctly — each branch's StreamLogger uses its own state name, output is interleaved with distinct labels (TDD: `tests/integration/test_parallel_flow.py`)
 
 ---
 

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -94,8 +94,8 @@
 
 **Independent Test Criteria**: End-to-end flow with hooks configured at multiple levels fires hooks in correct order. Abort-hook failure halts workflow. Warn-hook failure continues. ParallelState hooks wrap dispatch/collector, not individual branches.
 
-- [ ] T022 Create `_wrap_with_hooks()` in `src/fdsx/core/compiler.py` — wrapper function that calls `execute_hooks(on_start)` before node execution and `execute_hooks(on_complete)` after (TDD: `tests/integration/test_hooks_integration.py`)
-- [ ] T023 Apply `_wrap_with_hooks()` in `compile_flow()` for all node types in `src/fdsx/core/compiler.py` — use `collect_hooks()` at compile time, handle ParallelState dispatch/collector wrapping (TDD: `tests/integration/test_hooks_integration.py`)
+- [x] T022 Create `_wrap_with_hooks()` in `src/fdsx/core/compiler.py` — wrapper function that calls `execute_hooks(on_start)` before node execution and `execute_hooks(on_complete)` after (TDD: `tests/integration/test_hooks_integration.py`)
+- [x] T023 Apply `_wrap_with_hooks()` in `compile_flow()` for all node types in `src/fdsx/core/compiler.py` — use `collect_hooks()` at compile time, handle ParallelState dispatch/collector wrapping (TDD: `tests/integration/test_hooks_integration.py`)
 
 ---
 

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -32,9 +32,9 @@
 
 **Independent Test Criteria**: Run a workflow and see `✓ Workflow 'name' completed successfully in Xs` on stderr. On failure, see `✗ Workflow 'name' failed at state 'X' — error`. No JSON printed to stdout or stderr.
 
-- [ ] T005 Add `display_completion_summary()` function to `src/fdsx/display/terminal.py` with success and failure formatting (TDD: `tests/unit/test_terminal.py`)
-- [ ] T006 Wire `display_completion_summary()` into `run_flow()` in `src/fdsx/core/engine.py` — call on success and failure paths, calculate elapsed time from recorder timestamps (TDD: `tests/unit/test_engine.py`)
-- [ ] T007 Suppress `typer.echo(json.dumps(...))` for all modes (single-flow, batch, tasks-dir) in `src/fdsx/cli/main.py` (TDD: integration test verifying no JSON on terminal)
+- [x] T005 Add `display_completion_summary()` function to `src/fdsx/display/terminal.py` with success and failure formatting (TDD: `tests/unit/test_terminal.py`)
+- [x] T006 Wire `display_completion_summary()` into `run_flow()` in `src/fdsx/core/engine.py` — call on success and failure paths, calculate elapsed time from recorder timestamps (TDD: `tests/unit/test_engine.py`)
+- [x] T007 Suppress `typer.echo(json.dumps(...))` for all modes (single-flow, batch, tasks-dir) in `src/fdsx/cli/main.py` (TDD: integration test verifying no JSON on terminal)
 
 ---
 

--- a/specs/20260321120000-workflow-enhancements/tasks.md
+++ b/specs/20260321120000-workflow-enhancements/tasks.md
@@ -70,9 +70,9 @@
 
 **Independent Test Criteria**: Hook models validate correctly. YAML with `hooks` field parses without error on Flow and all state types. Config merging handles hooks with list concatenation.
 
-- [ ] T016 Define `HookEntry` and `HookConfig` Pydantic models in `src/fdsx/models/flow.py` (TDD: `tests/unit/test_models.py`)
-- [ ] T017 [P] Add `hooks: HookConfig | None = None` field to `Flow`, `TaskState`, `ChoiceState`, `ParallelState`, `PassState`, `WaitState` in `src/fdsx/models/flow.py` (TDD: `tests/unit/test_models.py`)
-- [ ] T018 [P] Add `hooks: HookConfig | None = None` to `FdsxConfig` in `src/fdsx/core/config.py` with correct `_deep_merge` handling for hook list concatenation (TDD: `tests/unit/test_config.py`)
+- [x] T016 Define `HookEntry` and `HookConfig` Pydantic models in `src/fdsx/models/flow.py` (TDD: `tests/unit/test_models.py`)
+- [x] T017 [P] Add `hooks: HookConfig | None = None` field to `Flow`, `TaskState`, `ChoiceState`, `ParallelState`, `PassState`, `WaitState` in `src/fdsx/models/flow.py` (TDD: `tests/unit/test_models.py`)
+- [x] T018 [P] Add `hooks: HookConfig | None = None` to `FdsxConfig` in `src/fdsx/core/config.py` with correct `_deep_merge` handling for hook list concatenation (TDD: `tests/unit/test_config.py`)
 
 ---
 

--- a/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
+++ b/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
@@ -1,0 +1,143 @@
+# Tasks: UUIDv7 Run IDs & Realtime Provider Streaming
+
+**Feature:** UUIDv7 Run IDs & Realtime Provider Streaming
+**Spec:** `specs/20260321133916-uuidv7-realtime-streaming/spec.md`
+**Plan:** `specs/20260321133916-uuidv7-realtime-streaming/impl-plan.md`
+**Generated:** 2026-03-21
+
+---
+
+## Phase 1: UUIDv7 Run IDs (FR-1.1–FR-1.6)
+
+**Goal:** Replace UUIDv4 with UUIDv7 for time-sortable run IDs.
+**Test criteria:** Generated IDs are valid UUIDv7, sort chronologically, and pass existing `THREAD_ID_PATTERN` validation. All existing tests pass without modification.
+
+- [x] T001 Add `uuid-utils` dependency to `pyproject.toml`
+- [x] T002 Write TDD tests for UUIDv7 generation in `tests/unit/test_uuidv7.py` — valid UUID format, version nibble = 7, sequential sort correctness, THREAD_ID_PATTERN acceptance
+- [x] T003 Replace `uuid.uuid4()` with `uuid_utils.uuid7()` at all 4 generation points in `src/fdsx/cli/main.py` and `src/fdsx/core/engine.py`
+- [x] T004 Verify full test suite passes with UUIDv7 IDs — no regressions in CheckpointManager, RunRecorder, resume_flow
+
+---
+
+## Phase 2: Claude Provider JSON Streaming (FR-2.1–FR-2.9)
+
+**Goal:** Enable realtime token-level streaming from Claude CLI via `stream-json` format.
+**Test criteria:** Stream parser correctly extracts text_delta, thinking_delta, tool_use events. ProviderResult.stdout matches expected final text from `result` event. Malformed JSON lines are skipped gracefully.
+
+- [ ] T005 Record real Claude stream-json fixture — run `claude -p "Say hello and list 3 items" --output-format stream-json --verbose --include-partial-messages` and save to `tests/fixtures/claude_stream.ndjson`
+- [ ] T006 Write TDD tests for Claude stream parser in `tests/unit/test_claude_stream_parser.py` — text_delta, thinking_delta, tool_use content_block_start, result event stdout extraction, malformed JSON skip, missing result fallback, non-streaming event ignore
+- [ ] T007 Implement Claude stream line parser `_make_stream_callback()` in `src/fdsx/providers/claude.py` — closure that parses each JSON line and dispatches to output_callback
+- [ ] T008 Wire streaming flags in Claude provider `execute()` in `src/fdsx/providers/claude.py` — add `--output-format stream-json --verbose --include-partial-messages` when output_callback provided, return ProviderResult with stdout from result event
+- [ ] T009 Write integration test for Claude streaming end-to-end in `tests/integration/test_claude_streaming.py` — mocked subprocess replaying fixture, verify callbacks and ProviderResult.stdout
+
+---
+
+## Phase 3: Codex Provider JSONL Streaming (FR-4.1–FR-4.10)
+
+**Goal:** Enable event-level streaming from Codex CLI via `--json` JSONL format.
+**Test criteria:** Stream parser correctly extracts agent_message, reasoning, command_execution, file_change, mcp_tool_call events. ProviderResult.stdout matches concatenated agent_message texts. Malformed JSON and turn.failed handled gracefully.
+
+- [ ] T010 Record real Codex JSONL fixture — run `codex exec --json "Say hello"` and save to `tests/fixtures/codex_stream.jsonl`
+- [ ] T011 Write TDD tests for Codex stream parser in `tests/unit/test_codex_stream_parser.py` — agent_message completed, reasoning completed, command_execution started, file_change started, mcp_tool_call started, turn.failed warning, malformed JSON skip, multiple agent_message concatenation, partial collection on crash
+- [ ] T012 Implement Codex stream line parser `_make_stream_callback()` in `src/fdsx/providers/codex.py`
+- [ ] T013 Wire streaming flags in Codex provider `execute()` in `src/fdsx/providers/codex.py` — add `--json` when output_callback provided, reconstruct stdout from accumulated agent_message texts
+- [ ] T014 Write integration test for Codex streaming end-to-end in `tests/integration/test_codex_streaming.py` — mocked subprocess replaying fixture
+
+---
+
+## Phase 4: StreamLogger Quiet Mode (FR-5.1–FR-5.4)
+
+**Goal:** Add `--quiet` flag that suppresses stderr streaming output while keeping log file writes and completion summary.
+**Test criteria:** `quiet=True` suppresses stderr print but log file content is identical to non-quiet mode. CLI `--quiet` flag wires through engine/compiler to StreamLogger.
+
+- [ ] T015 Write TDD tests for StreamLogger quiet mode in `tests/unit/test_stream_logger.py` — quiet=False default behavior, quiet=True no stderr print, quiet=True log file content matches
+- [ ] T016 Add `quiet: bool = False` parameter to StreamLogger `__init__` in `src/fdsx/logging/stream_logger.py` — guard `print()` calls with `if not self.quiet`
+- [ ] T017 Add `--quiet` flag to CLI `run` command in `src/fdsx/cli/main.py` — pass quiet value through to engine
+- [ ] T018 Wire quiet flag through compiler to StreamLogger — accept `quiet` in `src/fdsx/core/compiler.py` `compile_flow()` and `src/fdsx/core/engine.py` `run_flow()`, pass to StreamLogger construction
+- [ ] T019 Write integration test for quiet mode end-to-end in `tests/integration/test_quiet_mode.py` — `--quiet` suppresses stderr, log files written, completion summary still prints
+
+---
+
+## Phase 5: Verification & Polish
+
+**Goal:** Ensure no regressions across the full test suite and verify with real providers.
+
+- [ ] T020 Run full test suite, fix any regressions
+- [ ] T021 Verify existing integration tests still pass — linear, choice, parallel, checkpoint, batch flows
+- [ ] T022 Manual verification with real providers (if available) — Claude streaming, Codex streaming, quiet mode
+
+---
+
+## Dependencies
+
+```
+Phase 1 (UUIDv7) ──────────────────────────────────────┐
+                                                        ├── Phase 5 (Verification)
+Phase 2 (Claude Streaming) ─────────────────────────────┤
+                                                        │
+Phase 3 (Codex Streaming) ──────────────────────────────┤
+                                                        │
+Phase 4 (Quiet Mode) ──────────────────────────────────-┘
+```
+
+- **Phase 1** is independent — can start immediately
+- **Phases 2, 3, 4** are independent of each other — can be worked in parallel
+- **Phase 5** depends on all previous phases completing
+
+Within each phase, tasks are sequential (TDD: tests → implementation → integration test).
+
+---
+
+## Parallel Execution Opportunities
+
+- **Cross-phase**: Phases 1–4 can be executed in parallel (different files, no dependencies)
+- **Within Phase 2**: T005 (fixture recording) is a prerequisite for T006–T009
+- **Within Phase 3**: T010 (fixture recording) is a prerequisite for T011–T014
+- **Within Phase 4**: T015 (tests) → T016–T018 (implementation) → T019 (integration)
+
+---
+
+## Implementation Strategy
+
+1. **MVP**: Phase 1 (UUIDv7) — smallest, self-contained, immediate user value
+2. **High-value next**: Phase 2 (Claude streaming) — most impactful streaming improvement (token-level)
+3. **Incremental**: Phase 3 (Codex streaming) — event-level streaming, lower impact but completes provider coverage
+4. **Polish**: Phase 4 (Quiet mode) — UX refinement for CI/scripted usage
+5. **Verify**: Phase 5 — full regression sweep
+
+---
+
+## Suggested takt Usage
+
+```bash
+# Phase 1: UUIDv7 Run IDs
+takt run code "Phase 1: Add uuid-utils dependency, write UUIDv7 TDD tests, replace uuid4 with uuid7 at all generation points, verify no regressions"
+
+# Phase 2: Claude Provider JSON Streaming
+takt run code "Phase 2: Record Claude stream-json fixture, write TDD tests for stream parser, implement _make_stream_callback and wire streaming flags in Claude provider, write integration test"
+
+# Phase 3: Codex Provider JSONL Streaming
+takt run code "Phase 3: Record Codex JSONL fixture, write TDD tests for Codex stream parser, implement _make_stream_callback and wire --json flag in Codex provider, write integration test"
+
+# Phase 4: StreamLogger Quiet Mode
+takt run code "Phase 4: Write TDD tests for StreamLogger quiet mode, add quiet param to StreamLogger, add --quiet CLI flag, wire quiet through compiler/engine, write integration test"
+
+# Phase 5: Verification & Polish
+takt run code "Phase 5: Run full test suite, verify all existing integration tests pass, manual verification with real providers"
+```
+
+---
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total tasks | 22 |
+| Phase 1 (UUIDv7) | 4 tasks |
+| Phase 2 (Claude Streaming) | 5 tasks |
+| Phase 3 (Codex Streaming) | 5 tasks |
+| Phase 4 (Quiet Mode) | 5 tasks |
+| Phase 5 (Verification) | 3 tasks |
+| Parallel phases | Phases 1–4 (independent) |
+| MVP scope | Phase 1 only |
+| Format validation | All 22 tasks follow checklist format (checkbox, ID, description, file paths) |

--- a/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
+++ b/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
@@ -50,11 +50,11 @@
 **Goal:** Add `--quiet` flag that suppresses stderr streaming output while keeping log file writes and completion summary.
 **Test criteria:** `quiet=True` suppresses stderr print but log file content is identical to non-quiet mode. CLI `--quiet` flag wires through engine/compiler to StreamLogger.
 
-- [ ] T015 Write TDD tests for StreamLogger quiet mode in `tests/unit/test_stream_logger.py` — quiet=False default behavior, quiet=True no stderr print, quiet=True log file content matches
-- [ ] T016 Add `quiet: bool = False` parameter to StreamLogger `__init__` in `src/fdsx/logging/stream_logger.py` — guard `print()` calls with `if not self.quiet`
-- [ ] T017 Add `--quiet` flag to CLI `run` command in `src/fdsx/cli/main.py` — pass quiet value through to engine
-- [ ] T018 Wire quiet flag through compiler to StreamLogger — accept `quiet` in `src/fdsx/core/compiler.py` `compile_flow()` and `src/fdsx/core/engine.py` `run_flow()`, pass to StreamLogger construction
-- [ ] T019 Write integration test for quiet mode end-to-end in `tests/integration/test_quiet_mode.py` — `--quiet` suppresses stderr, log files written, completion summary still prints
+- [x] T015 Write TDD tests for StreamLogger quiet mode in `tests/unit/test_stream_logger.py` — quiet=False default behavior, quiet=True no stderr print, quiet=True log file content matches
+- [x] T016 Add `quiet: bool = False` parameter to StreamLogger `__init__` in `src/fdsx/logging/stream_logger.py` — guard `print()` calls with `if not self.quiet`
+- [x] T017 Add `--quiet` flag to CLI `run` command in `src/fdsx/cli/main.py` — pass quiet value through to engine
+- [x] T018 Wire quiet flag through compiler to StreamLogger — accept `quiet` in `src/fdsx/core/compiler.py` `compile_flow()` and `src/fdsx/core/engine.py` `run_flow()`, pass to StreamLogger construction
+- [x] T019 Write integration test for quiet mode end-to-end in `tests/integration/test_quiet_mode.py` — `--quiet` suppresses stderr, log files written, completion summary still prints
 
 ---
 

--- a/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
+++ b/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
@@ -62,8 +62,8 @@
 
 **Goal:** Ensure no regressions across the full test suite and verify with real providers.
 
-- [ ] T020 Run full test suite, fix any regressions
-- [ ] T021 Verify existing integration tests still pass — linear, choice, parallel, checkpoint, batch flows
+- [x] T020 Run full test suite, fix any regressions
+- [x] T021 Verify existing integration tests still pass — linear, choice, parallel, checkpoint, batch flows
 - [ ] T022 Manual verification with real providers (if available) — Claude streaming, Codex streaming, quiet mode
 
 ---

--- a/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
+++ b/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
@@ -24,11 +24,11 @@
 **Goal:** Enable realtime token-level streaming from Claude CLI via `stream-json` format.
 **Test criteria:** Stream parser correctly extracts text_delta, thinking_delta, tool_use events. ProviderResult.stdout matches expected final text from `result` event. Malformed JSON lines are skipped gracefully.
 
-- [ ] T005 Record real Claude stream-json fixture — run `claude -p "Say hello and list 3 items" --output-format stream-json --verbose --include-partial-messages` and save to `tests/fixtures/claude_stream.ndjson`
-- [ ] T006 Write TDD tests for Claude stream parser in `tests/unit/test_claude_stream_parser.py` — text_delta, thinking_delta, tool_use content_block_start, result event stdout extraction, malformed JSON skip, missing result fallback, non-streaming event ignore
-- [ ] T007 Implement Claude stream line parser `_make_stream_callback()` in `src/fdsx/providers/claude.py` — closure that parses each JSON line and dispatches to output_callback
-- [ ] T008 Wire streaming flags in Claude provider `execute()` in `src/fdsx/providers/claude.py` — add `--output-format stream-json --verbose --include-partial-messages` when output_callback provided, return ProviderResult with stdout from result event
-- [ ] T009 Write integration test for Claude streaming end-to-end in `tests/integration/test_claude_streaming.py` — mocked subprocess replaying fixture, verify callbacks and ProviderResult.stdout
+- [x] T005 Record real Claude stream-json fixture — run `claude -p "Say hello and list 3 items" --output-format stream-json --verbose --include-partial-messages` and save to `tests/fixtures/claude_stream.ndjson`
+- [x] T006 Write TDD tests for Claude stream parser in `tests/unit/test_claude_stream_parser.py` — text_delta, thinking_delta, tool_use content_block_start, result event stdout extraction, malformed JSON skip, missing result fallback, non-streaming event ignore
+- [x] T007 Implement Claude stream line parser `_make_stream_callback()` in `src/fdsx/providers/claude.py` — closure that parses each JSON line and dispatches to output_callback
+- [x] T008 Wire streaming flags in Claude provider `execute()` in `src/fdsx/providers/claude.py` — add `--output-format stream-json --verbose --include-partial-messages` when output_callback provided, return ProviderResult with stdout from result event
+- [x] T009 Write integration test for Claude streaming end-to-end in `tests/integration/test_claude_streaming.py` — mocked subprocess replaying fixture, verify callbacks and ProviderResult.stdout
 
 ---
 

--- a/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
+++ b/specs/20260321133916-uuidv7-realtime-streaming/tasks.md
@@ -37,11 +37,11 @@
 **Goal:** Enable event-level streaming from Codex CLI via `--json` JSONL format.
 **Test criteria:** Stream parser correctly extracts agent_message, reasoning, command_execution, file_change, mcp_tool_call events. ProviderResult.stdout matches concatenated agent_message texts. Malformed JSON and turn.failed handled gracefully.
 
-- [ ] T010 Record real Codex JSONL fixture — run `codex exec --json "Say hello"` and save to `tests/fixtures/codex_stream.jsonl`
-- [ ] T011 Write TDD tests for Codex stream parser in `tests/unit/test_codex_stream_parser.py` — agent_message completed, reasoning completed, command_execution started, file_change started, mcp_tool_call started, turn.failed warning, malformed JSON skip, multiple agent_message concatenation, partial collection on crash
-- [ ] T012 Implement Codex stream line parser `_make_stream_callback()` in `src/fdsx/providers/codex.py`
-- [ ] T013 Wire streaming flags in Codex provider `execute()` in `src/fdsx/providers/codex.py` — add `--json` when output_callback provided, reconstruct stdout from accumulated agent_message texts
-- [ ] T014 Write integration test for Codex streaming end-to-end in `tests/integration/test_codex_streaming.py` — mocked subprocess replaying fixture
+- [x] T010 Record real Codex JSONL fixture — run `codex exec --json "Say hello"` and save to `tests/fixtures/codex_stream.jsonl`
+- [x] T011 Write TDD tests for Codex stream parser in `tests/unit/test_codex_stream_parser.py` — agent_message completed, reasoning completed, command_execution started, file_change started, mcp_tool_call started, turn.failed warning, malformed JSON skip, multiple agent_message concatenation, partial collection on crash
+- [x] T012 Implement Codex stream line parser `_make_stream_callback()` in `src/fdsx/providers/codex.py`
+- [x] T013 Wire streaming flags in Codex provider `execute()` in `src/fdsx/providers/codex.py` — add `--json` when output_callback provided, reconstruct stdout from accumulated agent_message texts
+- [x] T014 Write integration test for Codex streaming end-to-end in `tests/integration/test_codex_streaming.py` — mocked subprocess replaying fixture
 
 ---
 

--- a/specs/20260321150000-fix-argmax-cli-providers/tasks.md
+++ b/specs/20260321150000-fix-argmax-cli-providers/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Fix "Argument list too long" for CLI Providers
+
+**Feature**: Fix "Argument list too long" for CLI Providers
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+**Created**: 2026-03-21
+
+---
+
+## Phase 1: Setup
+
+- [x] T001 Create test file scaffold with imports, constants, and shared fixtures in `tests/unit/test_provider_stdin_fallback.py`
+
+## Phase 2: Tests (TDD)
+
+> Write all unit tests before implementation. Tests should fail until Phase 3.
+
+- [ ] T002 [P] Write Claude provider stdin fallback tests (T01-T03, T10 from plan) in `tests/unit/test_provider_stdin_fallback.py`
+  - T01: prompt < threshold → prompt in args, stdin_data=None
+  - T02: prompt >= threshold → prompt NOT in args, stdin_data=prompt
+  - T03: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt
+  - T10: prompt exactly at threshold → uses stdin (boundary case)
+
+- [ ] T003 [P] Write Codex provider stdin fallback tests (T04-T06 from plan) in `tests/unit/test_provider_stdin_fallback.py`
+  - T04: prompt < threshold → prompt in args, stdin_data=None
+  - T05: prompt >= threshold → prompt NOT in args, stdin_data=prompt
+  - T06: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt
+
+- [ ] T004 [P] Write OpenCode provider stdin fallback tests (T07-T09 from plan) in `tests/unit/test_provider_stdin_fallback.py`
+  - T07: prompt < threshold → prompt in args, stdin_data=None
+  - T08: prompt >= threshold → prompt NOT in args, stdin_data=prompt
+  - T09: prompt >= threshold + model flag → `-m model` in args, prompt NOT in args, stdin_data=prompt
+
+## Phase 3: Implementation
+
+> Modify each provider's `execute()` method to detect oversized prompts and pipe via stdin.
+
+- [ ] T005 [P] Implement stdin fallback in ClaudeProvider.execute() in `src/fdsx/providers/claude.py`
+  - Import `ARG_MAX_STDIN_THRESHOLD` from `base`
+  - Check `len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD`
+  - If true: build args as `["claude", "-p"]` + flags, pass `stdin_data=prompt`
+  - If false: existing behavior (prompt in args)
+  - Emit debug log when stdin fallback is used
+
+- [ ] T006 [P] Implement stdin fallback in CodexProvider.execute() in `src/fdsx/providers/codex.py`
+  - Import `ARG_MAX_STDIN_THRESHOLD` from `base`
+  - Check `len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD`
+  - If true: build args as `["codex", "exec"]` + flags (no prompt), pass `stdin_data=prompt`
+  - If false: existing behavior (prompt appended to args)
+  - Emit debug log when stdin fallback is used
+
+- [ ] T007 [P] Implement stdin fallback in OpenCodeProvider.execute() in `src/fdsx/providers/opencode.py`
+  - Import `ARG_MAX_STDIN_THRESHOLD` from `base`
+  - Check `len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD`
+  - If true: build args as `["opencode", "run"]` + flags (no prompt), pass `stdin_data=prompt`
+  - If false: existing behavior (prompt appended to args)
+  - Emit debug log when stdin fallback is used
+
+## Phase 4: Verification
+
+- [ ] T008 Run `pytest tests/unit/test_provider_stdin_fallback.py` — all new tests pass
+- [ ] T009 Run `pytest tests/` — no regressions in existing tests
+
+---
+
+## Dependencies
+
+```
+T001 → T002, T003, T004 (scaffold before tests)
+T002 → T005 (Claude tests before Claude impl)
+T003 → T006 (Codex tests before Codex impl)
+T004 → T007 (OpenCode tests before OpenCode impl)
+T005, T006, T007 → T008 (all impl before verification)
+T008 → T009 (new tests pass before full regression)
+```
+
+## Parallel Execution
+
+| Phase | Parallelizable tasks |
+|---|---|
+| Phase 2 | T002, T003, T004 (independent test groups) |
+| Phase 3 | T005, T006, T007 (independent provider files) |
+
+## Implementation Strategy
+
+- **MVP**: Phase 1-3 with Claude provider only (T001 → T002 → T005) — the most commonly used provider
+- **Full scope**: All 3 providers (9 tasks total)
+- **Incremental delivery**: Each provider can be implemented and verified independently
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total tasks | 9 |
+| Test tasks | 3 (grouped by provider) |
+| Implementation tasks | 3 |
+| Setup/Verification tasks | 3 |
+| Parallel opportunities | Phase 2 (3 tasks), Phase 3 (3 tasks) |
+
+## Suggested takt usage
+
+```bash
+# Phase 1: Setup
+takt run coder "Create test file scaffold with imports, constants, and shared fixtures in tests/unit/test_provider_stdin_fallback.py"
+
+# Phase 2: Tests (TDD) — run in parallel
+takt run coder "Write Claude provider stdin fallback tests (small prompt, large prompt, large prompt with flags, boundary case) in tests/unit/test_provider_stdin_fallback.py"
+takt run coder "Write Codex provider stdin fallback tests (small prompt, large prompt, large prompt with flags) in tests/unit/test_provider_stdin_fallback.py"
+takt run coder "Write OpenCode provider stdin fallback tests (small prompt, large prompt, large prompt with model flag) in tests/unit/test_provider_stdin_fallback.py"
+
+# Phase 3: Implementation — run in parallel
+takt run coder "Implement stdin fallback in ClaudeProvider.execute() in src/fdsx/providers/claude.py per spec"
+takt run coder "Implement stdin fallback in CodexProvider.execute() in src/fdsx/providers/codex.py per spec"
+takt run coder "Implement stdin fallback in OpenCodeProvider.execute() in src/fdsx/providers/opencode.py per spec"
+
+# Phase 4: Verification
+takt run coder "Run pytest tests/unit/test_provider_stdin_fallback.py and verify all tests pass"
+takt run coder "Run pytest tests/ and verify no regressions"
+```

--- a/specs/20260321150000-fix-argmax-cli-providers/tasks.md
+++ b/specs/20260321150000-fix-argmax-cli-providers/tasks.md
@@ -15,18 +15,18 @@
 
 > Write all unit tests before implementation. Tests should fail until Phase 3.
 
-- [ ] T002 [P] Write Claude provider stdin fallback tests (T01-T03, T10 from plan) in `tests/unit/test_provider_stdin_fallback.py`
+- [x] T002 [P] Write Claude provider stdin fallback tests (T01-T03, T10 from plan) in `tests/unit/test_provider_stdin_fallback.py`
   - T01: prompt < threshold → prompt in args, stdin_data=None
   - T02: prompt >= threshold → prompt NOT in args, stdin_data=prompt
   - T03: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt
   - T10: prompt exactly at threshold → uses stdin (boundary case)
 
-- [ ] T003 [P] Write Codex provider stdin fallback tests (T04-T06 from plan) in `tests/unit/test_provider_stdin_fallback.py`
+- [x] T003 [P] Write Codex provider stdin fallback tests (T04-T06 from plan) in `tests/unit/test_provider_stdin_fallback.py`
   - T04: prompt < threshold → prompt in args, stdin_data=None
   - T05: prompt >= threshold → prompt NOT in args, stdin_data=prompt
   - T06: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt
 
-- [ ] T004 [P] Write OpenCode provider stdin fallback tests (T07-T09 from plan) in `tests/unit/test_provider_stdin_fallback.py`
+- [x] T004 [P] Write OpenCode provider stdin fallback tests (T07-T09 from plan) in `tests/unit/test_provider_stdin_fallback.py`
   - T07: prompt < threshold → prompt in args, stdin_data=None
   - T08: prompt >= threshold → prompt NOT in args, stdin_data=prompt
   - T09: prompt >= threshold + model flag → `-m model` in args, prompt NOT in args, stdin_data=prompt

--- a/specs/20260321150000-fix-argmax-cli-providers/tasks.md
+++ b/specs/20260321150000-fix-argmax-cli-providers/tasks.md
@@ -58,8 +58,8 @@
 
 ## Phase 4: Verification
 
-- [ ] T008 Run `pytest tests/unit/test_provider_stdin_fallback.py` — all new tests pass
-- [ ] T009 Run `pytest tests/` — no regressions in existing tests
+- [x] T008 Run `pytest tests/unit/test_provider_stdin_fallback.py` — all new tests pass
+- [x] T009 Run `pytest tests/` — no regressions in existing tests
 
 ---
 

--- a/specs/20260321150000-fix-argmax-cli-providers/tasks.md
+++ b/specs/20260321150000-fix-argmax-cli-providers/tasks.md
@@ -35,21 +35,21 @@
 
 > Modify each provider's `execute()` method to detect oversized prompts and pipe via stdin.
 
-- [ ] T005 [P] Implement stdin fallback in ClaudeProvider.execute() in `src/fdsx/providers/claude.py`
+- [x] T005 [P] Implement stdin fallback in ClaudeProvider.execute() in `src/fdsx/providers/claude.py`
   - Import `ARG_MAX_STDIN_THRESHOLD` from `base`
   - Check `len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD`
   - If true: build args as `["claude", "-p"]` + flags, pass `stdin_data=prompt`
   - If false: existing behavior (prompt in args)
   - Emit debug log when stdin fallback is used
 
-- [ ] T006 [P] Implement stdin fallback in CodexProvider.execute() in `src/fdsx/providers/codex.py`
+- [x] T006 [P] Implement stdin fallback in CodexProvider.execute() in `src/fdsx/providers/codex.py`
   - Import `ARG_MAX_STDIN_THRESHOLD` from `base`
   - Check `len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD`
   - If true: build args as `["codex", "exec"]` + flags (no prompt), pass `stdin_data=prompt`
   - If false: existing behavior (prompt appended to args)
   - Emit debug log when stdin fallback is used
 
-- [ ] T007 [P] Implement stdin fallback in OpenCodeProvider.execute() in `src/fdsx/providers/opencode.py`
+- [x] T007 [P] Implement stdin fallback in OpenCodeProvider.execute() in `src/fdsx/providers/opencode.py`
   - Import `ARG_MAX_STDIN_THRESHOLD` from `base`
   - Check `len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD`
   - If true: build args as `["opencode", "run"]` + flags (no prompt), pass `stdin_data=prompt`

--- a/specs/20260322050008-fix-split-task-granularity/tasks.md
+++ b/specs/20260322050008-fix-split-task-granularity/tasks.md
@@ -1,0 +1,105 @@
+# Tasks: Fix Split Command and Improve Task Granularity
+
+**Feature**: Fix `fdsx split` emptiness check and rewrite task split prompt for feature-level granularity
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+
+---
+
+## Phase 1: Fix Emptiness Check (Scenario 1, 2, 4)
+
+**Goal**: Allow `fdsx split` to succeed when only the `completed/` subdirectory exists, while preserving `--force` behavior.
+
+**Independent test criteria**: After this phase, `fdsx split` works without `--force` when `completed/` is the only entry in `.fdsx/tasks/`. Pending `.yaml` files still block split. `--force` clears pending `.yaml` but preserves `completed/`. Task numbering continues from highest index across both directories.
+
+- [x] T001 Write integration tests for split succeeding with only `completed/` dir in `tests/integration/test_split.py`
+  - `test_split_command_succeeds_with_only_completed_dir`: Create `.fdsx/tasks/completed/` with a YAML inside, no pending tasks. Run split without `--force`. Verify exit code 0 and new task files created.
+  - `test_split_command_preserves_completed_dir_on_normal_split`: After successful split with `completed/` present, verify `completed/` dir and contents are untouched.
+  - `test_split_command_numbering_continues_from_completed`: `completed/` has `001-old.yaml`, `002-old.yaml`. New split starts from 003.
+  - `test_split_command_still_blocks_with_pending_yaml`: Tasks dir has a pending `.yaml` file (not in `completed/`). Verify split without `--force` still fails.
+
+- [x] T002 Implement emptiness check fix in `src/fdsx/cli/main.py`
+  - Modify emptiness check (~line 292): replace `any(tasks_dir.iterdir())` with a check filtering out the `completed` subdirectory
+  - Import `COMPLETED_SUBDIR` from `fdsx.core.batch`
+  - New check: `any(entry for entry in tasks_dir.iterdir() if entry.name != COMPLETED_SUBDIR)`
+  - Run T001 tests to verify
+
+- [x] T003 Write integration test for `--force` preserving `completed/` dir in `tests/integration/test_split.py`
+  - `test_split_command_force_preserves_completed_dir`: Create tasks dir with pending `.yaml` AND `completed/` subdir. Run split with `--force`. Verify pending `.yaml` removed, `completed/` preserved with contents intact.
+
+---
+
+## Phase 2: Rewrite Task Split Prompt (Scenario 3)
+
+**Goal**: Produce feature-level tasks with structured sub-steps instead of micro-tasks.
+
+**Independent test criteria**: After this phase, the split prompt instructs feature-level grouping, includes sub-steps instruction, anti-examples, and a few-shot example. Integration test verifies the output structure.
+
+- [ ] T004 Write unit tests for prompt content verification in `tests/unit/test_batch.py`
+  - `test_build_task_split_prompt_contains_feature_level_instruction`: Verify prompt contains instruction to group related steps into feature-level tasks.
+  - `test_build_task_split_prompt_contains_substeps_instruction`: Verify prompt instructs numbered sub-steps within descriptions.
+  - `test_build_task_split_prompt_contains_anti_examples`: Verify prompt includes anti-examples of micro-tasks.
+  - `test_build_task_split_prompt_contains_few_shot_example`: Verify prompt includes a few-shot example.
+
+- [ ] T005 Rewrite `_build_task_split_prompt()` in `src/fdsx/core/batch.py`
+  - Rewrite the prompt (~lines 106-154):
+    - Change core instruction from "split into individual, self-contained task descriptions" to "group related work into feature-level tasks"
+    - Add instruction: each task description should include numbered sub-steps
+    - Add few-shot example showing BAD (5 micro-tasks) vs GOOD (1 feature-level task with 5 numbered sub-steps)
+    - Add anti-pattern guidance: "Do NOT create tasks for single file operations, single commands, or trivially small changes"
+    - Keep the JSON output format specification unchanged
+  - Run T004 tests to verify
+
+- [ ] T006 Write integration test for feature-level output in `tests/integration/test_split.py`
+  - `test_split_produces_feature_level_tasks`: Use mock provider returning a feature-level response (single task with sub-steps in description). Verify the output contains fewer files than micro-split. Verify task description contains numbered steps.
+
+---
+
+## Dependencies
+
+```
+Phase 1 (T001 → T002 → T003)  ──→  Phase 2 (T004 → T005 → T006)
+                                     │
+                                     └─ Phase 2 can start after Phase 1 is verified
+```
+
+- T001 must pass before T002 (TDD: write tests first)
+- T002 must pass before T003 (emptiness fix enables force test)
+- T004 must pass before T005 (TDD: write tests first)
+- T005 must pass before T006 (prompt must exist for integration test)
+- Phase 2 is independent of Phase 1 at the code level (different files), but logically follows
+
+## Parallel Opportunities
+
+- **Within Phase 1**: T001 and T003 test authoring can be done in parallel (different test concerns), but T002 implementation must wait for T001.
+- **Cross-phase**: T004 (unit tests for prompt) can start as soon as Phase 1 implementation (T002) is underway, since they touch different files.
+
+## Implementation Strategy
+
+1. **MVP**: Phase 1 alone delivers immediate value — developers no longer need `--force` after completed runs
+2. **Full delivery**: Phase 2 improves task quality, reducing AI cost per batch run
+3. **Files modified**: `src/fdsx/cli/main.py`, `src/fdsx/core/batch.py`
+4. **Files extended**: `tests/integration/test_split.py`, `tests/unit/test_batch.py`
+5. **No new files, no schema changes, no new dependencies**
+
+## Suggested takt Usage
+
+```bash
+# Phase 1: Fix emptiness check
+takt run coder "Phase 1: Write integration tests for split with completed dir (T001) in tests/integration/test_split.py"
+takt run coder "Phase 1: Implement emptiness check fix (T002) in src/fdsx/cli/main.py"
+takt run coder "Phase 1: Write force-preserves-completed test (T003) in tests/integration/test_split.py"
+
+# Phase 2: Rewrite split prompt
+takt run coder "Phase 2: Write unit tests for prompt content (T004) in tests/unit/test_batch.py"
+takt run coder "Phase 2: Rewrite _build_task_split_prompt (T005) in src/fdsx/core/batch.py"
+takt run coder "Phase 2: Write integration test for feature-level output (T006) in tests/integration/test_split.py"
+```
+
+## Summary
+
+| Phase | Tasks | Files |
+|---|---|---|
+| 1: Emptiness Check Fix | T001–T003 | `cli/main.py`, `tests/integration/test_split.py` |
+| 2: Prompt Rewrite | T004–T006 | `core/batch.py`, `tests/unit/test_batch.py`, `tests/integration/test_split.py` |
+| **Total** | **6 tasks** | **4 files** |

--- a/specs/20260322050008-fix-split-task-granularity/tasks.md
+++ b/specs/20260322050008-fix-split-task-granularity/tasks.md
@@ -35,13 +35,13 @@
 
 **Independent test criteria**: After this phase, the split prompt instructs feature-level grouping, includes sub-steps instruction, anti-examples, and a few-shot example. Integration test verifies the output structure.
 
-- [ ] T004 Write unit tests for prompt content verification in `tests/unit/test_batch.py`
+- [x] T004 Write unit tests for prompt content verification in `tests/unit/test_batch.py`
   - `test_build_task_split_prompt_contains_feature_level_instruction`: Verify prompt contains instruction to group related steps into feature-level tasks.
   - `test_build_task_split_prompt_contains_substeps_instruction`: Verify prompt instructs numbered sub-steps within descriptions.
   - `test_build_task_split_prompt_contains_anti_examples`: Verify prompt includes anti-examples of micro-tasks.
   - `test_build_task_split_prompt_contains_few_shot_example`: Verify prompt includes a few-shot example.
 
-- [ ] T005 Rewrite `_build_task_split_prompt()` in `src/fdsx/core/batch.py`
+- [x] T005 Rewrite `_build_task_split_prompt()` in `src/fdsx/core/batch.py`
   - Rewrite the prompt (~lines 106-154):
     - Change core instruction from "split into individual, self-contained task descriptions" to "group related work into feature-level tasks"
     - Add instruction: each task description should include numbered sub-steps
@@ -50,7 +50,7 @@
     - Keep the JSON output format specification unchanged
   - Run T004 tests to verify
 
-- [ ] T006 Write integration test for feature-level output in `tests/integration/test_split.py`
+- [x] T006 Write integration test for feature-level output in `tests/integration/test_split.py`
   - `test_split_produces_feature_level_tasks`: Use mock provider returning a feature-level response (single task with sub-steps in description). Verify the output contains fewer files than micro-split. Verify task description contains numbered steps.
 
 ---

--- a/specs/20260322083133-fix-realtime-streaming/tasks.md
+++ b/specs/20260322083133-fix-realtime-streaming/tasks.md
@@ -1,0 +1,119 @@
+# Tasks: Fix Realtime Streaming Output
+
+**Feature**: Fix subprocess stdout/stderr buffering and StreamLogger flush for real-time output delivery
+**Spec**: [spec.md](./spec.md)
+**Plan**: [impl-plan.md](./impl-plan.md)
+
+---
+
+## Phase 1: TDD — Write Regression Test (RED)
+
+**Goal**: Write a test that fails with the current buffered implementation and will pass after the fix.
+
+**Independent test criteria**: After this phase, a regression test exists that proves stdout/stderr lines are delivered incrementally (not batched at process exit). The test currently FAILS (RED) — confirming the buffering issue is real.
+
+- [x] T001 Create TDD regression test for realtime stdout/stderr delivery in `tests/unit/test_subprocess_realtime_streaming.py`
+  - `test_stdout_lines_delivered_before_process_exits`: Spawn subprocess printing 3 lines with `sleep 0.3` between each. Record `time.time()` in `output_callback` per line and after `_run_subprocess()` returns. Assert at least one callback timestamp is >0.2s before completion timestamp.
+  - `test_stderr_lines_delivered_before_process_exits`: Same approach for stderr via `stderr_callback`.
+
+- [x] T002 Run regression test to confirm RED (fails before fix) via `uv run pytest tests/unit/test_subprocess_realtime_streaming.py -v`
+  - Expected: FAIL — callbacks fire only after process exits due to Python's iterator read-ahead buffering
+
+---
+
+## Phase 2: Fix Subprocess Buffering (GREEN)
+
+**Goal**: Replace buffered `for line in` iterator with unbuffered `readline()` loop in both stdout and stderr paths.
+
+**Independent test criteria**: After this phase, the TDD regression test PASSES (GREEN). Stdout and stderr lines are delivered to callbacks immediately as each line is produced by the subprocess.
+
+- [x] T003 Fix stdout reading in `_run_subprocess()` in `src/fdsx/providers/base.py` (lines 146–154)
+  - Replace `for line in process.stdout:` with `while True: line = process.stdout.readline(); if not line: break; line = line.rstrip("\n")`
+
+- [x] T004 Fix stderr reading in `_read_stderr()` in `src/fdsx/providers/base.py` (lines 134–138)
+  - Replace `for raw_line in process.stderr:` with `while True: raw_line = process.stderr.readline(); if not raw_line: break; line = raw_line.rstrip("\n")`
+
+- [x] T005 Run regression test to confirm GREEN (passes after fix) via `uv run pytest tests/unit/test_subprocess_realtime_streaming.py -v`
+  - Expected: PASS
+
+---
+
+## Phase 3: Fix StreamLogger Stderr Flush
+
+**Goal**: Ensure terminal output appears immediately after each StreamLogger print by flushing stderr.
+
+**Independent test criteria**: After this phase, `sys.stderr.flush()` is called after every `print()` in StreamLogger's `on_stdout()` and `on_stderr()`, ensuring no Python-level stderr buffering delays terminal output.
+
+- [ ] T006 [P] Add `sys.stderr.flush()` after `print()` in `on_stdout()` in `src/fdsx/logging/stream_logger.py` (line 59)
+
+- [ ] T007 [P] Add `sys.stderr.flush()` after `print()` in `on_stderr()` in `src/fdsx/logging/stream_logger.py` (line 70)
+
+---
+
+## Phase 4: Verification
+
+**Goal**: Confirm all existing tests pass and no regressions introduced.
+
+**Independent test criteria**: Full test suite passes, including the new streaming regression test and all existing subprocess/streaming tests.
+
+- [ ] T008 Run full test suite including streaming-specific tests via `uv run pytest tests/ -v`
+  - Expected: All tests pass unchanged (existing + new streaming regression test)
+
+---
+
+## Dependencies
+
+```
+Phase 1 (T001 → T002)  ──→  Phase 2 (T003 → T004 → T005)  ──→  Phase 4 (T008)
+                                                                      ↑
+Phase 3 (T006, T007)  ────────────────────────────────────────────────┘
+```
+
+- T001 must complete before T002 (TDD: write test, then run to confirm RED)
+- T002 must confirm RED before T003–T004 (TDD discipline)
+- T003 and T004 can be done together (same file, different functions) but are sequential for safety
+- T005 must run after T003+T004 (confirm GREEN)
+- T006 and T007 are parallelizable (different methods in same file, no cross-dependency)
+- Phase 3 is independent of Phase 2 at the code level (different files) — can start in parallel
+- T008 runs after all implementation phases complete
+
+## Parallel Opportunities
+
+- **T006 + T007**: Both add `sys.stderr.flush()` to different methods in `stream_logger.py` — can be done in one pass
+- **Phase 3 vs Phase 2**: Phase 3 touches `stream_logger.py` while Phase 2 touches `base.py` — independent files, can be done concurrently
+
+## Implementation Strategy
+
+1. **MVP**: Phases 1–2 alone deliver the core value — real-time stdout/stderr delivery from subprocesses
+2. **Full delivery**: Phase 3 adds terminal flush to eliminate the last-mile buffering delay
+3. **Files modified**: `src/fdsx/providers/base.py`, `src/fdsx/logging/stream_logger.py`
+4. **Files created**: `tests/unit/test_subprocess_realtime_streaming.py`
+5. **No new dependencies, no schema changes, stdlib only**
+
+## Suggested takt Usage
+
+```bash
+# Phase 1: TDD regression test (RED)
+takt run coder "Phase 1: Create TDD regression test for realtime stdout/stderr delivery (T001) in tests/unit/test_subprocess_realtime_streaming.py"
+takt run coder "Phase 1: Run regression test to confirm RED (T002) via uv run pytest tests/unit/test_subprocess_realtime_streaming.py -v"
+
+# Phase 2: Fix subprocess buffering (GREEN)
+takt run coder "Phase 2: Fix stdout readline loop (T003) and stderr readline loop (T004) in src/fdsx/providers/base.py"
+takt run coder "Phase 2: Run regression test to confirm GREEN (T005) via uv run pytest tests/unit/test_subprocess_realtime_streaming.py -v"
+
+# Phase 3: StreamLogger flush
+takt run coder "Phase 3: Add sys.stderr.flush() in on_stdout (T006) and on_stderr (T007) in src/fdsx/logging/stream_logger.py"
+
+# Phase 4: Verification
+takt run coder "Phase 4: Run full test suite (T008) via uv run pytest tests/ -v"
+```
+
+## Summary
+
+| Phase | Tasks | Files |
+|---|---|---|
+| 1: TDD Regression Test (RED) | T001–T002 | `tests/unit/test_subprocess_realtime_streaming.py` (new) |
+| 2: Fix Subprocess Buffering (GREEN) | T003–T005 | `src/fdsx/providers/base.py` |
+| 3: StreamLogger Flush | T006–T007 | `src/fdsx/logging/stream_logger.py` |
+| 4: Verification | T008 | — |
+| **Total** | **8 tasks** | **3 files** |

--- a/specs/20260322083133-fix-realtime-streaming/tasks.md
+++ b/specs/20260322083133-fix-realtime-streaming/tasks.md
@@ -44,9 +44,9 @@
 
 **Independent test criteria**: After this phase, `sys.stderr.flush()` is called after every `print()` in StreamLogger's `on_stdout()` and `on_stderr()`, ensuring no Python-level stderr buffering delays terminal output.
 
-- [ ] T006 [P] Add `sys.stderr.flush()` after `print()` in `on_stdout()` in `src/fdsx/logging/stream_logger.py` (line 59)
+- [x] T006 [P] Add `sys.stderr.flush()` after `print()` in `on_stdout()` in `src/fdsx/logging/stream_logger.py` (line 59)
 
-- [ ] T007 [P] Add `sys.stderr.flush()` after `print()` in `on_stderr()` in `src/fdsx/logging/stream_logger.py` (line 70)
+- [x] T007 [P] Add `sys.stderr.flush()` after `print()` in `on_stderr()` in `src/fdsx/logging/stream_logger.py` (line 70)
 
 ---
 
@@ -56,7 +56,7 @@
 
 **Independent test criteria**: Full test suite passes, including the new streaming regression test and all existing subprocess/streaming tests.
 
-- [ ] T008 Run full test suite including streaming-specific tests via `uv run pytest tests/ -v`
+- [x] T008 Run full test suite including streaming-specific tests via `uv run pytest tests/ -v`
   - Expected: All tests pass unchanged (existing + new streaming regression test)
 
 ---

--- a/specs/20260322120000-result-file-variable-passing/tasks.md
+++ b/specs/20260322120000-result-file-variable-passing/tasks.md
@@ -97,14 +97,14 @@
 
 > FR-6 (test coverage), end-to-end validation with system provider.
 
-- [ ] T018 Write integration test with system provider in `tests/integration/test_result_file.py`
+- [x] T018 Write integration test with system provider in `tests/integration/test_result_file.py`
   - Two-state workflow: echo → read file. Assert file exists at `<run_dir>/data/output_ref.md`, content correct, variable contains absolute path
   - Parallel state with `result_file`: two echo branches, assert `.json` file created, variable contains path
 
-- [ ] T019 Write regression test for existing workflows in `tests/integration/test_result_file.py`
+- [x] T019 Write regression test for existing workflows in `tests/integration/test_result_file.py`
   - Run workflow without `result_file`, verify no `data/` directory is created
 
-- [ ] T020 Run full test suite `pytest tests/` — verify no regressions
+- [x] T020 Run full test suite `pytest tests/` — verify no regressions
 
 ---
 

--- a/specs/20260322120000-result-file-variable-passing/tasks.md
+++ b/specs/20260322120000-result-file-variable-passing/tasks.md
@@ -67,31 +67,31 @@
 
 > FR-2 (file writing on completion), FR-3 (usage modes). Tests first, then implement.
 
-- [ ] T011 Write TDD tests for task node `result_file` wiring in `tests/unit/test_result_file.py`
+- [x] T011 Write TDD tests for task node `result_file` wiring in `tests/unit/test_result_file.py`
   - Task with `result_file` only → file written, path stored in variable, no raw data in state
   - Task with both `result_path` and `result_file` → both set correctly
   - Task without `result_file` → no file I/O (existing behavior preserved)
   - Verify `write_result_to_file` called with correct arguments
 
-- [ ] T012 Wire `result_file` in task node function in `src/fdsx/core/compiler.py`
+- [x] T012 Wire `result_file` in task node function in `src/fdsx/core/compiler.py`
   - In `_create_task_node()`, after `result_path` handling: call `write_result_to_file()` and store path via `set_jsonpath`
   - Handle file-only mode (result_file set, result_path not used for file)
 
-- [ ] T013 Write TDD tests for parallel collector node `result_file` wiring in `tests/unit/test_result_file.py`
+- [x] T013 Write TDD tests for parallel collector node `result_file` wiring in `tests/unit/test_result_file.py`
   - Parallel with `result_file` → clean_results written to file, path stored
   - Parallel with both `result_path` and `result_file` → both set
   - Parallel without `result_file` → unchanged behavior
 
-- [ ] T014 Wire `result_file` in parallel collector node in `src/fdsx/core/compiler.py`
+- [x] T014 Wire `result_file` in parallel collector node in `src/fdsx/core/compiler.py`
   - In `_create_parallel_collector_node()`, after `set_jsonpath(state.result_path, ...)`: call `write_result_to_file()` and store path
 
-- [ ] T015 Register `result_file` keys in `_build_state_schema()` in `src/fdsx/core/compiler.py`
+- [x] T015 Register `result_file` keys in `_build_state_schema()` in `src/fdsx/core/compiler.py`
   - After result_path registration for TaskState and ParallelState: register `result_file` top-level key via `_top_level_key()`
 
-- [ ] T016 Register `result_file` in `_extract_result_paths()` in `src/fdsx/core/compiler.py`
+- [x] T016 Register `result_file` in `_extract_result_paths()` in `src/fdsx/core/compiler.py`
   - Add `result_file` to paths list for TaskState and ParallelState
 
-- [ ] T017 Run `pytest tests/unit/` — verify T011 + T013 tests pass, no regressions
+- [x] T017 Run `pytest tests/unit/` — verify T011 + T013 tests pass, no regressions
 
 ## Phase 4: Integration Test
 

--- a/specs/20260322120000-result-file-variable-passing/tasks.md
+++ b/specs/20260322120000-result-file-variable-passing/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: File-Based Variable Passing (`result_file`)
+
+**Feature**: File-Based Variable Passing (`result_file`)
+**Spec**: [spec.md](./spec.md)
+**Plan**: [plan.md](./plan.md)
+**Created**: 2026-03-22
+
+---
+
+## Phase 1: Model + Helper (TDD)
+
+> FR-1 (field definition), FR-2 (file writing helper). Write tests first, then implement.
+
+- [x] T001 Write TDD tests for `write_result_to_file()` helper in `tests/unit/test_result_file.py`
+  - String value → creates `<varname>.md` with string content
+  - Dict value → creates `<varname>.json` with JSON content
+  - List value → creates `<varname>.json` with JSON content
+  - `data/` directory created automatically if missing
+  - File overwritten on second call with same varname
+  - Returns absolute file path as string
+  - UTF-8 encoding for non-ASCII content
+
+- [x] T002 Implement `write_result_to_file()` in `src/fdsx/core/variables.py`
+  - Signature: `write_result_to_file(varname: str, value: Any, run_dir: Path) -> str`
+  - Creates `<run_dir>/data/` if needed
+  - Writes `.md` for str, `.json` for dict/list
+  - Returns `str(file_path.resolve())`
+
+- [x] T003 Write TDD tests for `result_file` model field validation in `tests/unit/test_result_file.py`
+  - `TaskState` accepts `result_file: "$.plan_ref"`
+  - `ParallelState` accepts `result_file: "$.reviews_ref"`
+  - Rejects missing `$.` prefix
+  - Rejects nested path `$.foo.bar`
+  - Defaults to `None` when not set
+  - `result_file` and `result_path` can coexist with different variable names
+
+- [x] T004 Add `result_file` field to `TaskState` and `ParallelState` in `src/fdsx/models/flow.py`
+  - Add `result_file: str | None = Field(default=None, ...)`
+  - Add `@field_validator` or `@model_validator` to require `$.` prefix and reject nested paths
+
+- [x] T005 Run `pytest tests/unit/test_result_file.py` — verify T001 + T003 tests pass
+
+## Phase 2: Engine + Static Analysis (TDD)
+
+> FR-5 (static analysis), `_meta.run_dir` propagation. Tests first, then implement.
+
+- [x] T006 Write TDD tests for `_meta.run_dir` propagation in `tests/unit/test_result_file.py`
+  - `initial_state["_meta"]["run_dir"]` is set in `run_flow` (mock compile_flow)
+  - `run_dir` value matches `<_runs_base>/runs/<thread_id>`
+
+- [x] T007 Add `run_dir` to `_meta` in `src/fdsx/core/engine.py`
+  - In `run_flow()`: add `"run_dir": str(run_dir)` to `_meta` dict
+  - In `resume_flow()`: compute and add `run_dir` to state dict if not already present
+  - Compute: `run_dir = _runs_base / RUNS_DIR_NAME / thread_id`
+
+- [x] T008 Write TDD tests for static analysis recognizing `result_file` in `tests/unit/test_result_file.py`
+  - `get_result_paths()` includes `result_file` variable in returned set
+  - `analyze_variable_references()` does not flag `{reviews_ref}` as undefined when upstream state has `result_file: $.reviews_ref`
+
+- [x] T009 Update static analysis in `src/fdsx/core/variables.py`
+  - In `get_result_paths()`: add `result_file` handling for TaskState and ParallelState
+  - If `state.result_file` is set and starts with `$.`, strip prefix and add to `result_paths`
+
+- [x] T010 Run `pytest tests/unit/test_result_file.py` — verify T006 + T008 tests pass
+
+## Phase 3: Compiler Wiring (TDD)
+
+> FR-2 (file writing on completion), FR-3 (usage modes). Tests first, then implement.
+
+- [ ] T011 Write TDD tests for task node `result_file` wiring in `tests/unit/test_result_file.py`
+  - Task with `result_file` only → file written, path stored in variable, no raw data in state
+  - Task with both `result_path` and `result_file` → both set correctly
+  - Task without `result_file` → no file I/O (existing behavior preserved)
+  - Verify `write_result_to_file` called with correct arguments
+
+- [ ] T012 Wire `result_file` in task node function in `src/fdsx/core/compiler.py`
+  - In `_create_task_node()`, after `result_path` handling: call `write_result_to_file()` and store path via `set_jsonpath`
+  - Handle file-only mode (result_file set, result_path not used for file)
+
+- [ ] T013 Write TDD tests for parallel collector node `result_file` wiring in `tests/unit/test_result_file.py`
+  - Parallel with `result_file` → clean_results written to file, path stored
+  - Parallel with both `result_path` and `result_file` → both set
+  - Parallel without `result_file` → unchanged behavior
+
+- [ ] T014 Wire `result_file` in parallel collector node in `src/fdsx/core/compiler.py`
+  - In `_create_parallel_collector_node()`, after `set_jsonpath(state.result_path, ...)`: call `write_result_to_file()` and store path
+
+- [ ] T015 Register `result_file` keys in `_build_state_schema()` in `src/fdsx/core/compiler.py`
+  - After result_path registration for TaskState and ParallelState: register `result_file` top-level key via `_top_level_key()`
+
+- [ ] T016 Register `result_file` in `_extract_result_paths()` in `src/fdsx/core/compiler.py`
+  - Add `result_file` to paths list for TaskState and ParallelState
+
+- [ ] T017 Run `pytest tests/unit/` — verify T011 + T013 tests pass, no regressions
+
+## Phase 4: Integration Test
+
+> FR-6 (test coverage), end-to-end validation with system provider.
+
+- [ ] T018 Write integration test with system provider in `tests/integration/test_result_file.py`
+  - Two-state workflow: echo → read file. Assert file exists at `<run_dir>/data/output_ref.md`, content correct, variable contains absolute path
+  - Parallel state with `result_file`: two echo branches, assert `.json` file created, variable contains path
+
+- [ ] T019 Write regression test for existing workflows in `tests/integration/test_result_file.py`
+  - Run workflow without `result_file`, verify no `data/` directory is created
+
+- [ ] T020 Run full test suite `pytest tests/` — verify no regressions
+
+---
+
+## Dependencies
+
+```
+T001 → T002 (tests before helper impl)
+T003 → T004 (tests before model field)
+T002, T004 → T005 (impl before verification)
+T006 → T007 (tests before engine change)
+T008 → T009 (tests before static analysis change)
+T007, T009 → T010 (impl before verification)
+T011 → T012 (tests before task node wiring)
+T013 → T014 (tests before parallel node wiring)
+T012, T014 → T015, T016 (wiring before schema/extract registration)
+T015, T016 → T017 (registration before verification)
+T017 → T018, T019 (unit tests pass before integration)
+T018, T019 → T020 (integration before full regression)
+```
+
+## Parallel Execution
+
+| Phase | Parallelizable tasks |
+|---|---|
+| Phase 1 | T001 + T003 (independent test groups), T002 + T004 (independent impl files) |
+| Phase 2 | T006 + T008 (independent test groups), T007 + T009 (independent impl files) |
+| Phase 3 | T011 + T013 (independent test groups), T015 + T016 (independent compiler registrations) |
+| Phase 4 | T018 + T019 (independent integration tests) |
+
+## Implementation Strategy
+
+- **MVP**: Phase 1 (Model + Helper) — establishes the core `write_result_to_file()` and model validation
+- **Full scope**: All 4 phases (20 tasks total)
+- **Incremental delivery**: Each phase is a complete, testable increment. Phase 1-2 can be merged independently of Phase 3-4.
+
+## Summary
+
+| Metric | Value |
+|---|---|
+| Total tasks | 20 |
+| Test tasks | 8 (T001, T003, T006, T008, T011, T013, T018, T019) |
+| Implementation tasks | 8 (T002, T004, T007, T009, T012, T014, T015, T016) |
+| Verification tasks | 4 (T005, T010, T017, T020) |
+| Parallel opportunities | Phase 1 (2+2), Phase 2 (2+2), Phase 3 (2+2), Phase 4 (2) |
+
+## Suggested takt usage
+
+```bash
+# Phase 1: Model + Helper (TDD)
+takt run coder "Write TDD tests for write_result_to_file() helper — string→.md, dict→.json, list→.json, auto-create data/ dir, overwrite, return absolute path, UTF-8 — in tests/unit/test_result_file.py"
+takt run coder "Implement write_result_to_file(varname, value, run_dir) in src/fdsx/core/variables.py — creates <run_dir>/data/<varname>.<ext>, .md for str, .json for dict/list, returns absolute path"
+takt run coder "Write TDD tests for result_file model field validation — TaskState/ParallelState accept $.varname, reject missing $. prefix, reject nested paths, default None, coexist with result_path — in tests/unit/test_result_file.py"
+takt run coder "Add result_file: str | None field to TaskState and ParallelState in src/fdsx/models/flow.py with field_validator requiring $. prefix and rejecting nested paths"
+takt run coder "Run pytest tests/unit/test_result_file.py and verify all Phase 1 tests pass"
+
+# Phase 2: Engine + Static Analysis (TDD)
+takt run coder "Write TDD tests for _meta.run_dir propagation — verify run_flow sets _meta.run_dir matching <_runs_base>/runs/<thread_id> — in tests/unit/test_result_file.py"
+takt run coder "Add run_dir to _meta dict in engine.py run_flow() and resume_flow() — compute as _runs_base / RUNS_DIR_NAME / thread_id"
+takt run coder "Write TDD tests for static analysis recognizing result_file — get_result_paths includes result_file vars, analyze_variable_references does not flag them as undefined — in tests/unit/test_result_file.py"
+takt run coder "Update get_result_paths() in src/fdsx/core/variables.py to include result_file handling for TaskState and ParallelState"
+takt run coder "Run pytest tests/unit/test_result_file.py and verify all Phase 2 tests pass"
+
+# Phase 3: Compiler Wiring (TDD)
+takt run coder "Write TDD tests for task node result_file wiring — file-only mode, both mode, no-file mode, verify write_result_to_file args — in tests/unit/test_result_file.py"
+takt run coder "Wire result_file in _create_task_node() in src/fdsx/core/compiler.py — call write_result_to_file after result_path, store path via set_jsonpath"
+takt run coder "Write TDD tests for parallel collector node result_file wiring — file written, both mode, unchanged without result_file — in tests/unit/test_result_file.py"
+takt run coder "Wire result_file in _create_parallel_collector_node() in src/fdsx/core/compiler.py — call write_result_to_file, store path via set_jsonpath"
+takt run coder "Register result_file keys in _build_state_schema() in src/fdsx/core/compiler.py for TaskState and ParallelState"
+takt run coder "Register result_file in _extract_result_paths() in src/fdsx/core/compiler.py for TaskState and ParallelState"
+takt run coder "Run pytest tests/unit/ and verify all Phase 3 tests pass with no regressions"
+
+# Phase 4: Integration Test
+takt run coder "Write integration test with system provider in tests/integration/test_result_file.py — two-state echo workflow with result_file, parallel state with result_file"
+takt run coder "Write regression test in tests/integration/test_result_file.py — workflow without result_file creates no data/ directory"
+takt run coder "Run pytest tests/ full suite and verify no regressions"
+```

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -179,23 +179,50 @@ class CheckpointManager:
     def list_threads(self) -> list[dict[str, Any]]:
         """List all known thread executions.
 
+        Merges threads from the checkpoint database and from run log directories
+        under <base_dir>/runs/.
+
         Returns:
             List of thread info dictionaries with thread_id, status, flow_name
         """
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+
+        # Collect thread IDs from checkpoint DB
+        checkpoint_thread_ids: list[str] = []
         db_path = self.checkpoints_dir / "checkpoints.db"
-        if not db_path.exists():
+        if db_path.exists():
+            try:
+                conn = sqlite3.connect(str(db_path), check_same_thread=False)
+                cursor = conn.cursor()
+                cursor.execute("SELECT DISTINCT thread_id FROM checkpoints")
+                checkpoint_thread_ids = [row[0] for row in cursor.fetchall()]
+                conn.close()
+            except Exception:
+                pass
+
+        # Collect thread IDs from run log directories
+        runs_dir = self.base_dir / RUNS_DIR_NAME
+        run_log_thread_ids: list[str] = []
+        if runs_dir.is_dir():
+            for entry in runs_dir.iterdir():
+                if entry.is_dir() and (entry / RUN_FILENAME).is_file():
+                    run_log_thread_ids.append(entry.name)
+
+        # Merge, preserving checkpoint-DB entries first, then run-log-only entries
+        seen: set[str] = set(checkpoint_thread_ids)
+        all_thread_ids = list(checkpoint_thread_ids)
+        for tid in run_log_thread_ids:
+            if tid not in seen:
+                seen.add(tid)
+                all_thread_ids.append(tid)
+
+        if not all_thread_ids:
             return []
 
         try:
-            conn = sqlite3.connect(str(db_path), check_same_thread=False)
-            cursor = conn.cursor()
-            cursor.execute("SELECT DISTINCT thread_id FROM checkpoints")
-            thread_rows = cursor.fetchall()
-            conn.close()
-
             threads = []
-            checkpointer = self.get_checkpointer()
-            for (thread_id,) in thread_rows:
+            checkpointer = self.get_checkpointer() if db_path.exists() else None
+            for thread_id in all_thread_ids:
                 is_locked, pid = self.is_locked(thread_id)
                 status = "running" if is_locked else "stopped"
                 flow_name = thread_id  # fallback default
@@ -204,7 +231,7 @@ class CheckpointManager:
                 started_at = ""
                 config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
                 try:
-                    checkpoint_tuple = checkpointer.get_tuple(config)
+                    checkpoint_tuple = checkpointer.get_tuple(config) if checkpointer is not None else None
                     if checkpoint_tuple is not None:
                         checkpoint_data = checkpoint_tuple.checkpoint
                         meta = _extract_meta_from_checkpoint(checkpoint_data)
@@ -241,6 +268,29 @@ class CheckpointManager:
                             started_at = str(ts)[:16].replace("T", " ")
                 except Exception:
                     pass
+
+                # Fallback: read flow_name and started_at from run log when
+                # the checkpoint did not provide them.
+                if flow_name == thread_id or not started_at:
+                    try:
+                        import json
+                        run_log_path = runs_dir / thread_id / RUN_FILENAME
+                        if run_log_path.is_file():
+                            with open(run_log_path, "r") as f:
+                                run_log = json.load(f)
+                            if flow_name == thread_id:
+                                flow_name = run_log.get("flow_name", thread_id)
+                            if not started_at:
+                                ts_str = run_log.get("started_at", "")
+                                if ts_str and "T" in ts_str:
+                                    started_at = ts_str[:16].replace("T", " ")
+                            if not is_locked and flow_name != thread_id:
+                                # Run-log-only thread: derive status from log status
+                                log_status = run_log.get("status", "")
+                                if log_status == "completed":
+                                    status = "completed"
+                    except (json.JSONDecodeError, OSError, KeyError):
+                        pass
 
                 threads.append(
                     {

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -24,10 +24,14 @@ def run(
         None, "--input", help="Input variable as KEY=VALUE"
     ),
     tasks_file: Path | None = typer.Option(
-        None, "--tasks", help="Batch task file path"
+        None,
+        "--tasks",
+        help="Batch task file for in-memory splitting and execution (requires workflow argument)",
     ),
     tasks_dir: Path | None = typer.Option(
-        None, "--tasks-dir", help="Directory of task YAML files to execute"
+        None,
+        "--tasks-dir",
+        help="Directory of task YAML files for persistent batch execution with resume support",
     ),
     auto_workflow: bool | None = typer.Option(
         None,
@@ -40,7 +44,7 @@ def run(
         help="Confirm workflow selection before execution (overrides config)",
     ),
 ) -> None:
-    """Run a workflow from a YAML file."""
+    """Run a workflow. Supports single execution, in-memory batch (--tasks), and persistent batch (--tasks-dir) modes."""
     if tasks_dir is not None:
         if input_vars is not None or tasks_file is not None:
             typer.echo(
@@ -142,7 +146,7 @@ def run(
             result = engine.run_flow(workflow, inputs, thread_id, base_dir)
             typer.echo(json.dumps(result, indent=2))
     except FlowValidationError as e:
-        typer.echo(f"Validation error: {e}", err=True)
+        typer.echo(f"Validation error: {_sanitize_output(str(e))}", err=True)
         raise typer.Exit(code=2)
     except RuntimeError as e:
         if isinstance(e, typer.Exit):
@@ -168,7 +172,7 @@ def validate(
         raise typer.Exit(code=0)
     else:
         for error in errors:
-            typer.echo(f"Error: {error}", err=True)
+            typer.echo(f"Error: {_sanitize_output(str(error))}", err=True)
         raise typer.Exit(code=2)
 
 

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -37,15 +37,20 @@ def run(
     auto_workflow: bool | None = typer.Option(
         None,
         "--auto-workflow",
-        help="Skip confirmation and auto-select workflow (overrides config)",
+        help="Skip interactive workflow confirmation and auto-select (overrides config)",
     ),
     confirm_workflow: bool | None = typer.Option(
         None,
         "--confirm-workflow",
-        help="Confirm workflow selection before execution (overrides config)",
+        help="Show interactive workflow confirmation UI before execution (overrides config)",
     ),
 ) -> None:
-    """Run a workflow. Supports single execution, in-memory batch (--tasks), and persistent batch (--tasks-dir) modes."""
+    """Run a workflow. Supports single execution, in-memory batch (--tasks), and persistent batch (--tasks-dir) modes.
+
+    Shows an animated spinner during workflow auto-selection for tasks-dir mode.
+    Displays an interactive numbered-list CUI for workflow confirmation (in interactive terminals).
+    Use --auto-workflow to skip the confirmation UI.
+    In non-interactive (non-TTY) terminals, auto-confirms without prompting."""
     if tasks_dir is not None:
         if input_vars is not None or tasks_file is not None:
             typer.echo(
@@ -270,6 +275,8 @@ def split(
 
     Reads task_splitter configuration from .fdsx/config.yaml (or defaults).
     Writes numbered task files to .fdsx/tasks/ directory.
+    Shows an animated spinner during LLM splitting. In non-interactive (non-TTY) terminals,
+    prints plain log lines instead of animation.
     """
     if not task_file.exists():
         typer.echo(f"Error: Task file not found: {task_file}", err=True)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -44,6 +44,11 @@ def run(
         "--confirm-workflow",
         help="Show interactive workflow confirmation UI before execution (overrides config)",
     ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        help="Suppress stderr streaming output from providers. Log files are still written and completion summary is still shown.",
+    ),
 ) -> None:
     """Run a workflow. Supports single execution, in-memory batch (--tasks), and persistent batch (--tasks-dir) modes.
 
@@ -151,7 +156,7 @@ def run(
             assert workflow is not None
             if current_thread_id is None:
                 current_thread_id = str(uuid_utils.uuid7())
-            engine.run_flow(workflow, inputs, current_thread_id, base_dir)
+            engine.run_flow(workflow, inputs, current_thread_id, base_dir, quiet=quiet)
     except FlowValidationError as e:
         typer.echo(f"Validation error: {_sanitize_output(str(e))}", err=True)
         raise typer.Exit(code=2)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -6,7 +6,7 @@ import uuid_utils
 
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core import engine
-from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.batch import COMPLETED_SUBDIR, TASKS_DIR, split_tasks_to_groups, write_task_files
 from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
 from fdsx.display.terminal import Spinner, _sanitize_output, display_resume_command
@@ -289,7 +289,9 @@ def split(
 
     tasks_dir = Path(TASKS_DIR)
 
-    if tasks_dir.exists() and any(tasks_dir.iterdir()):
+    if tasks_dir.exists() and any(
+        entry for entry in tasks_dir.iterdir() if entry.name != COMPLETED_SUBDIR
+    ):
         if not force:
             typer.echo(
                 f"Error: Tasks directory '{TASKS_DIR}' is not empty. "

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from pathlib import Path
 
 import typer
@@ -8,7 +9,7 @@ from fdsx.core import engine
 from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
 from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
-from fdsx.display.terminal import Spinner, _sanitize_output
+from fdsx.display.terminal import Spinner, _sanitize_output, display_resume_command
 
 app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework")
 
@@ -118,6 +119,8 @@ def run(
     if confirm_workflow is not None:
         effective_auto_workflow = not confirm_workflow
 
+    current_thread_id = thread_id if thread_id else None
+
     try:
         if tasks_dir is not None:
             results = engine.run_tasks_dir(
@@ -143,21 +146,39 @@ def run(
                 raise typer.Exit(code=0)
         else:
             assert workflow is not None
-            result = engine.run_flow(workflow, inputs, thread_id, base_dir)
+            if current_thread_id is None:
+                current_thread_id = str(uuid.uuid4())
+            result = engine.run_flow(workflow, inputs, current_thread_id, base_dir)
             typer.echo(json.dumps(result, indent=2))
     except FlowValidationError as e:
         typer.echo(f"Validation error: {_sanitize_output(str(e))}", err=True)
         raise typer.Exit(code=2)
+    except KeyboardInterrupt:
+        _display_resume_on_error(tasks_dir, current_thread_id)
+        raise typer.Exit(code=130)
     except RuntimeError as e:
         if isinstance(e, typer.Exit):
             raise
         typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
+        _display_resume_on_error(tasks_dir, current_thread_id)
         raise typer.Exit(code=1)
     except Exception as e:
         if not isinstance(e, typer.Exit):
             typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
+            _display_resume_on_error(tasks_dir, current_thread_id)
             raise typer.Exit(code=1)
         raise
+
+
+def _display_resume_on_error(
+    tasks_dir: Path | None,
+    thread_id: str | None,
+) -> None:
+    """Display resume command on error, if applicable."""
+    if tasks_dir is not None:
+        display_resume_command(mode="tasks-dir", tasks_dir=tasks_dir)
+    elif thread_id is not None:
+        display_resume_command(mode="single-flow", thread_id=thread_id)
 
 
 @app.command()

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -134,7 +134,6 @@ def run(
                 base_dir,
                 auto_workflow=effective_auto_workflow,
             )
-            typer.echo(json.dumps(results, indent=2))
             has_failure = any(r.get("status") == "failed" for r in results)
             if has_failure:
                 raise typer.Exit(code=1)
@@ -143,7 +142,6 @@ def run(
         elif tasks_file is not None:
             assert workflow is not None
             results = engine.run_batch(workflow, tasks_file, base_dir)
-            typer.echo(json.dumps(results, indent=2))
             has_failure = any(r.get("status") == "failed" for r in results)
             if has_failure:
                 raise typer.Exit(code=1)
@@ -153,8 +151,7 @@ def run(
             assert workflow is not None
             if current_thread_id is None:
                 current_thread_id = str(uuid.uuid4())
-            result = engine.run_flow(workflow, inputs, current_thread_id, base_dir)
-            typer.echo(json.dumps(result, indent=2))
+            engine.run_flow(workflow, inputs, current_thread_id, base_dir)
     except FlowValidationError as e:
         typer.echo(f"Validation error: {_sanitize_output(str(e))}", err=True)
         raise typer.Exit(code=2)
@@ -211,8 +208,7 @@ def resume(
 ) -> None:
     """Resume a flow from a checkpoint."""
     try:
-        result = engine.resume_flow(thread_id, base_dir)
-        typer.echo(json.dumps(result, indent=2))
+        engine.resume_flow(thread_id, base_dir)
     except RuntimeError as e:
         error_msg = str(e)
         if "No checkpoint found" in error_msg:

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -8,7 +8,7 @@ from fdsx.core import engine
 from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
 from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
-from fdsx.display.terminal import _sanitize_output
+from fdsx.display.terminal import Spinner, _sanitize_output
 
 app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework")
 
@@ -279,14 +279,17 @@ def split(
 
     try:
         task_content = task_file.read_text()
-        groups = split_tasks_to_groups(task_content, task_splitter)
 
-        if not groups:
-            typer.echo("No tasks were generated from the input file.", err=True)
-            typer.echo(json.dumps([]))
-            return
+        with Spinner("Splitting tasks...") as spinner:
+            groups = split_tasks_to_groups(task_content, task_splitter)
 
-        created_files = write_task_files(groups, tasks_dir)
+            if not groups:
+                typer.echo("No tasks were generated from the input file.", err=True)
+                typer.echo(json.dumps([]))
+                return
+
+            spinner.update(f"Writing {len(groups)} task file(s)...")
+            created_files = write_task_files(groups, tasks_dir)
 
         typer.echo(
             f"Created {len(created_files)} task file(s) in {TASKS_DIR}/", err=True

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -138,6 +138,7 @@ def run(
                 tasks_dir,
                 base_dir,
                 auto_workflow=effective_auto_workflow,
+                quiet=quiet,
             )
             has_failure = any(r.get("status") == "failed" for r in results)
             if has_failure:
@@ -146,7 +147,7 @@ def run(
                 raise typer.Exit(code=0)
         elif tasks_file is not None:
             assert workflow is not None
-            results = engine.run_batch(workflow, tasks_file, base_dir)
+            results = engine.run_batch(workflow, tasks_file, base_dir, quiet=quiet)
             has_failure = any(r.get("status") == "failed" for r in results)
             if has_failure:
                 raise typer.Exit(code=1)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -15,7 +15,7 @@ app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework
 
 @app.command()
 def run(
-    workflow: Path = typer.Argument(..., help="Path to the YAML workflow file"),
+    workflow: Path | None = typer.Argument(None, help="Path to the YAML workflow file"),
     thread_id: str | None = typer.Option(None, help="Thread ID for this execution"),
     input_vars: list[str] | None = typer.Option(
         None, "--input", help="Input variable as KEY=VALUE"
@@ -23,11 +23,51 @@ def run(
     tasks_file: Path | None = typer.Option(
         None, "--tasks", help="Batch task file path"
     ),
+    tasks_dir: Path | None = typer.Option(
+        None, "--tasks-dir", help="Directory of task YAML files to execute"
+    ),
 ) -> None:
     """Run a workflow from a YAML file."""
-    if input_vars and tasks_file is not None:
+    if tasks_dir is not None:
+        if workflow is None:
+            typer.echo(
+                "Error: workflow argument is required when using --tasks-dir",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if input_vars is not None or tasks_file is not None:
+            typer.echo(
+                "Error: --tasks-dir is mutually exclusive with --input and --tasks",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if not tasks_dir.exists():
+            typer.echo(
+                f"Error: Tasks directory not found: {tasks_dir}",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if tasks_dir.is_symlink():
+            typer.echo(
+                f"Error: --tasks-dir must not be a symlink: {tasks_dir}",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if not tasks_dir.is_dir():
+            typer.echo(
+                f"Error: --tasks-dir must be a directory: {tasks_dir}",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+    elif input_vars and tasks_file is not None:
         typer.echo(
             "Error: --input and --tasks are mutually exclusive",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    elif workflow is None and tasks_dir is None:
+        typer.echo(
+            "Error: workflow argument is required when not using --tasks-dir",
             err=True,
         )
         raise typer.Exit(code=2)
@@ -48,7 +88,15 @@ def run(
     base_dir = Path(".fdsx")
 
     try:
-        if tasks_file is not None:
+        if tasks_dir is not None:
+            results = engine.run_tasks_dir(workflow, tasks_dir, base_dir)
+            typer.echo(json.dumps(results, indent=2))
+            has_failure = any(r.get("status") == "failed" for r in results)
+            if has_failure:
+                raise typer.Exit(code=1)
+            else:
+                raise typer.Exit(code=0)
+        elif tasks_file is not None:
             results = engine.run_batch(workflow, tasks_file, base_dir)
             typer.echo(json.dumps(results, indent=2))
             has_failure = any(r.get("status") == "failed" for r in results)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -15,7 +15,10 @@ app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework
 
 @app.command()
 def run(
-    workflow: Path | None = typer.Argument(None, help="Path to the YAML workflow file"),
+    workflow: Path | None = typer.Argument(
+        None,
+        help="Path to the YAML workflow file (optional with --tasks-dir for auto-selection)",
+    ),
     thread_id: str | None = typer.Option(None, help="Thread ID for this execution"),
     input_vars: list[str] | None = typer.Option(
         None, "--input", help="Input variable as KEY=VALUE"
@@ -26,15 +29,19 @@ def run(
     tasks_dir: Path | None = typer.Option(
         None, "--tasks-dir", help="Directory of task YAML files to execute"
     ),
+    auto_workflow: bool | None = typer.Option(
+        None,
+        "--auto-workflow",
+        help="Skip confirmation and auto-select workflow (overrides config)",
+    ),
+    confirm_workflow: bool | None = typer.Option(
+        None,
+        "--confirm-workflow",
+        help="Confirm workflow selection before execution (overrides config)",
+    ),
 ) -> None:
     """Run a workflow from a YAML file."""
     if tasks_dir is not None:
-        if workflow is None:
-            typer.echo(
-                "Error: workflow argument is required when using --tasks-dir",
-                err=True,
-            )
-            raise typer.Exit(code=2)
         if input_vars is not None or tasks_file is not None:
             typer.echo(
                 "Error: --tasks-dir is mutually exclusive with --input and --tasks",
@@ -71,6 +78,19 @@ def run(
             err=True,
         )
         raise typer.Exit(code=2)
+    elif tasks_file is not None and workflow is None:
+        typer.echo(
+            "Error: workflow argument is required when using --tasks",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    if auto_workflow is not None and confirm_workflow is not None:
+        typer.echo(
+            "Error: --auto-workflow and --confirm-workflow are mutually exclusive",
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
     inputs = None
     if input_vars:
@@ -86,10 +106,22 @@ def run(
             inputs[key] = value
 
     base_dir = Path(".fdsx")
+    config = load_config()
+
+    effective_auto_workflow = (
+        auto_workflow if auto_workflow is not None else config.auto_workflow
+    )
+    if confirm_workflow is not None:
+        effective_auto_workflow = not confirm_workflow
 
     try:
         if tasks_dir is not None:
-            results = engine.run_tasks_dir(workflow, tasks_dir, base_dir)
+            results = engine.run_tasks_dir(
+                workflow,
+                tasks_dir,
+                base_dir,
+                auto_workflow=effective_auto_workflow,
+            )
             typer.echo(json.dumps(results, indent=2))
             has_failure = any(r.get("status") == "failed" for r in results)
             if has_failure:
@@ -97,6 +129,7 @@ def run(
             else:
                 raise typer.Exit(code=0)
         elif tasks_file is not None:
+            assert workflow is not None
             results = engine.run_batch(workflow, tasks_file, base_dir)
             typer.echo(json.dumps(results, indent=2))
             has_failure = any(r.get("status") == "failed" for r in results)
@@ -105,6 +138,7 @@ def run(
             else:
                 raise typer.Exit(code=0)
         else:
+            assert workflow is not None
             result = engine.run_flow(workflow, inputs, thread_id, base_dir)
             typer.echo(json.dumps(result, indent=2))
     except FlowValidationError as e:

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -5,6 +5,8 @@ import typer
 
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core import engine
+from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
 from fdsx.display.terminal import _sanitize_output
 
@@ -148,6 +150,71 @@ def list_flows(
             f"{_sanitize_output(thread.get('current_state', '')):<20} "
             f"{_sanitize_output(thread.get('started_at', '')):<20}"
         )
+
+
+@app.command()
+def split(
+    task_file: Path = typer.Argument(..., help="Path to the task file to split"),
+    force: bool = typer.Option(
+        False, "--force", help="Clear existing tasks directory before splitting"
+    ),
+) -> None:
+    """Split a task file into individual task files for persistent batch execution.
+
+    Reads task_splitter configuration from .fdsx/config.yaml (or defaults).
+    Writes numbered task files to .fdsx/tasks/ directory.
+    """
+    if not task_file.exists():
+        typer.echo(f"Error: Task file not found: {task_file}", err=True)
+        raise typer.Exit(code=2)
+
+    config = load_config()
+    task_splitter = config.task_splitter or TaskSplitterConfig()
+
+    tasks_dir = Path(TASKS_DIR)
+
+    if tasks_dir.exists() and any(tasks_dir.iterdir()):
+        if not force:
+            typer.echo(
+                f"Error: Tasks directory '{TASKS_DIR}' is not empty. "
+                "Use --force to clear and overwrite.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        if tasks_dir.is_symlink():
+            typer.echo(
+                f"Error: Tasks directory '{TASKS_DIR}' is a symlink. Refusing to delete.",
+                err=True,
+            )
+            raise typer.Exit(code=2)
+        for f in tasks_dir.glob("*.yaml"):
+            f.unlink()
+        typer.echo(f"Cleared existing task files in {TASKS_DIR}/", err=True)
+
+    try:
+        task_content = task_file.read_text()
+        groups = split_tasks_to_groups(task_content, task_splitter)
+
+        if not groups:
+            typer.echo("No tasks were generated from the input file.", err=True)
+            typer.echo(json.dumps([]))
+            return
+
+        created_files = write_task_files(groups, tasks_dir)
+
+        typer.echo(
+            f"Created {len(created_files)} task file(s) in {TASKS_DIR}/", err=True
+        )
+        for f in created_files:
+            typer.echo(f"  {f}", err=True)
+        typer.echo(json.dumps([str(f) for f in created_files]))
+
+    except RuntimeError as e:
+        typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)
+        raise typer.Exit(code=1)
+    except ValueError as e:
+        typer.echo(f"Error parsing tasks: {_sanitize_output(str(e))}", err=True)
+        raise typer.Exit(code=1)
 
 
 if __name__ == "__main__":

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -1,8 +1,8 @@
 import json
-import uuid
 from pathlib import Path
 
 import typer
+import uuid_utils
 
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core import engine
@@ -150,7 +150,7 @@ def run(
         else:
             assert workflow is not None
             if current_thread_id is None:
-                current_thread_id = str(uuid.uuid4())
+                current_thread_id = str(uuid_utils.uuid7())
             engine.run_flow(workflow, inputs, current_thread_id, base_dir)
     except FlowValidationError as e:
         typer.echo(f"Validation error: {_sanitize_output(str(e))}", err=True)

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -1,13 +1,14 @@
 import sys
 from typing import Any
 
+from fdsx.core.config import TaskSplitterConfig
 from fdsx.display.terminal import _sanitize_output
-from fdsx.models.flow import Flow, TaskSplitter
+from fdsx.models.flow import Flow
 from fdsx.providers.base import get_provider
 
 
 def split_tasks(
-    task_content: str, flow: Flow, task_splitter: TaskSplitter
+    task_content: str, flow: Flow, task_splitter: TaskSplitterConfig
 ) -> list[str]:
     """Invoke the task_splitter LLM to split the task file content into individual tasks.
 

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -1,10 +1,28 @@
+import json
+import re as _re
 import sys
+from pathlib import Path
 from typing import Any
 
 from fdsx.core.config import TaskSplitterConfig
 from fdsx.display.terminal import _sanitize_output
 from fdsx.models.flow import Flow
+from fdsx.models.task import TaskEntry, TaskFile, save_task_file
 from fdsx.providers.base import get_provider
+
+
+TASKS_DIR = ".fdsx/tasks"
+
+
+def _slugify(text: str, max_length: int = 40) -> str:
+    """Convert text to a URL-safe slug for use in filenames."""
+    slug = text.lower()
+    slug = _re.sub(r"[^a-z0-9\s-]", "", slug)
+    slug = _re.sub(r"[\s_]+", "-", slug).strip("-")
+    slug = _re.sub(r"-+", "-", slug)
+    if len(slug) > max_length:
+        slug = slug[:max_length].rstrip("-")
+    return slug or "task"
 
 
 def split_tasks(
@@ -35,19 +53,68 @@ def split_tasks(
     if result.exit_code != 0:
         raise RuntimeError(f"Task splitter failed: {result.stderr}")
 
-    tasks = _parse_task_list(result.stdout)
+    try:
+        groups = _parse_structured_tasks(result.stdout)
+        flattened = [entry.description for group in groups for entry in group]
+        return flattened
+    except ValueError:
+        return _parse_task_list(result.stdout)
 
-    return tasks
+
+def split_tasks_to_groups(
+    task_content: str,
+    task_splitter: TaskSplitterConfig,
+    state_names: list[str] | None = None,
+    input_vars: set[str] | None = None,
+) -> list[list[TaskEntry]]:
+    """Invoke the task_splitter LLM to split task content into file groups.
+
+    This is the standalone version used by the split CLI command that doesn't
+    require a flow object.
+
+    Args:
+        task_content: The content of the task file
+        task_splitter: The task splitter configuration
+        state_names: Optional list of state names for context
+        input_vars: Optional set of input variables for context
+
+    Returns:
+        List of file groups. Each group contains sequentially-dependent
+        TaskEntry objects that belong in the same file.
+
+    Raises:
+        RuntimeError: If the LLM call fails
+        ValueError: If the response cannot be parsed
+    """
+    provider = get_provider(task_splitter.provider)
+
+    prompt = _build_task_split_prompt(task_content, state_names, input_vars)
+
+    result = provider.execute(
+        prompt=prompt,
+        model=task_splitter.model,
+    )
+
+    if result.exit_code != 0:
+        raise RuntimeError(f"Task splitter failed: {result.stderr}")
+
+    return _parse_structured_tasks(result.stdout)
 
 
 def _build_task_split_prompt(
-    task_content: str, state_names: list[str], input_vars: set[str]
+    task_content: str, state_names: list[str] | None, input_vars: set[str] | None
 ) -> str:
-    """Build the prompt for the task splitter LLM."""
-    states_desc = ", ".join(state_names)
-    input_vars_desc = ", ".join(input_vars) if input_vars else "none"
+    """Build the prompt for the task splitter LLM.
 
-    prompt = f"""You are a task splitter. Given a batch of work, split it into individual executable tasks.
+    Args:
+        task_content: The content of the task file
+        state_names: List of state names in the workflow (optional for standalone split)
+        input_vars: Set of input variable names (optional for standalone split)
+    """
+    states_desc = ", ".join(state_names) if state_names else "any workflow"
+    input_vars_desc = ", ".join(input_vars) if input_vars else "task"
+
+    prompt = f"""You are a task splitter. Given a batch of work, split it into individual executable tasks and organize them into file groups.
 
 The workflow has these states: {states_desc}
 The workflow accepts these input variables: {input_vars_desc}
@@ -58,12 +125,29 @@ TASK CONTENT:
 INSTRUCTIONS:
 1. Analyze the task content above
 2. Split it into individual, self-contained task descriptions
-3. Each task should be executable by the workflow and should set a 'task' variable
-4. Output ONLY a numbered list (1., 2., 3., etc.) with one task per line
-5. Keep tasks concise but clear
-6. Do NOT include any additional text, explanations, or formatting
+3. Group tasks that DEPEND on each other sequentially into the same group (they will be executed in order within one file)
+4. Place independent tasks (no dependencies between them) in SEPARATE groups (each becomes its own file)
+5. Within each group, order tasks by their sequential dependency (first task executed first)
+6. Output ONLY valid JSON in the format described below
 
-OUTPUT:"""
+OUTPUT FORMAT:
+Return a JSON array of file groups. Each group is an array of task objects that belong in the same file.
+```json
+[
+  [
+    {{"description": "Independent task A"}}
+  ],
+  [
+    {{"description": "Step 1 of related work"}},
+    {{"description": "Step 2 that depends on step 1"}}
+  ],
+  [
+    {{"description": "Independent task B"}}
+  ]
+]
+```
+
+IMPORTANT: Output ONLY the JSON array, no additional text, explanations, or markdown formatting."""
 
     return prompt
 
@@ -114,6 +198,107 @@ def _parse_task_list(response: str) -> list[str]:
             tasks.append(line)
 
     return tasks
+
+
+def _parse_structured_tasks(response: str) -> list[list[TaskEntry]]:
+    """Parse the LLM JSON response into a list of file groups.
+
+    Each group is a list of TaskEntry objects that belong in the same file.
+    Tasks within a group execute sequentially; separate groups become
+    separate files.
+
+    Args:
+        response: The LLM response containing JSON
+
+    Returns:
+        List of file groups, each containing TaskEntry objects
+
+    Raises:
+        ValueError: If JSON parsing fails or format is invalid
+    """
+    cleaned = response.strip()
+
+    code_block_patterns = [
+        r"```json\s*(.*?)\s*```",
+        r"```\s*(.*?)\s*```",
+    ]
+    for pattern in code_block_patterns:
+        import re
+
+        match = re.search(pattern, cleaned, re.DOTALL)
+        if match:
+            cleaned = match.group(1).strip()
+            break
+
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse JSON from LLM response: {e}") from e
+
+    if not isinstance(data, list):
+        raise ValueError(
+            f"Expected JSON array of file groups, got {type(data).__name__}"
+        )
+
+    groups: list[list[TaskEntry]] = []
+    for i, group in enumerate(data):
+        if not isinstance(group, list):
+            raise ValueError(
+                f"Group {i} must be an array of tasks, got {type(group).__name__}"
+            )
+
+        entries: list[TaskEntry] = []
+        for j, task in enumerate(group):
+            if not isinstance(task, dict):
+                raise ValueError(
+                    f"Task {j} in group {i} must be an object, got {type(task).__name__}"
+                )
+            if "description" not in task:
+                raise ValueError(
+                    f"Task {j} in group {i} missing required 'description' field"
+                )
+            entries.append(TaskEntry(description=task["description"]))
+        groups.append(entries)
+
+    return groups
+
+
+def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Path]:
+    """Write task groups to numbered YAML files in the tasks directory.
+
+    Creates files in the format: tasks_dir/001-<slug>.yaml, tasks_dir/002-<slug>.yaml, etc.
+    Each file contains sequentially-dependent tasks from one file group.
+
+    Args:
+        groups: List of file groups, each containing TaskEntry objects
+        tasks_dir: Directory to write task files to
+
+    Returns:
+        List of created file paths
+
+    Raises:
+        ValueError: If tasks_dir is a symlink or other security checks fail
+    """
+    current = tasks_dir
+    while current != current.parent:
+        if current.exists() and current.is_symlink():
+            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
+        current = current.parent
+
+    tasks_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    created_files: list[Path] = []
+    for i, group in enumerate(groups):
+        if not group:
+            continue
+
+        task_file = TaskFile(entries=group)
+        slug = _slugify(group[0].description)
+        file_path = tasks_dir / f"{i + 1:03d}-{slug}.yaml"
+        save_task_file(file_path, task_file)
+        created_files.append(file_path)
+
+    return created_files
 
 
 def display_task_list(tasks: list[str]) -> bool:

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -116,7 +116,7 @@ def _build_task_split_prompt(
     states_desc = ", ".join(state_names) if state_names else "any workflow"
     input_vars_desc = ", ".join(input_vars) if input_vars else "task"
 
-    prompt = f"""You are a task splitter. Given a batch of work, split it into individual executable tasks and organize them into file groups.
+    prompt = f"""You are a task splitter. Given a batch of work, group related work into feature-level tasks and organize them into file groups.
 
 The workflow has these states: {states_desc}
 The workflow accepts these input variables: {input_vars_desc}
@@ -126,25 +126,50 @@ TASK CONTENT:
 
 INSTRUCTIONS:
 1. Analyze the task content above
-2. Split it into individual, self-contained task descriptions
-3. Group tasks that DEPEND on each other sequentially into the same group (they will be executed in order within one file)
-4. Place independent tasks (no dependencies between them) in SEPARATE groups (each becomes its own file)
-5. Within each group, order tasks by their sequential dependency (first task executed first)
-6. Output ONLY valid JSON in the format described below
+2. Group related work into feature-level tasks — do NOT create tasks for single file operations, single commands, or trivially small changes
+3. Each task description should include numbered sub-steps (e.g., "Implement X\\n1. Do A\\n2. Do B\\n3. Do C")
+4. Group tasks that DEPEND on each other sequentially into the same group (they will be executed in order within one file)
+5. Place independent tasks (no dependencies between them) in SEPARATE groups (each becomes its own file)
+6. Within each group, order tasks by their sequential dependency (first task executed first)
+7. Output ONLY valid JSON in the format described below
+
+EXAMPLE:
+BAD (micro-tasks — too granular):
+[
+  [{{"description": "Create models/user.py"}}],
+  [{{"description": "Add User class to models/user.py"}}],
+  [{{"description": "Create routes/user.py"}}],
+  [{{"description": "Add /users endpoint to routes/user.py"}}],
+  [{{"description": "Write tests for User model"}}]
+]
+
+GOOD (feature-level tasks with numbered sub-steps):
+[
+  [
+    {{
+      "description": "Implement User model\\n1. Create models/user.py\\n2. Define User class with id, name, email fields\\n3. Add validation methods"
+    }}
+  ],
+  [
+    {{
+      "description": "Implement user API endpoints\\n1. Create routes/user.py\\n2. Add GET /users endpoint\\n3. Add POST /users endpoint\\n4. Write tests for all endpoints"
+    }}
+  ]
+]
 
 OUTPUT FORMAT:
 Return a JSON array of file groups. Each group is an array of task objects that belong in the same file.
 ```json
 [
   [
-    {{"description": "Independent task A"}}
+    {{"description": "Independent feature A\\n1. Step one\\n2. Step two"}}
   ],
   [
     {{"description": "Step 1 of related work"}},
     {{"description": "Step 2 that depends on step 1"}}
   ],
   [
-    {{"description": "Independent task B"}}
+    {{"description": "Independent feature B\\n1. Step one\\n2. Step two"}}
   ]
 ]
 ```

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -369,3 +369,65 @@ def display_batch_summary(results: list[dict[str, Any]]) -> None:
         f"Total: {total} | Succeeded: {succeeded} | Failed: {failed}", file=sys.stderr
     )
     print("=" * 80, file=sys.stderr)
+
+
+def display_tasks_dir_summary(results: list[dict[str, Any]]) -> None:
+    """Display a summary of tasks-dir execution results.
+
+    Shows skipped, retried, new, completed, and failed entries with symbols.
+
+    Args:
+        results: List of result dicts with file_index, file_name, entry_index,
+                 entry_description, thread_id, status, error, category.
+    """
+    print("\n" + "=" * 80, file=sys.stderr)
+    print("TASKS-DIR EXECUTION SUMMARY", file=sys.stderr)
+    print("=" * 80, file=sys.stderr)
+    print(
+        f"{'FILE':<30} {'ENTRY':<6} {'CAT':<8} {'STATUS':<12} {'THREAD_ID':<36} {'TASK':<20}",
+        file=sys.stderr,
+    )
+    print("-" * 80, file=sys.stderr)
+
+    for result in results:
+        file_name = result.get("file_name", "")[:30]
+        entry_idx = result.get("entry_index", -1)
+        category = result.get("category", "new")
+        status = result.get("status", "unknown")
+        thread_id = result.get("thread_id", "")[:36]
+        entry_desc = result.get("entry_description", "")[:20]
+
+        symbol_map = {
+            "skipped": "⊘",
+            "retried": "↻",
+            "new": "○",
+            "completed": "✓",
+        }
+        status_symbol = symbol_map.get(category, "?") if status == "completed" else "✗"
+
+        entry_display = str(entry_idx + 1) if entry_idx >= 0 else "-"
+        print(
+            f"{_sanitize_output(file_name):<30} {entry_display:<6} {category:<8} "
+            f"{status_symbol} {status:<10} {_sanitize_output(thread_id):<36} "
+            f"{_sanitize_output(entry_desc):<20}",
+            file=sys.stderr,
+        )
+
+        if result.get("error"):
+            error_preview = result["error"][:70]
+            print(f"       Error: {_sanitize_output(error_preview)}", file=sys.stderr)
+
+    print("-" * 80, file=sys.stderr)
+
+    skipped = sum(1 for r in results if r.get("category") == "skipped")
+    retried = sum(1 for r in results if r.get("category") == "retried")
+    new_total = sum(1 for r in results if r.get("category") == "new")
+    failed = sum(1 for r in results if r.get("status") == "failed")
+    total = len(results)
+
+    print(
+        f"Total: {total} | Skipped: {skipped} | Retried: {retried} | New: {new_total} | "
+        f"Failed: {failed}",
+        file=sys.stderr,
+    )
+    print("=" * 80, file=sys.stderr)

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -1,5 +1,6 @@
 import json
 import re as _re
+import shutil
 import sys
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,7 @@ from fdsx.providers.base import get_provider
 
 
 TASKS_DIR = ".fdsx/tasks"
+COMPLETED_SUBDIR = "completed"
 
 
 def _slugify(text: str, max_length: int = 40) -> str:
@@ -263,11 +265,40 @@ def _parse_structured_tasks(response: str) -> list[list[TaskEntry]]:
     return groups
 
 
+def _scan_max_task_index(tasks_dir: Path) -> int:
+    """Scan tasks_dir and tasks_dir/completed/ for existing numeric file indices.
+
+    Looks for files whose names start with one or more digits followed by a hyphen
+    (e.g. ``001-some-task.yaml``).  Returns the highest index found, or 0 if no
+    such files exist.
+
+    Args:
+        tasks_dir: The active tasks directory to scan (completed/ is derived from it).
+
+    Returns:
+        Maximum index found across both directories, or 0 if none found.
+    """
+    max_idx = 0
+    dirs_to_scan = [tasks_dir, tasks_dir / COMPLETED_SUBDIR]
+    for scan_dir in dirs_to_scan:
+        if not scan_dir.exists() or not scan_dir.is_dir():
+            continue
+        for f in scan_dir.glob("*.yaml"):
+            m = _re.match(r"^(\d+)-", f.name)
+            if m:
+                idx = int(m.group(1))
+                if idx > max_idx:
+                    max_idx = idx
+    return max_idx
+
+
 def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Path]:
     """Write task groups to numbered YAML files in the tasks directory.
 
-    Creates files in the format: tasks_dir/001-<slug>.yaml, tasks_dir/002-<slug>.yaml, etc.
-    Each file contains sequentially-dependent tasks from one file group.
+    Creates files in the format: tasks_dir/NNN-<slug>.yaml where NNN continues
+    from the highest existing index found in both tasks_dir and
+    tasks_dir/completed/.  Each file contains sequentially-dependent tasks from
+    one file group.
 
     Args:
         groups: List of file groups, each containing TaskEntry objects
@@ -287,6 +318,8 @@ def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Pat
 
     tasks_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
+    base_index = _scan_max_task_index(tasks_dir)
+
     created_files: list[Path] = []
     for i, group in enumerate(groups):
         if not group:
@@ -294,11 +327,46 @@ def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Pat
 
         task_file = TaskFile(entries=group)
         slug = _slugify(group[0].description)
-        file_path = tasks_dir / f"{i + 1:03d}-{slug}.yaml"
+        file_path = tasks_dir / f"{base_index + i + 1:03d}-{slug}.yaml"
         save_task_file(file_path, task_file)
         created_files.append(file_path)
 
     return created_files
+
+
+def move_task_to_completed(file_path: Path) -> None:
+    """Move a task file to the ``completed/`` subdirectory alongside it.
+
+    The ``completed/`` directory is created automatically if it does not exist.
+    The original filename is preserved.
+
+    Args:
+        file_path: Absolute (or relative) path to the task YAML file to move.
+
+    Raises:
+        ValueError: If a symlink is detected anywhere in the ancestor path of
+            the destination directory.
+        FileExistsError: If a file with the same name already exists inside
+            ``completed/``.
+    """
+    completed_dir = file_path.parent / COMPLETED_SUBDIR
+
+    # Security check: no symlinks in the ancestor path
+    current = completed_dir
+    while current != current.parent:
+        if current.exists() and current.is_symlink():
+            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
+        current = current.parent
+
+    completed_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    dest = completed_dir / file_path.name
+    if dest.exists():
+        raise FileExistsError(
+            f"Destination already exists in completed/: {dest}"
+        )
+
+    shutil.move(str(file_path), str(dest))
 
 
 def display_task_list(tasks: list[str]) -> bool:

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -1,6 +1,7 @@
 import operator
 import subprocess
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Callable, TypedDict
 
 from langgraph.graph import END, StateGraph
@@ -167,6 +168,7 @@ def compile_flow(
     checkpointer: Any = None,
     recorder: Any = None,
     config: "FdsxConfig | None" = None,
+    log_dir: Path | None = None,
 ) -> CompiledGraph:
     """Compile a Flow into a LangGraph StateGraph.
 
@@ -178,6 +180,9 @@ def compile_flow(
                       If not provided and the flow contains Wait states,
                       a MemorySaver will be used as default.
         config: Optional fdsx configuration used to resolve provider options.
+        log_dir: Optional directory for per-state streaming log files
+                 (.fdsx/runs/<thread-id>/logs/). When None, streaming still
+                 works on the terminal but no log files are written.
 
     Returns:
         CompiledGraph with the compiled state machine
@@ -199,7 +204,7 @@ def compile_flow(
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
             graph.add_node(
-                state_name, _create_task_node(state_name, state, flow, recorder, config)
+                state_name, _create_task_node(state_name, state, flow, recorder, config, log_dir)
             )  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
             graph.add_node(
@@ -211,7 +216,7 @@ def compile_flow(
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_branch_{state_name}",
-                _create_branch_executor(state_name, state, flow, recorder, config),
+                _create_branch_executor(state_name, state, flow, recorder, config, log_dir),
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_collect_{state_name}",
@@ -332,12 +337,14 @@ def _create_task_node(
     flow: Flow,
     recorder: Any = None,
     config: "FdsxConfig | None" = None,
+    log_dir: Path | None = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Task state."""
     merged_options = _merge_provider_options(config, flow, state.provider, state.provider_options)
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         from fdsx.core.extraction import extract_value
+        from fdsx.logging.stream_logger import StreamLogger
         from fdsx.providers.base import ProviderResult
 
         start_time = time.time()
@@ -361,48 +368,54 @@ def _create_task_node(
         result = ProviderResult(exit_code=1, stdout="", stderr="")
         extracted: str | None = None
 
-        for attempt in range(max_retries + 1):
-            if attempt > 0:
-                time.sleep(min(2 ** (attempt - 1), 30))
-            try:
-                if state.provider == "system":
-                    resolved_command = resolve_template_shell_safe(
-                        state.command or "", state_dict
-                    )
-                    result = provider.execute(
-                        prompt="",
-                        model=state.model,
-                        timeout=state.timeout_seconds,
-                        command=resolved_command,
-                        output_callback=None,
-                    )
-                else:
-                    result = provider.execute(
-                        prompt=resolved_prompt,
-                        model=state.model,
-                        timeout=state.timeout_seconds,
-                        output_callback=terminal.display_output_line,
-                    )
-            except (subprocess.TimeoutExpired, TimeoutError) as exc:
-                last_error = str(exc)
-                result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
-                continue
+        stream_logger = StreamLogger(state_name, log_dir)
+        try:
+            for attempt in range(max_retries + 1):
+                if attempt > 0:
+                    time.sleep(min(2 ** (attempt - 1), 30))
+                try:
+                    if state.provider == "system":
+                        resolved_command = resolve_template_shell_safe(
+                            state.command or "", state_dict
+                        )
+                        result = provider.execute(
+                            prompt="",
+                            model=state.model,
+                            timeout=state.timeout_seconds,
+                            command=resolved_command,
+                            output_callback=stream_logger.on_stdout,
+                            stderr_callback=stream_logger.on_stderr,
+                        )
+                    else:
+                        result = provider.execute(
+                            prompt=resolved_prompt,
+                            model=state.model,
+                            timeout=state.timeout_seconds,
+                            output_callback=stream_logger.on_stdout,
+                            stderr_callback=stream_logger.on_stderr,
+                        )
+                except (subprocess.TimeoutExpired, TimeoutError) as exc:
+                    last_error = str(exc)
+                    result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
+                    continue
 
-            if result.exit_code == 0:
-                if state.extract:
-                    extracted = extract_value(
-                        result.stdout.strip(),
-                        state.extract,
-                        get_provider,
-                        source_provider=state.provider,
-                    )
-                    if extracted is not None:
+                if result.exit_code == 0:
+                    if state.extract:
+                        extracted = extract_value(
+                            result.stdout.strip(),
+                            state.extract,
+                            get_provider,
+                            source_provider=state.provider,
+                        )
+                        if extracted is not None:
+                            break
+                        last_error = "Extraction failed: all strategies returned None"
+                    else:
                         break
-                    last_error = "Extraction failed: all strategies returned None"
                 else:
-                    break
-            else:
-                last_error = result.stderr
+                    last_error = result.stderr
+        finally:
+            stream_logger.close()
 
         if result.exit_code != 0:
             terminal.display_state_error(state_name, last_error)
@@ -487,6 +500,7 @@ def _create_branch_executor(
     flow: Flow,
     recorder: Any = None,
     config: "FdsxConfig | None" = None,
+    log_dir: Path | None = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a shared branch executor node invoked once per branch via Send.
 
@@ -497,6 +511,7 @@ def _create_branch_executor(
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         from fdsx.core.extraction import extract_value
+        from fdsx.logging.stream_logger import StreamLogger
         from fdsx.providers.base import ProviderResult
 
         branch_index: int = state_dict.get("_branch_index", 0)
@@ -521,48 +536,54 @@ def _create_branch_executor(
         result = ProviderResult(exit_code=1, stdout="", stderr="")
         extracted: str | None = None
 
-        for attempt in range(max_retries + 1):
-            if attempt > 0:
-                time.sleep(min(2 ** (attempt - 1), 30))
-            try:
-                if branch.provider == "system":
-                    resolved_command = resolve_template_shell_safe(
-                        branch.command or "", state_dict
-                    )
-                    result = provider.execute(
-                        prompt="",
-                        model=branch.model,
-                        timeout=branch.timeout_seconds,
-                        command=resolved_command,
-                        output_callback=None,
-                    )
-                else:
-                    result = provider.execute(
-                        prompt=resolved_prompt,
-                        model=branch.model,
-                        timeout=branch.timeout_seconds,
-                        output_callback=terminal.display_output_line,
-                    )
-            except (subprocess.TimeoutExpired, TimeoutError) as exc:
-                last_error = str(exc)
-                result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
-                continue
+        stream_logger = StreamLogger(state_name, log_dir)
+        try:
+            for attempt in range(max_retries + 1):
+                if attempt > 0:
+                    time.sleep(min(2 ** (attempt - 1), 30))
+                try:
+                    if branch.provider == "system":
+                        resolved_command = resolve_template_shell_safe(
+                            branch.command or "", state_dict
+                        )
+                        result = provider.execute(
+                            prompt="",
+                            model=branch.model,
+                            timeout=branch.timeout_seconds,
+                            command=resolved_command,
+                            output_callback=stream_logger.on_stdout,
+                            stderr_callback=stream_logger.on_stderr,
+                        )
+                    else:
+                        result = provider.execute(
+                            prompt=resolved_prompt,
+                            model=branch.model,
+                            timeout=branch.timeout_seconds,
+                            output_callback=stream_logger.on_stdout,
+                            stderr_callback=stream_logger.on_stderr,
+                        )
+                except (subprocess.TimeoutExpired, TimeoutError) as exc:
+                    last_error = str(exc)
+                    result = ProviderResult(exit_code=1, stdout="", stderr=last_error)
+                    continue
 
-            if result.exit_code == 0:
-                if branch.extract:
-                    extracted = extract_value(
-                        result.stdout.strip(),
-                        branch.extract,
-                        get_provider,
-                        source_provider=branch.provider,
-                    )
-                    if extracted is not None:
+                if result.exit_code == 0:
+                    if branch.extract:
+                        extracted = extract_value(
+                            result.stdout.strip(),
+                            branch.extract,
+                            get_provider,
+                            source_provider=branch.provider,
+                        )
+                        if extracted is not None:
+                            break
+                        last_error = "Extraction failed: all strategies returned None"
+                    else:
                         break
-                    last_error = "Extraction failed: all strategies returned None"
                 else:
-                    break
-            else:
-                last_error = result.stderr
+                    last_error = result.stderr
+        finally:
+            stream_logger.close()
 
         duration = time.time() - start_time
 

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -1,11 +1,12 @@
 import operator
 import subprocess
 import time
-from typing import Annotated, Any, Callable, TypedDict
+from typing import TYPE_CHECKING, Annotated, Any, Callable, TypedDict
 
 from langgraph.graph import END, StateGraph
 from langgraph.types import interrupt, Send
 
+from fdsx.core.config import _deep_merge
 from fdsx.core.variables import (
     resolve_template,
     resolve_template_shell_safe,
@@ -23,6 +24,9 @@ from fdsx.models.flow import (
     WaitState,
 )
 from fdsx.providers.base import get_provider
+
+if TYPE_CHECKING:
+    from fdsx.core.config import FdsxConfig
 
 
 class FlowState(TypedDict):
@@ -117,11 +121,52 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
     return TypedDict("FlowState", annotations, total=False)  # type: ignore[no-any-return,operator]
 
 
+def _merge_provider_options(
+    config: "FdsxConfig | None",
+    flow: Flow,
+    provider_name: str,
+    task_options: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Merge provider options from three levels: config → workflow → task/branch.
+
+    Args:
+        config: Top-level fdsx configuration (level 1 source).
+        flow: The flow definition carrying workflow-level provider options (level 2).
+        provider_name: Provider name (e.g. 'claude', 'codex', 'opencode').
+        task_options: Per-task or per-branch provider_options dict (level 3).
+
+    Returns:
+        Merged options dict, or None if no options were set at any level.
+    """
+    merged: dict[str, Any] = {}
+
+    # Level 1: Config-level options.
+    # Use exclude_defaults=True so that Pydantic default values (False, [], None)
+    # do not override explicit settings at higher-priority levels.
+    if config is not None and config.providers is not None:
+        config_opts = getattr(config.providers, provider_name, None)
+        if config_opts is not None:
+            merged = _deep_merge(merged, config_opts.model_dump(exclude_defaults=True))
+
+    # Level 2: Workflow-level options (from flow.providers dict).
+    if flow.providers is not None:
+        flow_opts = flow.providers.get(provider_name)
+        if flow_opts is not None:
+            merged = _deep_merge(merged, flow_opts)
+
+    # Level 3: Task/Branch-level options.
+    if task_options is not None:
+        merged = _deep_merge(merged, task_options)
+
+    return merged if merged else None
+
+
 def compile_flow(
     flow: Flow,
     input_keys: set[str] | None = None,
     checkpointer: Any = None,
     recorder: Any = None,
+    config: "FdsxConfig | None" = None,
 ) -> CompiledGraph:
     """Compile a Flow into a LangGraph StateGraph.
 
@@ -132,6 +177,7 @@ def compile_flow(
         checkpointer: Optional checkpointer for state persistence.
                       If not provided and the flow contains Wait states,
                       a MemorySaver will be used as default.
+        config: Optional fdsx configuration used to resolve provider options.
 
     Returns:
         CompiledGraph with the compiled state machine
@@ -153,7 +199,7 @@ def compile_flow(
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
             graph.add_node(
-                state_name, _create_task_node(state_name, state, flow, recorder)
+                state_name, _create_task_node(state_name, state, flow, recorder, config)
             )  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
             graph.add_node(
@@ -165,7 +211,7 @@ def compile_flow(
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_branch_{state_name}",
-                _create_branch_executor(state_name, state, flow, recorder),
+                _create_branch_executor(state_name, state, flow, recorder, config),
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_collect_{state_name}",
@@ -281,9 +327,14 @@ def _set_next_state_meta(state_dict: dict[str, Any], state: Any) -> dict[str, An
 
 
 def _create_task_node(
-    state_name: str, state: TaskState, flow: Flow, recorder: Any = None
+    state_name: str,
+    state: TaskState,
+    flow: Flow,
+    recorder: Any = None,
+    config: "FdsxConfig | None" = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Task state."""
+    merged_options = _merge_provider_options(config, flow, state.provider, state.provider_options)
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         from fdsx.core.extraction import extract_value
@@ -303,7 +354,7 @@ def _create_task_node(
         prompt = state.prompt_template or ""
         resolved_prompt = resolve_template(prompt, state_dict)
 
-        provider = get_provider(state.provider)
+        provider = get_provider(state.provider, merged_options)
 
         max_retries = state.retry if state.retry is not None else 3
         last_error = "No attempts made"
@@ -431,7 +482,11 @@ def _create_dispatch_node(
 
 
 def _create_branch_executor(
-    state_name: str, state: ParallelState, flow: Flow, recorder: Any = None
+    state_name: str,
+    state: ParallelState,
+    flow: Flow,
+    recorder: Any = None,
+    config: "FdsxConfig | None" = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a shared branch executor node invoked once per branch via Send.
 
@@ -458,7 +513,8 @@ def _create_branch_executor(
         prompt = branch.prompt_template or ""
         resolved_prompt = resolve_template(prompt, state_dict)
 
-        provider = get_provider(branch.provider)
+        merged_options = _merge_provider_options(config, flow, branch.provider, branch.provider_options)
+        provider = get_provider(branch.provider, merged_options)
 
         max_retries = branch.retry if branch.retry is not None else 3
         last_error = "No attempts made"

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -8,6 +8,13 @@ from langgraph.graph import END, StateGraph
 from langgraph.types import interrupt, Send
 
 from fdsx.core.config import _deep_merge
+from fdsx.core.hooks import (
+    INPUT_FILENAME,
+    OUTPUT_FILENAME,
+    collect_hooks,
+    execute_hooks,
+    write_hook_data,
+)
 from fdsx.core.variables import (
     resolve_template,
     resolve_template_shell_safe,
@@ -19,6 +26,7 @@ from fdsx.models.flow import (
     AggregateRule,
     ChoiceState,
     Flow,
+    HookEntry,
     ParallelState,
     PassState,
     TaskState,
@@ -201,38 +209,83 @@ def compile_flow(
 
             checkpointer = MemorySaver()
 
+    # Derive the .fdsx base directory for hook data files from log_dir.
+    # log_dir = .fdsx/runs/<thread-id>/logs/ → parent×3 = .fdsx/
+    fdsx_base_dir: Path | None = log_dir.parent.parent.parent if log_dir is not None else None
+
+    # Resolve config-level hooks (merged global+project hooks are in fdsx_config.hooks)
+    config_hooks = config.hooks if config is not None else None
+
+    def _collect_state_hooks(state_obj: Any) -> tuple[list[HookEntry], list[HookEntry]]:
+        """Collect on_start and on_complete hooks for a state from all levels."""
+        on_s = collect_hooks(
+            "on_start",
+            global_hooks=config_hooks,
+            project_hooks=None,
+            flow_hooks=flow.hooks,
+            state_hooks=state_obj.hooks,
+        )
+        on_c = collect_hooks(
+            "on_complete",
+            global_hooks=config_hooks,
+            project_hooks=None,
+            flow_hooks=flow.hooks,
+            state_hooks=state_obj.hooks,
+        )
+        return on_s, on_c
+
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
+            on_start, on_complete = _collect_state_hooks(state)
+            node = _create_task_node(state_name, state, flow, recorder, config, log_dir)
             graph.add_node(
-                state_name, _create_task_node(state_name, state, flow, recorder, config, log_dir)
+                state_name,
+                _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
+            on_start, on_complete = _collect_state_hooks(state)
+            node = _create_choice_node(state_name, state, flow, recorder)
             graph.add_node(
-                state_name, _create_choice_node(state_name, state, flow, recorder)
+                state_name,
+                _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
         elif isinstance(state, ParallelState):
+            on_start, on_complete = _collect_state_hooks(state)
+            # Hooks wrap dispatch (on_start) and collector (on_complete), not branch executor.
+            dispatch_node = _create_dispatch_node(state_name, state, recorder)
             graph.add_node(
-                state_name, _create_dispatch_node(state_name, state, recorder)
+                state_name,
+                _wrap_with_hooks(dispatch_node, state_name, on_start, [], recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_branch_{state_name}",
                 _create_branch_executor(state_name, state, flow, recorder, config, log_dir),
             )  # type: ignore[call-overload]
+            collector_node = _create_collector_node(state_name, state, flow, recorder)
             graph.add_node(
                 f"_collect_{state_name}",
-                _create_collector_node(state_name, state, flow, recorder),
+                _wrap_with_hooks(collector_node, state_name, [], on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
         elif state.type == "pass":
+            on_start, on_complete = _collect_state_hooks(state)
+            node = _create_pass_node(state_name, state, flow, recorder)
             graph.add_node(
-                state_name, _create_pass_node(state_name, state, flow, recorder)
+                state_name,
+                _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
         elif state.type == "wait":
+            on_start, on_complete = _collect_state_hooks(state)
+            # WaitState is split into two nodes: notify (pre-interrupt) and interrupt.
+            # on_start hooks fire in the notify node; on_complete hooks fire in the interrupt node.
+            notify_node = _create_wait_notify_node(state_name, state, recorder)
             graph.add_node(
-                state_name, _create_wait_notify_node(state_name, state, recorder)
+                state_name,
+                _wrap_with_hooks(notify_node, state_name, on_start, [], recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
+            interrupt_node = _create_wait_interrupt_node(state_name, state, recorder)
             graph.add_node(
                 f"_{state_name}_int",
-                _create_wait_interrupt_node(state_name, state, recorder),
+                _wrap_with_hooks(interrupt_node, state_name, [], on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
             )  # type: ignore[call-overload]
             graph.add_edge(state_name, f"_{state_name}_int")
 
@@ -329,6 +382,96 @@ def _set_next_state_meta(state_dict: dict[str, Any], state: Any) -> dict[str, An
     else:
         state_dict["_meta"] = {"next_state": next_name}
     return state_dict
+
+
+def _wrap_with_hooks(
+    node_fn: Callable[[dict[str, Any]], dict[str, Any]],
+    state_name: str,
+    on_start_hooks: list[HookEntry],
+    on_complete_hooks: list[HookEntry],
+    *,
+    recorder: Any = None,
+    fdsx_base_dir: Path | None = None,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Wrap a node function with hook execution.
+
+    Calls execute_hooks(on_start_hooks) with status "starting" before node
+    execution and execute_hooks(on_complete_hooks) with status "completed"
+    after.  Hook data (input/output state dicts) is written to
+    .fdsx/runs/<thread-id>/hooks/<state-name>/{input,output}.json.
+
+    If both hook lists are empty, returns node_fn unchanged (no-op).
+
+    Args:
+        node_fn: The original node function to wrap.
+        state_name: Logical state name used for hook data paths.
+        on_start_hooks: Hooks to execute before the node runs.
+        on_complete_hooks: Hooks to execute after the node runs.
+        recorder: RunRecorder providing thread_id and flow_name.
+        fdsx_base_dir: The .fdsx root directory for hook data files.
+                       When None, defaults to CWD/.fdsx.
+
+    Returns:
+        Wrapped node function, or the original node_fn when both lists are empty.
+    """
+    if not on_start_hooks and not on_complete_hooks:
+        return node_fn
+
+    def wrapped(state_dict: dict[str, Any]) -> dict[str, Any]:
+        thread_id: str = recorder.thread_id if recorder is not None else ""
+        flow_name: str = recorder.flow_name if recorder is not None else ""
+
+        input_data_path = write_hook_data(
+            state_dict,
+            state_name=state_name,
+            filename=INPUT_FILENAME,
+            thread_id=thread_id,
+            base_dir=fdsx_base_dir,
+        )
+
+        if on_start_hooks:
+            execute_hooks(
+                on_start_hooks,
+                state_name=state_name,
+                status="starting",
+                data_path=input_data_path,
+                thread_id=thread_id,
+                flow_name=flow_name,
+            )
+
+        node_error: BaseException | None = None
+        result: dict[str, Any] = state_dict  # fallback data written to output.json on failure
+        try:
+            result = node_fn(state_dict)
+        except BaseException as exc:
+            node_error = exc
+
+        status = "completed" if node_error is None else "failed"
+
+        output_data_path = write_hook_data(
+            result,
+            state_name=state_name,
+            filename=OUTPUT_FILENAME,
+            thread_id=thread_id,
+            base_dir=fdsx_base_dir,
+        )
+
+        if on_complete_hooks:
+            execute_hooks(
+                on_complete_hooks,
+                state_name=state_name,
+                status=status,
+                data_path=output_data_path,
+                thread_id=thread_id,
+                flow_name=flow_name,
+            )
+
+        if node_error is not None:
+            raise node_error
+
+        return result
+
+    return wrapped
 
 
 def _create_task_node(

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -180,6 +180,7 @@ def compile_flow(
     recorder: Any = None,
     config: "FdsxConfig | None" = None,
     log_dir: Path | None = None,
+    quiet: bool = False,
 ) -> CompiledGraph:
     """Compile a Flow into a LangGraph StateGraph.
 
@@ -194,6 +195,8 @@ def compile_flow(
         log_dir: Optional directory for per-state streaming log files
                  (.fdsx/runs/<thread-id>/logs/). When None, streaming still
                  works on the terminal but no log files are written.
+        quiet: When True, suppresses stderr streaming output from StreamLogger.
+               Log files are still written.
 
     Returns:
         CompiledGraph with the compiled state machine
@@ -240,7 +243,7 @@ def compile_flow(
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
             on_start, on_complete = _collect_state_hooks(state)
-            node = _create_task_node(state_name, state, flow, recorder, config, log_dir)
+            node = _create_task_node(state_name, state, flow, recorder, config, log_dir, quiet)
             graph.add_node(
                 state_name,
                 _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
@@ -262,7 +265,7 @@ def compile_flow(
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_branch_{state_name}",
-                _create_branch_executor(state_name, state, flow, recorder, config, log_dir),
+                _create_branch_executor(state_name, state, flow, recorder, config, log_dir, quiet),
             )  # type: ignore[call-overload]
             collector_node = _create_collector_node(state_name, state, flow, recorder)
             graph.add_node(
@@ -490,6 +493,7 @@ def _create_task_node(
     recorder: Any = None,
     config: "FdsxConfig | None" = None,
     log_dir: Path | None = None,
+    quiet: bool = False,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Task state."""
     merged_options = _merge_provider_options(config, flow, state.provider, state.provider_options)
@@ -520,7 +524,7 @@ def _create_task_node(
         result = ProviderResult(exit_code=1, stdout="", stderr="")
         extracted: str | None = None
 
-        stream_logger = StreamLogger(state_name, log_dir)
+        stream_logger = StreamLogger(state_name, log_dir, quiet=quiet)
         try:
             for attempt in range(max_retries + 1):
                 if attempt > 0:
@@ -653,6 +657,7 @@ def _create_branch_executor(
     recorder: Any = None,
     config: "FdsxConfig | None" = None,
     log_dir: Path | None = None,
+    quiet: bool = False,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a shared branch executor node invoked once per branch via Send.
 
@@ -688,7 +693,7 @@ def _create_branch_executor(
         result = ProviderResult(exit_code=1, stdout="", stderr="")
         extracted: str | None = None
 
-        stream_logger = StreamLogger(state_name, log_dir)
+        stream_logger = StreamLogger(state_name, log_dir, quiet=quiet)
         try:
             for attempt in range(max_retries + 1):
                 if attempt > 0:

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -20,6 +20,7 @@ from fdsx.core.variables import (
     resolve_template,
     resolve_template_shell_safe,
     set_jsonpath,
+    write_result_to_file,
 )
 from fdsx.display import terminal
 from fdsx.display.terminal import _sanitize_output
@@ -103,10 +104,18 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
                 k = _top_level_key(state.extract.result_path)
                 if k:
                     annotations.setdefault(k, Any)
+            if state.result_file:
+                k = _top_level_key(state.result_file)
+                if k:
+                    annotations.setdefault(k, Any)
         elif isinstance(state, ParallelState) and state.result_path:
             k = _top_level_key(state.result_path)
             if k:
                 annotations.setdefault(k, Any)
+            if state.result_file:
+                k = _top_level_key(state.result_file)
+                if k:
+                    annotations.setdefault(k, Any)
         elif isinstance(state, PassState):
             if state.aggregate:
                 k = _top_level_key(state.aggregate.result_path)
@@ -359,8 +368,12 @@ def _extract_result_paths(flow: Flow) -> list[str]:
             paths.append(state.result_path)
             if state.extract:
                 paths.append(state.extract.result_path)
+            if state.result_file:
+                paths.append(state.result_file)
         elif isinstance(state, ParallelState) and state.result_path:
             paths.append(state.result_path)
+            if state.result_file:
+                paths.append(state.result_file)
         elif isinstance(state, PassState) and state.aggregate:
             paths.append(state.aggregate.result_path)
         elif isinstance(state, WaitState) and state.result_path:
@@ -599,6 +612,14 @@ def _create_task_node(
                 state.result_path, state_dict, result.stdout.strip()
             )
             variables_set = [state.result_path]
+
+        if state.result_file:
+            run_dir = state_dict.get("_meta", {}).get("run_dir", "")
+            if run_dir:
+                varname = state.result_file[2:]  # strip "$."
+                file_path = write_result_to_file(varname, result.stdout.strip(), Path(run_dir))
+                new_state = set_jsonpath(state.result_file, new_state, file_path)
+                variables_set = [*variables_set, state.result_file]
 
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
@@ -881,6 +902,13 @@ def _create_collector_node(
 
         new_state = set_jsonpath(state.result_path, state_dict, clean_results)
 
+        if state.result_file:
+            run_dir = state_dict.get("_meta", {}).get("run_dir", "")
+            if run_dir:
+                varname = state.result_file[2:]  # strip "$."
+                file_path = write_result_to_file(varname, clean_results, Path(run_dir))
+                new_state = set_jsonpath(state.result_file, new_state, file_path)
+
         display_results = []
         for r in sorted_results:
             idx = r.get("index", 0)
@@ -901,12 +929,16 @@ def _create_collector_node(
         duration = time.time() - start_time
         terminal.display_state_complete(state_name, duration)
 
+        recorded_paths = [state.result_path]
+        if state.result_file:
+            recorded_paths.append(state.result_file)
+
         if recorder is not None:
             recorder.record_state_complete(
                 state_name,
                 "success",
                 "",
-                [state.result_path],
+                recorded_paths,
                 branch_info_list,
             )
 

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -1,3 +1,4 @@
+import logging
 import operator
 import subprocess
 import time
@@ -36,6 +37,8 @@ from fdsx.providers.base import get_provider
 
 if TYPE_CHECKING:
     from fdsx.core.config import FdsxConfig
+
+logger = logging.getLogger(__name__)
 
 
 class FlowState(TypedDict):
@@ -448,23 +451,29 @@ def _wrap_with_hooks(
 
         status = "completed" if node_error is None else "failed"
 
-        output_data_path = write_hook_data(
-            result,
-            state_name=state_name,
-            filename=OUTPUT_FILENAME,
-            thread_id=thread_id,
-            base_dir=fdsx_base_dir,
-        )
-
-        if on_complete_hooks:
-            execute_hooks(
-                on_complete_hooks,
+        try:
+            output_data_path = write_hook_data(
+                result,
                 state_name=state_name,
-                status=status,
-                data_path=output_data_path,
+                filename=OUTPUT_FILENAME,
                 thread_id=thread_id,
-                flow_name=flow_name,
+                base_dir=fdsx_base_dir,
             )
+
+            if on_complete_hooks:
+                execute_hooks(
+                    on_complete_hooks,
+                    state_name=state_name,
+                    status=status,
+                    data_path=output_data_path,
+                    thread_id=thread_id,
+                    flow_name=flow_name,
+                )
+        except BaseException:
+            if node_error is not None:
+                logger.warning("Hook cleanup failed after node error", exc_info=True)
+                raise node_error
+            raise
 
         if node_error is not None:
             raise node_error

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -1,7 +1,7 @@
 """Configuration system for fdsx.
 
 Loads config from XDG global (~/.config/fdsx/config.yaml) and project-level
-.fdsx/config.yaml, shallow-merging with project taking precedence.
+.fdsx/config.yaml, deep-merging with project taking precedence.
 Built-in defaults are used when no config files exist.
 """
 
@@ -15,6 +15,9 @@ import yaml
 from pydantic import BaseModel, Field, field_validator
 
 from fdsx.models.validators import validate_llm_provider
+from fdsx.providers.claude import ClaudeOptions
+from fdsx.providers.codex import CodexOptions
+from fdsx.providers.opencode import OpenCodeOptions
 
 
 class TaskSplitterConfig(BaseModel):
@@ -53,6 +56,25 @@ class WorkflowSelectorConfig(BaseModel):
         return validate_llm_provider(v, "workflow_selector")
 
 
+class ProviderConfigs(BaseModel):
+    """Configuration for provider-specific options."""
+
+    claude: ClaudeOptions | None = Field(
+        default=None,
+        description="Claude provider options",
+    )
+    codex: CodexOptions | None = Field(
+        default=None,
+        description="Codex provider options",
+    )
+    opencode: OpenCodeOptions | None = Field(
+        default=None,
+        description="OpenCode provider options",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
 class FdsxConfig(BaseModel):
     """Top-level fdsx configuration."""
 
@@ -72,6 +94,10 @@ class FdsxConfig(BaseModel):
         default=False,
         description="Skip confirmation for auto-selected workflows",
     )
+    providers: ProviderConfigs | None = Field(
+        default=None,
+        description="Provider-specific configuration options",
+    )
 
     @field_validator("workflows_dir")
     @classmethod
@@ -86,6 +112,29 @@ class FdsxConfig(BaseModel):
         return v
 
     model_config = {"extra": "forbid"}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge override into base, with override taking precedence.
+
+    When both base and override have a dict value for the same key, the dicts
+    are merged recursively. Otherwise, the override value wins outright.
+
+    Args:
+        base: Base dictionary (lower priority).
+        override: Override dictionary (higher priority).
+
+    Returns:
+        New merged dictionary (does not mutate either input).
+    """
+    result: dict[str, Any] = dict(base)
+    for key, override_val in override.items():
+        base_val = result.get(key)
+        if isinstance(base_val, dict) and isinstance(override_val, dict):
+            result[key] = _deep_merge(base_val, override_val)
+        else:
+            result[key] = override_val
+    return result
 
 
 def _load_yaml(path: Path | None) -> dict[str, Any]:
@@ -161,6 +210,8 @@ def load_config(
         if proj_config_dir is not None:
             raw_project = _load_yaml(proj_config_dir / "config.yaml")
 
-    merged: dict[str, Any] = {**defaults.model_dump(), **raw_global, **raw_project}
+    merged: dict[str, Any] = _deep_merge(
+        _deep_merge(defaults.model_dump(), raw_global), raw_project
+    )
 
     return FdsxConfig.model_validate(merged)

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -56,9 +56,9 @@ class WorkflowSelectorConfig(BaseModel):
 class FdsxConfig(BaseModel):
     """Top-level fdsx configuration."""
 
-    task_splitter: TaskSplitterConfig = Field(
-        default_factory=TaskSplitterConfig,
-        description="Batch task splitting configuration",
+    task_splitter: TaskSplitterConfig | None = Field(
+        default=None,
+        description="Batch task splitting configuration (must be explicitly configured)",
     )
     workflow_selector: WorkflowSelectorConfig = Field(
         default_factory=WorkflowSelectorConfig,

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -14,10 +14,14 @@ from typing import Any
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
+from fdsx.models.flow import HookConfig
 from fdsx.models.validators import validate_llm_provider
 from fdsx.providers.claude import ClaudeOptions
 from fdsx.providers.codex import CodexOptions
 from fdsx.providers.opencode import OpenCodeOptions
+
+# Keys within HookConfig whose list values are concatenated (not replaced) during deep merge
+_HOOK_LIST_KEYS: frozenset[str] = frozenset({"on_start", "on_complete"})
 
 
 class TaskSplitterConfig(BaseModel):
@@ -98,6 +102,10 @@ class FdsxConfig(BaseModel):
         default=None,
         description="Provider-specific configuration options",
     )
+    hooks: HookConfig | None = Field(
+        default=None,
+        description="Global hook configuration applied to all flows",
+    )
 
     @field_validator("workflows_dir")
     @classmethod
@@ -118,7 +126,9 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     """Recursively merge override into base, with override taking precedence.
 
     When both base and override have a dict value for the same key, the dicts
-    are merged recursively. Otherwise, the override value wins outright.
+    are merged recursively. For keys in _HOOK_LIST_KEYS (on_start, on_complete),
+    list values are concatenated (base + override) rather than replaced.
+    Otherwise, the override value wins outright.
 
     Args:
         base: Base dictionary (lower priority).
@@ -132,6 +142,12 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
         base_val = result.get(key)
         if isinstance(base_val, dict) and isinstance(override_val, dict):
             result[key] = _deep_merge(base_val, override_val)
+        elif (
+            key in _HOOK_LIST_KEYS
+            and isinstance(base_val, list)
+            and isinstance(override_val, list)
+        ):
+            result[key] = base_val + override_val
         else:
             result[key] = override_val
     return result

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -1,0 +1,166 @@
+"""Configuration system for fdsx.
+
+Loads config from XDG global (~/.config/fdsx/config.yaml) and project-level
+.fdsx/config.yaml, shallow-merging with project taking precedence.
+Built-in defaults are used when no config files exist.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+from fdsx.models.validators import validate_llm_provider
+
+
+class TaskSplitterConfig(BaseModel):
+    """Configuration for batch task splitting (formerly TaskSplitter in flow.py)."""
+
+    provider: str = Field(
+        default="claude",
+        description="Provider name (claude/opencode/codex)",
+    )
+    model: str = Field(
+        default="claude-sonnet-4-6",
+        description="Model name",
+    )
+
+    @field_validator("provider")
+    @classmethod
+    def validate_provider(cls, v: str) -> str:
+        return validate_llm_provider(v, "task_splitter")
+
+
+class WorkflowSelectorConfig(BaseModel):
+    """Configuration for workflow auto-selection."""
+
+    provider: str = Field(
+        default="claude",
+        description="Provider for workflow selection",
+    )
+    model: str = Field(
+        default="claude-sonnet-4-6",
+        description="Model for workflow selection",
+    )
+
+    @field_validator("provider")
+    @classmethod
+    def validate_provider(cls, v: str) -> str:
+        return validate_llm_provider(v, "workflow_selector")
+
+
+class FdsxConfig(BaseModel):
+    """Top-level fdsx configuration."""
+
+    task_splitter: TaskSplitterConfig = Field(
+        default_factory=TaskSplitterConfig,
+        description="Batch task splitting configuration",
+    )
+    workflow_selector: WorkflowSelectorConfig = Field(
+        default_factory=WorkflowSelectorConfig,
+        description="Workflow auto-selection configuration",
+    )
+    workflows_dir: str = Field(
+        default=".fdsx/workflows",
+        description="Directory to discover workflow files",
+    )
+    auto_workflow: bool = Field(
+        default=False,
+        description="Skip confirmation for auto-selected workflows",
+    )
+
+    @field_validator("workflows_dir")
+    @classmethod
+    def validate_workflows_dir(cls, v: str) -> str:
+        p = Path(v)
+        if p.is_absolute():
+            raise ValueError(f"workflows_dir must be a relative path, got '{v}'")
+        if ".." in p.parts:
+            raise ValueError(
+                f"workflows_dir must not contain '..' components, got '{v}'"
+            )
+        return v
+
+    model_config = {"extra": "forbid"}
+
+
+def _load_yaml(path: Path | None) -> dict[str, Any]:
+    """Load YAML file, returning empty dict if file doesn't exist."""
+    if path is None or not path.exists():
+        return {}
+    with open(path, encoding="utf-8") as f:
+        try:
+            data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML in config file {path}: {e}") from e
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Config file {path} must be a YAML mapping, got {type(data).__name__}"
+        )
+    return data
+
+
+def _resolve_xdg_config_dir() -> Path | None:
+    """Resolve XDG_CONFIG_HOME or fallback to ~/.config."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        config_dir = Path(xdg)
+    else:
+        config_dir = Path.home() / ".config"
+    fdsx_dir = config_dir / "fdsx"
+    return fdsx_dir if fdsx_dir.exists() else None
+
+
+def _resolve_project_config_dir(cwd: Path | None = None) -> Path | None:
+    """Resolve project-level .fdsx config directory."""
+    if cwd is None:
+        cwd = Path.cwd()
+    project_dir = cwd / ".fdsx"
+    return project_dir if project_dir.exists() else None
+
+
+def load_config(
+    project_dir: Path | None = None,
+    *,
+    load_global: bool = True,
+    load_project: bool = True,
+) -> FdsxConfig:
+    """Load and merge fdsx configuration.
+
+    Resolution order (later wins):
+    1. Built-in defaults (FdsxConfig defaults)
+    2. Global config: $XDG_CONFIG_HOME/fdsx/config.yaml (or ~/.config/fdsx/config.yaml)
+    3. Project config: <project_dir>/.fdsx/config.yaml
+
+    Args:
+        project_dir: Project root directory. Defaults to CWD.
+        load_global: Whether to load global config. Defaults to True.
+        load_project: Whether to load project config. Defaults to True.
+
+    Returns:
+        Merged FdsxConfig with all three layers applied.
+    """
+    defaults = FdsxConfig()
+
+    raw_global: dict[str, Any] = {}
+    if load_global:
+        global_dir = _resolve_xdg_config_dir()
+        if global_dir is not None:
+            raw_global = _load_yaml(global_dir / "config.yaml")
+
+    raw_project: dict[str, Any] = {}
+    if load_project:
+        proj_dir = project_dir or Path.cwd()
+        proj_config_dir = _resolve_project_config_dir(proj_dir)
+        if proj_config_dir is not None:
+            raw_project = _load_yaml(proj_config_dir / "config.yaml")
+
+    merged: dict[str, Any] = {**defaults.model_dump(), **raw_global, **raw_project}
+
+    return FdsxConfig.model_validate(merged)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -1,8 +1,9 @@
 import sys
-import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, cast
+
+import uuid_utils
 
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.errors import GraphRecursionError
@@ -63,7 +64,7 @@ def run_flow(
         RuntimeError: If flow validation fails or execution fails
     """
     if thread_id is None:
-        thread_id = str(uuid.uuid4())
+        thread_id = str(uuid_utils.uuid7())
 
     print(f"Thread ID: {_sanitize_output(thread_id)}", file=sys.stderr)
 
@@ -298,8 +299,6 @@ def run_batch(
         FlowValidationError: If flow validation fails
         RuntimeError: If task_splitter is missing or execution fails
     """
-    import uuid
-
     flow, errors = load_flow(workflow_path)
     if flow is None:
         raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
@@ -331,7 +330,7 @@ def run_batch(
     results: list[dict[str, Any]] = []
 
     for i, task_description in enumerate(tasks):
-        thread_id = str(uuid.uuid4())
+        thread_id = str(uuid_utils.uuid7())
 
         print(
             f"\nExecuting task {i + 1}/{len(tasks)}: {_sanitize_output(task_description[:50])}...",
@@ -712,8 +711,6 @@ def run_tasks_dir(
     Raises:
         FlowValidationError: If flow validation fails.
     """
-    import uuid
-
     try:
         task_files = load_tasks_dir(tasks_dir)
     except ValueError as e:
@@ -857,7 +854,7 @@ def run_tasks_dir(
                 )
 
         for entry_idx, entry in actionable:
-            thread_id = str(uuid.uuid4())
+            thread_id = str(uuid_utils.uuid7())
             description = entry.description
             original_status = entry.status
             category = "retried" if original_status in ("failed", "running") else "new"

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -14,6 +14,7 @@ from fdsx.core.batch import (
     split_tasks,
 )
 from fdsx.core.compiler import compile_flow
+from fdsx.core.config import load_config
 from fdsx.core.loader import load_flow
 from fdsx.display.terminal import _sanitize_output, display_wait_prompt
 from fdsx.logging import RunRecorder
@@ -233,12 +234,16 @@ def run_batch(
     if flow is None:
         raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
 
-    if flow.task_splitter is None:
+    config = load_config()
+    if config.task_splitter is None:
         raise FlowValidationError(
-            "Flow must define 'task_splitter' configuration for batch execution"
+            "Batch execution requires task_splitter configuration. "
+            "Add task_splitter settings to your .fdsx/config.yaml:\n"
+            "  task_splitter:\n"
+            "    provider: claude\n"
+            "    model: claude-sonnet-4-6"
         )
-
-    task_splitter = flow.task_splitter
+    task_splitter = config.task_splitter
 
     tasks_file_content = tasks_file.read_text()
 

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -13,6 +13,7 @@ from fdsx.core.batch import (
     display_batch_summary,
     display_task_list,
     display_tasks_dir_summary,
+    move_task_to_completed,
     split_tasks,
 )
 from fdsx.core.compiler import compile_flow
@@ -820,6 +821,15 @@ def run_tasks_dir(
                         "category": "skipped",
                     }
                 )
+            # All entries were already completed — move to completed/
+            try:
+                move_task_to_completed(file_path)
+            except Exception as e:
+                print(
+                    f"  Warning: could not move {_sanitize_output(file_path.name)} "
+                    f"to completed/: {_sanitize_output(str(e))}",
+                    file=sys.stderr,
+                )
             continue
 
         print(
@@ -931,6 +941,17 @@ def run_tasks_dir(
                         print("Stopping tasks-dir execution.", file=sys.stderr)
                         display_tasks_dir_summary(results)
                         return results
+
+        # Move the file to completed/ if all entries finished successfully
+        if all(entry.status == "completed" for entry in task_file.entries):
+            try:
+                move_task_to_completed(file_path)
+            except Exception as e:
+                print(
+                    f"  Warning: could not move {_sanitize_output(file_path.name)} "
+                    f"to completed/: {_sanitize_output(str(e))}",
+                    file=sys.stderr,
+                )
 
     display_tasks_dir_summary(results)
     return results

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -631,7 +631,12 @@ def run_tasks_dir(
     """
     import uuid
 
-    task_files = load_tasks_dir(tasks_dir)
+    try:
+        task_files = load_tasks_dir(tasks_dir)
+    except ValueError as e:
+        raise FlowValidationError(str(e)) from e
+    except FileNotFoundError as e:
+        raise FlowValidationError(str(e))
     results: list[dict[str, Any]] = []
     workflow_assignments: dict[tuple[int, int], Path] = {}
 

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -28,6 +28,7 @@ from fdsx.display.terminal import (
     display_wait_prompt,
 )
 from fdsx.logging import RunRecorder
+from fdsx.logging.recorder import FDSX_DIR_NAME, LOGS_DIR_NAME, RUNS_DIR_NAME
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 
 
@@ -96,12 +97,16 @@ def run_flow(
 
     fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
 
+    _runs_base = base_dir if base_dir is not None else Path.cwd() / FDSX_DIR_NAME
+    log_dir = _runs_base / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
     compiled = compile_flow(
         flow,
         input_keys=set(inputs.keys()) if inputs else None,
         checkpointer=checkpointer,
         recorder=recorder,
         config=fdsx_config,
+        log_dir=log_dir,
     )
 
     initial_state: dict[str, Any] = {
@@ -465,11 +470,14 @@ def resume_flow(
 
         fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
 
+        resume_log_dir = base_dir / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
         compiled = compile_flow(
             flow,
             checkpointer=checkpointer,
             recorder=recorder,
             config=fdsx_config,
+            log_dir=resume_log_dir,
         )
 
         parallel_extra = sum(

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -713,6 +713,13 @@ def run_tasks_dir(
             entry = task_file.entries[entry_idx]
             entry.workflow = wf_path.name
             save_task_file(file_path, task_file)
+    elif auto_workflow and auto_selection_keys:
+        for (file_idx, entry_idx), wf_path in workflow_assignments.items():
+            file_path, task_file = task_files[file_idx]
+            entry = task_file.entries[entry_idx]
+            if entry.workflow is None:
+                entry.workflow = wf_path.name
+                save_task_file(file_path, task_file)
 
     for file_idx, (file_path, task_file) in enumerate(task_files):
         actionable = _filter_actionable_entries(task_file)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -170,13 +170,13 @@ def run_flow(
 
         results = _extract_results(last_state, compiled.result_paths)
         recorder.finalize(_sanitize_state_for_log(last_state), "completed")
-        recorder.save()
+        recorder.save(base_dir=base_dir)
         return results
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         results = _extract_results(last_state, compiled.result_paths)
         recorder.finalize(_sanitize_state_for_log(last_state), "completed")
-        recorder.save()
+        recorder.save(base_dir=base_dir)
         return results
     except Exception as e:
         if checkpoint_manager is not None:
@@ -185,7 +185,7 @@ def run_flow(
                 file=sys.stderr,
             )
         recorder.finalize(_sanitize_state_for_log(last_state), "error")
-        recorder.save()
+        recorder.save(base_dir=base_dir)
         raise RuntimeError(f"Flow execution failed: {e}")
     finally:
         if checkpoint_manager is not None:
@@ -385,9 +385,10 @@ def resume_flow(
             raise RuntimeError(f"Failed to load flow for resume: {', '.join(errors)}")
 
         from fdsx.models.flow import WaitState, ParallelState
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
 
-        runs_dir = Path.cwd() / "runs"
-        existing_log_path = runs_dir / f"{thread_id}.json"
+        runs_dir = base_dir / RUNS_DIR_NAME
+        existing_log_path = runs_dir / thread_id / RUN_FILENAME
 
         if existing_log_path.exists():
             import json
@@ -501,19 +502,19 @@ def resume_flow(
         results = _extract_results(last_state, compiled.result_paths)
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "completed")
-            recorder.save()
+            recorder.save(base_dir=base_dir)
         return results
     except GraphRecursionError:
         if flow is not None:
             print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "completed")
-            recorder.save()
+            recorder.save(base_dir=base_dir)
         return {}
     except Exception as e:
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "error")
-            recorder.save()
+            recorder.save(base_dir=base_dir)
         raise RuntimeError(f"Flow resume failed: {e}")
     finally:
         checkpoint_manager.release_lock(thread_id)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -1,5 +1,6 @@
 import sys
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -20,7 +21,12 @@ from fdsx.core.loader import load_flow
 from fdsx.core.selector import (
     resolve_workflow_for_task,
 )
-from fdsx.display.terminal import Spinner, _sanitize_output, display_wait_prompt
+from fdsx.display.terminal import (
+    Spinner,
+    _sanitize_output,
+    display_completion_summary,
+    display_wait_prompt,
+)
 from fdsx.logging import RunRecorder
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 
@@ -171,12 +177,14 @@ def run_flow(
         results = _extract_results(last_state, compiled.result_paths)
         recorder.finalize(_sanitize_state_for_log(last_state), "completed")
         recorder.save(base_dir=base_dir)
+        display_completion_summary(flow.name, _calc_elapsed(recorder))
         return results
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         results = _extract_results(last_state, compiled.result_paths)
         recorder.finalize(_sanitize_state_for_log(last_state), "completed")
         recorder.save(base_dir=base_dir)
+        display_completion_summary(flow.name, _calc_elapsed(recorder))
         return results
     except Exception as e:
         if checkpoint_manager is not None:
@@ -186,6 +194,12 @@ def run_flow(
             )
         recorder.finalize(_sanitize_state_for_log(last_state), "error")
         recorder.save(base_dir=base_dir)
+        failed = _find_failed_state(recorder)
+        failed_state_name = failed[0] if failed else "unknown"
+        error_message = failed[1] if (failed and failed[1]) else str(e)
+        display_completion_summary(
+            flow.name, _calc_elapsed(recorder), failed_state_name, error_message
+        )
         raise RuntimeError(f"Flow execution failed: {e}")
     finally:
         if checkpoint_manager is not None:
@@ -215,6 +229,48 @@ def _sanitize_state_for_log(state: dict[str, Any]) -> dict[str, Any]:
         and not k.startswith("__")
         and not k.startswith("_br_")
     }
+
+
+def _calc_elapsed(recorder: RunRecorder) -> float:
+    """Calculate elapsed seconds between recorder.started_at and completed_at.
+
+    Falls back to current time if completed_at is not set.
+
+    Args:
+        recorder: The RunRecorder instance
+
+    Returns:
+        Elapsed time in seconds as a float
+    """
+    try:
+        start = datetime.fromisoformat(recorder.started_at.replace("Z", "+00:00"))
+        end_str = recorder.completed_at
+        end = (
+            datetime.fromisoformat(end_str.replace("Z", "+00:00"))
+            if end_str is not None
+            else datetime.now(timezone.utc)
+        )
+        return (end - start).total_seconds()
+    except (ValueError, TypeError):
+        return 0.0
+
+
+def _find_failed_state(recorder: RunRecorder) -> tuple[str, str] | None:
+    """Return (state_name, error_message) for the most recent error state.
+
+    Searches recorder.states in reverse order for the first state with
+    status=="error".
+
+    Args:
+        recorder: The RunRecorder instance
+
+    Returns:
+        Tuple of (state_name, error_message) or None if no error state found
+    """
+    for state in reversed(recorder.states):
+        if state.get("status") == "error":
+            return (str(state.get("name", "unknown")), str(state.get("error", "")))
+    return None
 
 
 def run_batch(
@@ -503,6 +559,7 @@ def resume_flow(
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "completed")
             recorder.save(base_dir=base_dir)
+            display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
         return results
     except GraphRecursionError:
         if flow is not None:
@@ -510,11 +567,21 @@ def resume_flow(
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "completed")
             recorder.save(base_dir=base_dir)
+            display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
         return {}
     except Exception as e:
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "error")
             recorder.save(base_dir=base_dir)
+            failed = _find_failed_state(recorder)
+            failed_state_name = failed[0] if failed else "unknown"
+            error_message = failed[1] if (failed and failed[1]) else str(e)
+            display_completion_summary(
+                recorder.flow_name,
+                _calc_elapsed(recorder),
+                failed_state_name,
+                error_message,
+            )
         raise RuntimeError(f"Flow resume failed: {e}")
     finally:
         checkpoint_manager.release_lock(thread_id)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -661,6 +661,7 @@ def run_tasks_dir(
                     (file_idx, entry_idx, file_path, entry.description)
                 )
 
+    auto_selection_keys: list[tuple[int, int]] = []
     if auto_selection_entries:
         total = len(auto_selection_entries)
         with Spinner(
@@ -672,49 +673,46 @@ def run_tasks_dir(
                 spinner.update(
                     f"Auto-selecting workflows for {total} task{'s' if total != 1 else ''}... ({count}/{total})"
                 )
-                resolved = resolve_workflow_for_task(
-                    task_description=description,
-                    workflows_dir=workflows_dir,
-                    selector_config=config.workflow_selector,
-                    auto_workflow=True,
-                )
-                if resolved is not None:
-                    workflow_assignments[(file_idx, entry_idx)] = resolved
-                else:
-                    raise ValueError(
-                        f"No workflow selected for entry {entry_idx} "
-                        f"in {file_path.name}: selection was cancelled."
+                auto_selection_keys.append((file_idx, entry_idx))
+                try:
+                    resolved = resolve_workflow_for_task(
+                        task_description=description,
+                        workflows_dir=workflows_dir,
+                        selector_config=config.workflow_selector,
+                        auto_workflow=True,
+                    )
+                    if resolved is not None:
+                        workflow_assignments[(file_idx, entry_idx)] = resolved
+                except (ValueError, RuntimeError) as e:
+                    print(
+                        f"  Warning: auto-selection failed for entry {entry_idx} "
+                        f"in {file_path.name}: {_sanitize_output(str(e))}",
+                        file=sys.stderr,
                     )
 
-    if workflow_assignments and not auto_workflow:
-        from fdsx.core.selector import discover_workflows, pick_workflow_manually
+    if (workflow_assignments or auto_selection_keys) and not auto_workflow:
+        from fdsx.core.selector import discover_workflows
+        from fdsx.display.terminal import confirm_workflow_assignments_interactive
 
-        _display_batch_workflow_confirm(workflow_assignments, task_files)
-        approved = input("Approve workflow assignments? (y/n): ").strip().lower()
-        if approved != "y":
-            print("\nEdit workflow assignments:", file=sys.stderr)
-            discovered = discover_workflows(workflows_dir)
-            for key in sorted(workflow_assignments.keys()):
-                file_idx, entry_idx = key
-                file_path, task_file = task_files[file_idx]
-                entry = task_file.entries[entry_idx]
-                current_wf = workflow_assignments[key]
-                desc_preview = entry.description[:40]
-                if len(entry.description) > 40:
-                    desc_preview += "..."
-                print(
-                    f"\n  {file_path.name} entry {entry_idx + 1}: {desc_preview}",
-                    file=sys.stderr,
-                )
-                print(f"  Current: {current_wf.name}", file=sys.stderr)
-                choice = input("  Keep (k) or Change (c)? ").strip().lower()
-                if choice == "c":
-                    picked = pick_workflow_manually(discovered)
-                    if picked is not None:
-                        workflow_assignments[key] = picked
-                    else:
-                        print("Batch execution aborted.", file=sys.stderr)
-                        return results
+        discovered = discover_workflows(workflows_dir)
+        display_keys = sorted(workflow_assignments.keys()) + [
+            k for k in auto_selection_keys if k not in workflow_assignments
+        ]
+        result = confirm_workflow_assignments_interactive(
+            display_keys=display_keys,
+            workflow_assignments=workflow_assignments,
+            task_files=task_files,
+            available_workflows=discovered,
+        )
+        if result is None:
+            print("Workflow assignments cancelled.", file=sys.stderr)
+            return results
+        workflow_assignments = result
+        for (file_idx, entry_idx), wf_path in workflow_assignments.items():
+            file_path, task_file = task_files[file_idx]
+            entry = task_file.entries[entry_idx]
+            entry.workflow = wf_path.name
+            save_task_file(file_path, task_file)
 
     for file_idx, (file_path, task_file) in enumerate(task_files):
         actionable = _filter_actionable_entries(task_file)
@@ -847,38 +845,3 @@ def run_tasks_dir(
 
     display_tasks_dir_summary(results)
     return results
-
-
-def _display_batch_workflow_confirm(
-    workflow_assignments: dict[tuple[int, int], Path],
-    task_files: list[tuple[Path, TaskFile]],
-) -> None:
-    """Display workflow assignments for batch confirmation (FR-6.3).
-
-    Args:
-        workflow_assignments: Map of (file_idx, entry_idx) -> workflow path.
-        task_files: List of (file_path, task_file) tuples.
-    """
-    print("\n" + "=" * 80, file=sys.stderr)
-    print("WORKFLOW ASSIGNMENTS", file=sys.stderr)
-    print("=" * 80, file=sys.stderr)
-    print(
-        f"{'FILE':<30} {'ENTRY':<6} {'WORKFLOW':<30} {'TASK':<15}",
-        file=sys.stderr,
-    )
-    print("-" * 80, file=sys.stderr)
-
-    for (file_idx, entry_idx), wf_path in sorted(workflow_assignments.items()):
-        file_path, task_file = task_files[file_idx]
-        entry = task_file.entries[entry_idx]
-        file_name = file_path.name[:29]
-        entry_num = str(entry_idx + 1)
-        wf_name = wf_path.name[:29]
-        task_preview = entry.description[:14]
-
-        print(
-            f"{_sanitize_output(file_name):<30} {entry_num:<6} {_sanitize_output(wf_name):<30} {_sanitize_output(task_preview):<15}",
-            file=sys.stderr,
-        )
-
-    print("=" * 80, file=sys.stderr)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -17,6 +17,9 @@ from fdsx.core.batch import (
 from fdsx.core.compiler import compile_flow
 from fdsx.core.config import load_config
 from fdsx.core.loader import load_flow
+from fdsx.core.selector import (
+    resolve_workflow_for_task,
+)
 from fdsx.display.terminal import _sanitize_output, display_wait_prompt
 from fdsx.logging import RunRecorder
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
@@ -605,16 +608,19 @@ def _update_task_status(
 
 
 def run_tasks_dir(
-    workflow_path: Path,
+    workflow_path: Path | None,
     tasks_dir: Path,
     base_dir: Path | None = None,
+    auto_workflow: bool = False,
 ) -> list[dict[str, Any]]:
     """Execute tasks from a directory of YAML task files with crash-resilient persistence.
 
     Args:
-        workflow_path: Path to the YAML workflow file.
+        workflow_path: Path to the YAML workflow file. If None, workflows are auto-selected
+            per task entry using the selector.
         tasks_dir: Directory containing task YAML files.
         base_dir: Optional base directory for checkpoints (.fdsx/).
+        auto_workflow: If True, skip workflow confirmation prompts and auto-select.
 
     Returns:
         List of result dicts with file_index, file_name, entry_index,
@@ -625,12 +631,68 @@ def run_tasks_dir(
     """
     import uuid
 
-    flow, errors = load_flow(workflow_path)
-    if flow is None:
-        raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
-
     task_files = load_tasks_dir(tasks_dir)
     results: list[dict[str, Any]] = []
+    workflow_assignments: dict[tuple[int, int], Path] = {}
+
+    if base_dir is None:
+        base_dir = Path.cwd() / ".fdsx"
+    config = load_config(project_dir=base_dir.parent)
+    project_root = base_dir.parent
+    workflows_dir = project_root / config.workflows_dir
+
+    for file_idx, (file_path, task_file) in enumerate(task_files):
+        actionable = _filter_actionable_entries(task_file)
+        for entry_idx, entry in actionable:
+            if entry.workflow is not None:
+                wf_path = workflows_dir / entry.workflow
+                workflow_assignments[(file_idx, entry_idx)] = wf_path
+            elif workflow_path is not None:
+                workflow_assignments[(file_idx, entry_idx)] = workflow_path
+            else:
+                resolved = resolve_workflow_for_task(
+                    task_description=entry.description,
+                    workflows_dir=workflows_dir,
+                    selector_config=config.workflow_selector,
+                    auto_workflow=True,
+                )
+                if resolved is not None:
+                    workflow_assignments[(file_idx, entry_idx)] = resolved
+                else:
+                    raise ValueError(
+                        f"No workflow selected for entry {entry_idx} "
+                        f"in {file_path.name}: selection was cancelled."
+                    )
+
+    if workflow_assignments and not auto_workflow:
+        from fdsx.core.selector import discover_workflows, pick_workflow_manually
+
+        _display_batch_workflow_confirm(workflow_assignments, task_files)
+        approved = input("Approve workflow assignments? (y/n): ").strip().lower()
+        if approved != "y":
+            print("\nEdit workflow assignments:", file=sys.stderr)
+            discovered = discover_workflows(workflows_dir)
+            for key in sorted(workflow_assignments.keys()):
+                file_idx, entry_idx = key
+                file_path, task_file = task_files[file_idx]
+                entry = task_file.entries[entry_idx]
+                current_wf = workflow_assignments[key]
+                desc_preview = entry.description[:40]
+                if len(entry.description) > 40:
+                    desc_preview += "..."
+                print(
+                    f"\n  {file_path.name} entry {entry_idx + 1}: {desc_preview}",
+                    file=sys.stderr,
+                )
+                print(f"  Current: {current_wf.name}", file=sys.stderr)
+                choice = input("  Keep (k) or Change (c)? ").strip().lower()
+                if choice == "c":
+                    picked = pick_workflow_manually(discovered)
+                    if picked is not None:
+                        workflow_assignments[key] = picked
+                    else:
+                        print("Batch execution aborted.", file=sys.stderr)
+                        return results
 
     for file_idx, (file_path, task_file) in enumerate(task_files):
         actionable = _filter_actionable_entries(task_file)
@@ -681,6 +743,15 @@ def run_tasks_dir(
             original_status = entry.status
             category = "retried" if original_status in ("failed", "running") else "new"
 
+            effective_workflow = workflow_assignments.get(
+                (file_idx, entry_idx), workflow_path
+            )
+            if effective_workflow is None:
+                raise ValueError(
+                    f"No workflow available for entry {entry_idx} in {file_path}. "
+                    "Ensure the task has a workflow set or that workflows exist in the workflows directory."
+                )
+
             print(
                 f"  Executing entry {entry_idx + 1}/{len(task_file.entries)}: {_sanitize_output(description[:50])}...",
                 file=sys.stderr,
@@ -693,7 +764,7 @@ def run_tasks_dir(
             try:
                 task_inputs = {"task": description}
                 run_flow(
-                    flow_path=workflow_path,
+                    flow_path=effective_workflow,
                     inputs=task_inputs,
                     thread_id=thread_id,
                     base_dir=base_dir,
@@ -754,3 +825,38 @@ def run_tasks_dir(
 
     display_tasks_dir_summary(results)
     return results
+
+
+def _display_batch_workflow_confirm(
+    workflow_assignments: dict[tuple[int, int], Path],
+    task_files: list[tuple[Path, TaskFile]],
+) -> None:
+    """Display workflow assignments for batch confirmation (FR-6.3).
+
+    Args:
+        workflow_assignments: Map of (file_idx, entry_idx) -> workflow path.
+        task_files: List of (file_path, task_file) tuples.
+    """
+    print("\n" + "=" * 80, file=sys.stderr)
+    print("WORKFLOW ASSIGNMENTS", file=sys.stderr)
+    print("=" * 80, file=sys.stderr)
+    print(
+        f"{'FILE':<30} {'ENTRY':<6} {'WORKFLOW':<30} {'TASK':<15}",
+        file=sys.stderr,
+    )
+    print("-" * 80, file=sys.stderr)
+
+    for (file_idx, entry_idx), wf_path in sorted(workflow_assignments.items()):
+        file_path, task_file = task_files[file_idx]
+        entry = task_file.entries[entry_idx]
+        file_name = file_path.name[:29]
+        entry_num = str(entry_idx + 1)
+        wf_name = wf_path.name[:29]
+        task_preview = entry.description[:14]
+
+        print(
+            f"{_sanitize_output(file_name):<30} {entry_num:<6} {_sanitize_output(wf_name):<30} {_sanitize_output(task_preview):<15}",
+            file=sys.stderr,
+        )
+
+    print("=" * 80, file=sys.stderr)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -45,6 +45,7 @@ def run_flow(
     inputs: dict[str, str] | None = None,
     thread_id: str | None = None,
     base_dir: Path | None = None,
+    quiet: bool = False,
 ) -> dict[str, Any]:
     """Run a flow from a YAML file.
 
@@ -54,6 +55,8 @@ def run_flow(
         thread_id: Optional thread ID (generated if not provided)
         base_dir: Optional base directory for checkpoints (.fdsx/).
                   If None, uses MemorySaver (no persistence).
+        quiet: When True, suppresses stderr streaming output from StreamLogger.
+               Log files are still written and completion summary is still shown.
 
     Returns:
         Final state variables as result dict. When max_loop is reached,
@@ -109,6 +112,7 @@ def run_flow(
         recorder=recorder,
         config=fdsx_config,
         log_dir=log_dir,
+        quiet=quiet,
     )
 
     initial_state: dict[str, Any] = {

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -88,11 +88,14 @@ def run_flow(
         flow_version=flow.version,
     )
 
+    fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
+
     compiled = compile_flow(
         flow,
         input_keys=set(inputs.keys()) if inputs else None,
         checkpointer=checkpointer,
         recorder=recorder,
+        config=fdsx_config,
     )
 
     initial_state: dict[str, Any] = {
@@ -403,10 +406,13 @@ def resume_flow(
             flow_version=flow_version,
         )
 
+        fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
+
         compiled = compile_flow(
             flow,
             checkpointer=checkpointer,
             recorder=recorder,
+            config=fdsx_config,
         )
 
         parallel_extra = sum(

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -288,6 +288,7 @@ def run_batch(
     workflow_path: Path,
     tasks_file: Path,
     base_dir: Path | None = None,
+    quiet: bool = False,
 ) -> list[dict[str, Any]]:
     """Orchestrate batch execution of tasks.
 
@@ -295,6 +296,7 @@ def run_batch(
         workflow_path: Path to the YAML workflow file
         tasks_file: Path to the task file
         base_dir: Optional base directory for checkpoints (.fdsx/).
+        quiet: If True, suppress streaming output during execution.
 
     Returns:
         List of result dicts with task_index, task_description, thread_id, status, error
@@ -348,6 +350,7 @@ def run_batch(
                 inputs=task_inputs,
                 thread_id=thread_id,
                 base_dir=base_dir,
+                quiet=quiet,
             )
             results.append(
                 {
@@ -698,6 +701,7 @@ def run_tasks_dir(
     tasks_dir: Path,
     base_dir: Path | None = None,
     auto_workflow: bool = False,
+    quiet: bool = False,
 ) -> list[dict[str, Any]]:
     """Execute tasks from a directory of YAML task files with crash-resilient persistence.
 
@@ -707,6 +711,7 @@ def run_tasks_dir(
         tasks_dir: Directory containing task YAML files.
         base_dir: Optional base directory for checkpoints (.fdsx/).
         auto_workflow: If True, skip workflow confirmation prompts and auto-select.
+        quiet: If True, suppress streaming output during execution.
 
     Returns:
         List of result dicts with file_index, file_name, entry_index,
@@ -888,6 +893,7 @@ def run_tasks_dir(
                     inputs=task_inputs,
                     thread_id=thread_id,
                     base_dir=base_dir,
+                    quiet=quiet,
                 )
                 _update_task_status(
                     file_path, task_file, entry_idx, "completed", thread_id=thread_id

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -103,7 +103,8 @@ def run_flow(
     fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
 
     _runs_base = base_dir if base_dir is not None else Path.cwd() / FDSX_DIR_NAME
-    log_dir = _runs_base / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+    run_dir = _runs_base / RUNS_DIR_NAME / thread_id
+    log_dir = run_dir / LOGS_DIR_NAME
 
     compiled = compile_flow(
         flow,
@@ -120,6 +121,7 @@ def run_flow(
             "thread_id": thread_id,
             "flow_path": str(flow_path),
             "flow_name": flow.name,
+            "run_dir": str(run_dir),
         }
     }
 
@@ -477,7 +479,8 @@ def resume_flow(
 
         fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
 
-        resume_log_dir = base_dir / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+        resume_run_dir = base_dir / RUNS_DIR_NAME / thread_id
+        resume_log_dir = resume_run_dir / LOGS_DIR_NAME
 
         compiled = compile_flow(
             flow,
@@ -500,6 +503,14 @@ def resume_flow(
             "recursion_limit": recursion_limit,
             "configurable": {"thread_id": thread_id},
         }
+
+        state_info = compiled.graph.get_state(resume_config)
+        existing_meta = (
+            state_info.values.get("_meta", {}) if state_info.values else {}
+        )
+        if "run_dir" not in existing_meta:
+            updated_meta = {**existing_meta, "run_dir": str(resume_run_dir)}
+            compiled.graph.update_state(resume_config, {"_meta": updated_meta})
 
         state_info = compiled.graph.get_state(resume_config)
         if state_info.tasks:

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -20,7 +20,7 @@ from fdsx.core.loader import load_flow
 from fdsx.core.selector import (
     resolve_workflow_for_task,
 )
-from fdsx.display.terminal import _sanitize_output, display_wait_prompt
+from fdsx.display.terminal import Spinner, _sanitize_output, display_wait_prompt
 from fdsx.logging import RunRecorder
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 
@@ -646,6 +646,8 @@ def run_tasks_dir(
     project_root = base_dir.parent
     workflows_dir = project_root / config.workflows_dir
 
+    auto_selection_entries: list[tuple[int, int, Path, str]] = []
+
     for file_idx, (file_path, task_file) in enumerate(task_files):
         actionable = _filter_actionable_entries(task_file)
         for entry_idx, entry in actionable:
@@ -655,8 +657,23 @@ def run_tasks_dir(
             elif workflow_path is not None:
                 workflow_assignments[(file_idx, entry_idx)] = workflow_path
             else:
+                auto_selection_entries.append(
+                    (file_idx, entry_idx, file_path, entry.description)
+                )
+
+    if auto_selection_entries:
+        total = len(auto_selection_entries)
+        with Spinner(
+            f"Auto-selecting workflows for {total} task{'s' if total != 1 else ''}..."
+        ) as spinner:
+            for count, (file_idx, entry_idx, file_path, description) in enumerate(
+                auto_selection_entries, start=1
+            ):
+                spinner.update(
+                    f"Auto-selecting workflows for {total} task{'s' if total != 1 else ''}... ({count}/{total})"
+                )
                 resolved = resolve_workflow_for_task(
-                    task_description=entry.description,
+                    task_description=description,
                     workflows_dir=workflows_dir,
                     selector_config=config.workflow_selector,
                     auto_workflow=True,

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -1,7 +1,7 @@
 import sys
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.errors import GraphRecursionError
@@ -11,6 +11,7 @@ from fdsx.checkpoint.manager import CheckpointManager, _extract_meta_from_checkp
 from fdsx.core.batch import (
     display_batch_summary,
     display_task_list,
+    display_tasks_dir_summary,
     split_tasks,
 )
 from fdsx.core.compiler import compile_flow
@@ -18,6 +19,7 @@ from fdsx.core.config import load_config
 from fdsx.core.loader import load_flow
 from fdsx.display.terminal import _sanitize_output, display_wait_prompt
 from fdsx.logging import RunRecorder
+from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 
 
 class FlowValidationError(Exception):
@@ -519,3 +521,236 @@ def validate_flow(flow_path: Path) -> tuple[bool, list[str]]:
     """
     flow, errors = load_flow(flow_path)
     return flow is not None, errors
+
+
+def load_tasks_dir(tasks_dir: Path) -> list[tuple[Path, TaskFile]]:
+    """Load and sort all task YAML files from a directory.
+
+    Args:
+        tasks_dir: Directory containing task YAML files.
+
+    Returns:
+        List of (file_path, task_file) tuples sorted alphabetically by filename.
+
+    Raises:
+        FileNotFoundError: If the tasks directory does not exist.
+        ValueError: If no .yaml files are found.
+    """
+    if not tasks_dir.exists():
+        raise FileNotFoundError(f"Tasks directory not found: {tasks_dir}")
+    if tasks_dir.is_symlink():
+        raise ValueError(f"Tasks directory must not be a symlink: {tasks_dir}")
+
+    yaml_files = sorted(tasks_dir.glob("*.yaml"))
+    if not yaml_files:
+        raise ValueError(f"No .yaml files found in {tasks_dir}")
+
+    result: list[tuple[Path, TaskFile]] = []
+    for fp in yaml_files:
+        if fp.is_symlink() or not fp.is_file():
+            raise ValueError(
+                f"Task file must be a regular file (not a symlink or special file): {fp}"
+            )
+        task_file = load_task_file(fp)
+        result.append((fp, task_file))
+
+    return result
+
+
+def _filter_actionable_entries(
+    task_file: TaskFile,
+) -> list[tuple[int, TaskEntry]]:
+    """Return entries that need execution.
+
+    Skips entries with status "completed". Treats "failed" and "running"
+    as retriable (returns them for execution).
+
+    Args:
+        task_file: The TaskFile to filter.
+
+    Returns:
+        List of (entry_index, entry) tuples for entries that should run.
+    """
+    actionable: list[tuple[int, TaskEntry]] = []
+    for i, entry in enumerate(task_file.entries):
+        if entry.status == "completed":
+            continue
+        actionable.append((i, entry))
+    return actionable
+
+
+def _update_task_status(
+    file_path: Path,
+    task_file: TaskFile,
+    entry_index: int,
+    status: str,
+    thread_id: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Update and persist a single entry's status in the task file.
+
+    Args:
+        file_path: Path to the task YAML file.
+        task_file: The TaskFile containing the entry.
+        entry_index: Index of the entry within task_file.entries.
+        status: New status value.
+        thread_id: Optional thread ID to store.
+        error: Optional error message to store.
+    """
+    entry = task_file.entries[entry_index]
+    entry.status = cast(Literal["pending", "running", "completed", "failed"], status)
+    entry.thread_id = thread_id
+    entry.error = error
+    save_task_file(file_path, task_file)
+
+
+def run_tasks_dir(
+    workflow_path: Path,
+    tasks_dir: Path,
+    base_dir: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Execute tasks from a directory of YAML task files with crash-resilient persistence.
+
+    Args:
+        workflow_path: Path to the YAML workflow file.
+        tasks_dir: Directory containing task YAML files.
+        base_dir: Optional base directory for checkpoints (.fdsx/).
+
+    Returns:
+        List of result dicts with file_index, file_name, entry_index,
+        entry_description, thread_id, status, error, category.
+
+    Raises:
+        FlowValidationError: If flow validation fails.
+    """
+    import uuid
+
+    flow, errors = load_flow(workflow_path)
+    if flow is None:
+        raise FlowValidationError(f"Flow validation failed: {', '.join(errors)}")
+
+    task_files = load_tasks_dir(tasks_dir)
+    results: list[dict[str, Any]] = []
+
+    for file_idx, (file_path, task_file) in enumerate(task_files):
+        actionable = _filter_actionable_entries(task_file)
+
+        if not actionable:
+            for entry_idx, entry in enumerate(task_file.entries):
+                results.append(
+                    {
+                        "file_index": file_idx,
+                        "file_name": file_path.name,
+                        "entry_index": entry_idx,
+                        "entry_description": entry.description,
+                        "thread_id": entry.thread_id or "",
+                        "status": "completed",
+                        "error": None,
+                        "category": "skipped",
+                    }
+                )
+            continue
+
+        print(
+            f"\nProcessing file {file_idx + 1}/{len(task_files)}: {_sanitize_output(file_path.name)}",
+            file=sys.stderr,
+        )
+        print(
+            f"  {len(actionable)} actionable entries out of {len(task_file.entries)}",
+            file=sys.stderr,
+        )
+
+        for entry_idx, entry in enumerate(task_file.entries):
+            if entry.status == "completed":
+                results.append(
+                    {
+                        "file_index": file_idx,
+                        "file_name": file_path.name,
+                        "entry_index": entry_idx,
+                        "entry_description": entry.description,
+                        "thread_id": entry.thread_id or "",
+                        "status": "completed",
+                        "error": None,
+                        "category": "skipped",
+                    }
+                )
+
+        for entry_idx, entry in actionable:
+            thread_id = str(uuid.uuid4())
+            description = entry.description
+            original_status = entry.status
+            category = "retried" if original_status in ("failed", "running") else "new"
+
+            print(
+                f"  Executing entry {entry_idx + 1}/{len(task_file.entries)}: {_sanitize_output(description[:50])}...",
+                file=sys.stderr,
+            )
+
+            _update_task_status(
+                file_path, task_file, entry_idx, "running", thread_id=thread_id
+            )
+
+            try:
+                task_inputs = {"task": description}
+                run_flow(
+                    flow_path=workflow_path,
+                    inputs=task_inputs,
+                    thread_id=thread_id,
+                    base_dir=base_dir,
+                )
+                _update_task_status(
+                    file_path, task_file, entry_idx, "completed", thread_id=thread_id
+                )
+                results.append(
+                    {
+                        "file_index": file_idx,
+                        "file_name": file_path.name,
+                        "entry_index": entry_idx,
+                        "entry_description": description,
+                        "thread_id": thread_id,
+                        "status": "completed",
+                        "error": None,
+                        "category": category,
+                    }
+                )
+            except Exception as e:
+                _update_task_status(
+                    file_path,
+                    task_file,
+                    entry_idx,
+                    "failed",
+                    thread_id=thread_id,
+                    error=str(e),
+                )
+                results.append(
+                    {
+                        "file_index": file_idx,
+                        "file_name": file_path.name,
+                        "entry_index": entry_idx,
+                        "entry_description": description,
+                        "thread_id": thread_id,
+                        "status": "failed",
+                        "error": str(e),
+                        "category": category,
+                    }
+                )
+
+                print(
+                    f"  Entry {entry_idx + 1} failed: {_sanitize_output(str(e))}",
+                    file=sys.stderr,
+                )
+                while True:
+                    response = (
+                        input("Continue with remaining entries? (y/n): ")
+                        .strip()
+                        .lower()
+                    )
+                    if response == "y":
+                        break
+                    elif response == "n":
+                        print("Stopping tasks-dir execution.", file=sys.stderr)
+                        display_tasks_dir_summary(results)
+                        return results
+
+    display_tasks_dir_summary(results)
+    return results

--- a/src/fdsx/core/hooks.py
+++ b/src/fdsx/core/hooks.py
@@ -1,0 +1,197 @@
+"""Hook executor, data writer, and collector for fdsx lifecycle hooks (FR-5).
+
+Provides three public functions:
+- execute_hooks()  — run a flat list of HookEntry commands (T019)
+- write_hook_data() — write per-state JSON data to .fdsx/runs/.../hooks/ (T020)
+- collect_hooks()   — merge hooks from global → project → flow → state (T021)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any, Literal
+
+from fdsx.logging.recorder import FDSX_DIR_NAME, RUNS_DIR_NAME
+from fdsx.models.flow import HookConfig, HookEntry
+
+logger = logging.getLogger(__name__)
+
+# --- Directory / file name constants ----------------------------------------
+
+# FDSX_DIR_NAME and RUNS_DIR_NAME are imported from fdsx.logging.recorder
+HOOKS_DIR_NAME = "hooks"
+INPUT_FILENAME = "input.json"
+OUTPUT_FILENAME = "output.json"
+
+# --- Environment variable name constants -------------------------------------
+
+ENV_STATE_NAME = "FDSX_STATE_NAME"
+ENV_STATUS = "FDSX_STATUS"
+ENV_DATA_PATH = "FDSX_DATA_PATH"
+ENV_THREAD_ID = "FDSX_THREAD_ID"
+ENV_FLOW_NAME = "FDSX_FLOW_NAME"
+
+
+class HookAbortError(Exception):
+    """Raised when a hook with on_failure='abort' exits with a non-zero code."""
+
+    def __init__(self, command: str, return_code: int) -> None:
+        self.command = command
+        self.return_code = return_code
+        super().__init__(
+            f"Hook command exited with code {return_code} (abort policy): {command!r}"
+        )
+
+
+def execute_hooks(
+    hooks: list[HookEntry],
+    *,
+    state_name: str,
+    status: str,
+    data_path: Path,
+    thread_id: str,
+    flow_name: str,
+) -> None:
+    """Execute a flat list of hook commands in order.
+
+    Each command is run with ``shell=True`` and receives:
+    - Positional args: $1=state_name, $2=status, $3=data_path
+    - Environment variables: FDSX_STATE_NAME, FDSX_STATUS, FDSX_DATA_PATH,
+      FDSX_THREAD_ID, FDSX_FLOW_NAME
+
+    Args:
+        hooks: Ordered list of HookEntry objects to execute.
+        state_name: Name of the current state.
+        status: Lifecycle status ("starting", "completed", or "failed").
+        data_path: Path to the state data JSON file passed as $3 / FDSX_DATA_PATH.
+        thread_id: Current run thread ID.
+        flow_name: Name of the flow.
+
+    Raises:
+        HookAbortError: When a hook exits non-zero and its on_failure is "abort".
+    """
+    env = {
+        **os.environ,
+        ENV_STATE_NAME: state_name,
+        ENV_STATUS: status,
+        ENV_DATA_PATH: str(data_path),
+        ENV_THREAD_ID: thread_id,
+        ENV_FLOW_NAME: flow_name,
+    }
+
+    # Build positional arg suffix (safely quoted)
+    positional_args = (
+        f" {shlex.quote(state_name)}"
+        f" {shlex.quote(status)}"
+        f" {shlex.quote(str(data_path))}"
+    )
+
+    for hook in hooks:
+        full_command = hook.command + positional_args
+        result = subprocess.run(full_command, shell=True, env=env)  # noqa: S602
+
+        if result.returncode != 0:
+            if hook.on_failure == "abort":
+                raise HookAbortError(hook.command, result.returncode)
+            else:
+                # on_failure == "warn"
+                logger.warning(
+                    "Hook command exited with code %d (warn policy, continuing): %r",
+                    result.returncode,
+                    hook.command,
+                )
+
+
+def write_hook_data(
+    data: dict[str, Any],
+    *,
+    state_name: str,
+    filename: str,
+    thread_id: str,
+    base_dir: Path | None = None,
+) -> Path:
+    """Write per-state hook data JSON to the hooks directory.
+
+    Writes to:
+        <base_dir>/runs/<thread_id>/hooks/<state_name>/<filename>
+
+    When base_dir is None, defaults to <CWD>/.fdsx.
+
+    Directories are created with mode 0o700; the file is written with mode 0o600.
+
+    Args:
+        data: JSON-serialisable dict to write.
+        state_name: Name of the state (used as subdirectory name).
+        filename: File name — typically INPUT_FILENAME or OUTPUT_FILENAME.
+        thread_id: Current run thread ID.
+        base_dir: Override for the .fdsx root. Defaults to CWD/.fdsx.
+
+    Returns:
+        Path to the written JSON file.
+    """
+    if base_dir is not None:
+        fdsx_dir = base_dir
+    else:
+        fdsx_dir = Path.cwd() / FDSX_DIR_NAME
+
+    base_runs_dir = (fdsx_dir / RUNS_DIR_NAME).resolve()
+    expected_hooks_base = (base_runs_dir / thread_id / HOOKS_DIR_NAME).resolve()
+    hooks_dir = (expected_hooks_base / state_name).resolve()
+    if not str(hooks_dir).startswith(str(expected_hooks_base) + os.sep) and hooks_dir != expected_hooks_base:
+        raise ValueError(
+            "Invalid thread_id or state_name: path resolved outside runs directory"
+        )
+    if not str(expected_hooks_base).startswith(str(base_runs_dir)):
+        raise ValueError(
+            "Invalid thread_id or state_name: path resolved outside runs directory"
+        )
+
+    os.makedirs(hooks_dir, mode=0o700, exist_ok=True)
+    os.chmod(str(hooks_dir), 0o700)
+
+    file_path = hooks_dir / filename
+    json_bytes = json.dumps(data, indent=2).encode("utf-8")
+
+    fd = os.open(str(file_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        os.write(fd, json_bytes)
+    finally:
+        os.close(fd)
+
+    return file_path
+
+
+def collect_hooks(
+    event: Literal["on_start", "on_complete"],
+    *,
+    global_hooks: HookConfig | None,
+    project_hooks: HookConfig | None,
+    flow_hooks: HookConfig | None,
+    state_hooks: HookConfig | None,
+) -> list[HookEntry]:
+    """Collect and merge hooks from all configuration levels for a given event.
+
+    Merges in order: global → project → flow → state.
+    Returns a single flat list of HookEntry objects.
+
+    Args:
+        event: "on_start" or "on_complete".
+        global_hooks: Hook config from global ~/.config/fdsx/config.yaml.
+        project_hooks: Hook config from project .fdsx/config.yaml.
+        flow_hooks: Hook config from the flow definition.
+        state_hooks: Hook config from the individual state definition.
+
+    Returns:
+        Concatenated list of HookEntry objects in global → project → flow → state order.
+    """
+    result: list[HookEntry] = []
+    for hook_config in (global_hooks, project_hooks, flow_hooks, state_hooks):
+        if hook_config is not None:
+            result.extend(getattr(hook_config, event))
+    return result

--- a/src/fdsx/core/loader.py
+++ b/src/fdsx/core/loader.py
@@ -32,6 +32,9 @@ def load_flow(
     if data is None:
         return None, ["Empty YAML file"]
 
+    if not isinstance(data, dict):
+        return None, ["Workflow file must be a YAML mapping, not a list or scalar"]
+
     flow, flow_errors = _parse_and_validate_flow(data, path)
     if flow_errors:
         return None, flow_errors
@@ -56,6 +59,13 @@ def _parse_and_validate_flow(
     """Parse raw YAML data into Flow model and validate."""
     errors: list[str] = []
 
+    if "description" not in data or not data.get("description"):
+        return None, [
+            "Missing required field 'description'. "
+            "Please add a description to your workflow file, e.g.:\n"
+            "  description: 'My workflow that does X and Y'"
+        ]
+
     try:
         flow = Flow(**data)
     except Exception as e:
@@ -76,7 +86,9 @@ def _validate_prompt_file_path(
     Returns an error string, or None if the path is safe.
     """
     if Path(raw_path).is_absolute():
-        return f"{context}: prompt_file must be a relative path, got absolute: {raw_path}"
+        return (
+            f"{context}: prompt_file must be a relative path, got absolute: {raw_path}"
+        )
     resolved_dir = yaml_dir.resolve()
     try:
         prompt_path.relative_to(resolved_dir)
@@ -103,7 +115,10 @@ def _resolve_prompt_files(flow: Flow, yaml_path: Path) -> tuple[Flow, list[str]]
             if "prompt_file" in state_data and state_data["prompt_file"]:
                 prompt_path = (yaml_dir / state_data["prompt_file"]).resolve()
                 path_error = _validate_prompt_file_path(
-                    state_data["prompt_file"], prompt_path, yaml_dir, f"State '{state_name}'"
+                    state_data["prompt_file"],
+                    prompt_path,
+                    yaml_dir,
+                    f"State '{state_name}'",
                 )
                 if path_error:
                     errors.append(path_error)
@@ -126,7 +141,10 @@ def _resolve_prompt_files(flow: Flow, yaml_path: Path) -> tuple[Flow, list[str]]
                 if "prompt_file" in branch and branch["prompt_file"]:
                     prompt_path = (yaml_dir / branch["prompt_file"]).resolve()
                     path_error = _validate_prompt_file_path(
-                        branch["prompt_file"], prompt_path, yaml_dir, f"Parallel branch {branch_idx}"
+                        branch["prompt_file"],
+                        prompt_path,
+                        yaml_dir,
+                        f"Parallel branch {branch_idx}",
                     )
                     if path_error:
                         errors.append(path_error)

--- a/src/fdsx/core/selector.py
+++ b/src/fdsx/core/selector.py
@@ -1,0 +1,331 @@
+"""Workflow auto-selection system.
+
+Discovers workflow files from a directory, uses an LLM to select the most
+appropriate workflow based on task description, and supports both auto and
+confirm modes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import warnings
+from pathlib import Path
+
+from fdsx.core.config import WorkflowSelectorConfig
+from fdsx.core.loader import load_flow
+from fdsx.providers.base import get_provider
+
+
+def discover_workflows(workflows_dir: Path) -> list[tuple[Path, str]]:
+    """Discover all workflow YAML files in the given directory.
+
+    Loads each discovered YAML file, extracts the description field, and returns
+    a list of (path, description) tuples. Files with invalid YAML are skipped
+    with a warning.
+
+    Args:
+        workflows_dir: Directory containing workflow YAML files.
+
+    Returns:
+        List of (workflow_path, description) tuples sorted by filename.
+        Returns an empty list if the directory does not exist.
+
+    Raises:
+        ValueError: If the workflows directory is a symlink.
+    """
+    if not workflows_dir.exists():
+        return []
+    if workflows_dir.is_symlink():
+        raise ValueError(f"Workflows directory must not be a symlink: {workflows_dir}")
+
+    yaml_files = sorted(workflows_dir.glob("*.yaml"))
+    results: list[tuple[Path, str]] = []
+
+    for fp in yaml_files:
+        if fp.is_symlink():
+            warnings.warn(
+                f"Skipping symlinked workflow file: {fp}",
+                RuntimeWarning,
+            )
+            continue
+        if not fp.is_file():
+            warnings.warn(
+                f"Skipping non-regular workflow file: {fp}",
+                RuntimeWarning,
+            )
+            continue
+        try:
+            flow, errors = load_flow(fp)
+            if flow is None:
+                warnings.warn(
+                    f"Skipping invalid workflow file {fp}: {', '.join(errors)}",
+                    RuntimeWarning,
+                )
+                continue
+            results.append((fp, flow.description))
+        except Exception as e:
+            warnings.warn(
+                f"Skipping unparseable workflow file {fp}: {e}",
+                RuntimeWarning,
+            )
+
+    return results
+
+
+def _build_workflow_selection_prompt(
+    task_description: str, workflows: list[tuple[Path, str]]
+) -> str:
+    """Build the LLM prompt for workflow selection.
+
+    Args:
+        task_description: The task/goal description to match against workflows.
+        workflows: List of (path, description) tuples for discovered workflows.
+
+    Returns:
+        The formatted prompt string.
+    """
+    workflow_list = "\n".join(
+        f"- **{fp.name}**: {description}" for fp, description in workflows
+    )
+
+    return f"""You are a workflow selector. Given a task description, select the most appropriate workflow from the available options.
+
+TASK:
+{task_description}
+
+AVAILABLE WORKFLOWS:
+{workflow_list}
+
+INSTRUCTIONS:
+1. Analyze the task description above
+2. Consider which workflow best matches the task's goal and requirements
+3. Return ONLY the filename of the selected workflow (e.g., "plan-implement-review.yaml")
+4. Do not include any explanations, markdown, or additional text — just the filename
+
+OUTPUT FORMAT:
+Return the exact filename string only."""
+
+
+def _parse_workflow_selection(response: str) -> str:
+    """Parse the LLM response to extract the selected workflow filename.
+
+    Handles markdown code blocks, quotes, and whitespace. Returns the raw
+    cleaned string without strict validation — the calling code handles
+    matching against known workflows.
+
+    Args:
+        response: The raw LLM response text.
+
+    Returns:
+        The extracted workflow filename (may not have .yaml extension).
+
+    Raises:
+        ValueError: If no content can be extracted.
+    """
+    cleaned = response.strip()
+
+    code_block_patterns = [
+        r"```(?:yaml)?\s*(.*?)\s*```",
+        r"```\s*(.*?)\s*```",
+    ]
+    for pattern in code_block_patterns:
+        match = re.search(pattern, cleaned, re.DOTALL)
+        if match:
+            cleaned = match.group(1).strip()
+
+    cleaned = cleaned.strip("\"'")
+    cleaned = cleaned.strip()
+
+    if not cleaned:
+        raise ValueError(f"Empty workflow selection from response: {response}")
+
+    return cleaned
+
+
+def select_workflow(
+    task_description: str,
+    workflows: list[tuple[Path, str]],
+    selector_config: WorkflowSelectorConfig,
+) -> Path:
+    """Select the most appropriate workflow for the given task description.
+
+    Selection rules:
+    - If exactly one workflow is available, it is returned directly (FR-5.7).
+    - If no workflows are available, raises ValueError (FR-5.8).
+    - If multiple workflows are available, calls the LLM to select one.
+
+    Args:
+        task_description: The task/goal description to match against workflows.
+        workflows: List of (workflow_path, description) tuples.
+        selector_config: Configuration for the workflow selector LLM.
+
+    Returns:
+        Path to the selected workflow file.
+
+    Raises:
+        ValueError: If no workflows are available.
+    """
+    if len(workflows) == 0:
+        raise ValueError(
+            "No workflows found in the workflows directory. "
+            "Please add workflow YAML files or check your workflows_dir configuration."
+        )
+
+    if len(workflows) == 1:
+        return workflows[0][0]
+
+    provider = get_provider(selector_config.provider)
+
+    prompt = _build_workflow_selection_prompt(task_description, workflows)
+
+    result = provider.execute(
+        prompt=prompt,
+        model=selector_config.model,
+    )
+
+    if result.exit_code != 0:
+        raise RuntimeError(f"Workflow selector failed: {result.stderr}")
+
+    selected_name = _parse_workflow_selection(result.stdout)
+
+    # Strategy 1: exact filename match
+    for wf_path, _ in workflows:
+        if wf_path.name == selected_name:
+            return wf_path
+
+    # Strategy 2: append .yaml if missing
+    if not selected_name.endswith(".yaml"):
+        candidate = selected_name + ".yaml"
+        for wf_path, _ in workflows:
+            if wf_path.name == candidate:
+                return wf_path
+
+    # Strategy 3: check if exactly one known filename or stem appears in the response
+    matches: list[Path] = []
+    for wf_path, _ in workflows:
+        if wf_path.name in selected_name:
+            if wf_path not in matches:
+                matches.append(wf_path)
+    # Only try stem matching if filename matching found nothing
+    if not matches:
+        response_words = selected_name.split()
+        for wf_path, _ in workflows:
+            if wf_path.stem in response_words:
+                if wf_path not in matches:
+                    matches.append(wf_path)
+    if len(matches) == 1:
+        return matches[0]
+
+    raise ValueError(
+        f"LLM selected workflow '{selected_name}' which does not match any available workflow. "
+        f"Available: {[wf_path.name for wf_path, _ in workflows]}"
+    )
+
+
+def confirm_workflow_selection(
+    workflow_path: Path,
+    task_description: str,
+) -> bool:
+    """Prompt the user to confirm a workflow selection.
+
+    Args:
+        workflow_path: Path to the selected workflow.
+        task_description: The task description that was used for selection.
+
+    Returns:
+        True if the user approves, False if they reject.
+    """
+    print(f"\nSelected workflow: {workflow_path.name}", file=sys.stderr)
+    print(
+        f"  Task: {task_description[:60]}{'...' if len(task_description) > 60 else ''}",
+        file=sys.stderr,
+    )
+    print(
+        "  (y) Accept and run  (n) Reject and choose manually  (l) List all workflows",
+        file=sys.stderr,
+    )
+
+    while True:
+        response = input("Choice: ").strip().lower()
+        if response == "y":
+            return True
+        elif response == "n":
+            return False
+        elif response == "l":
+            return False
+        else:
+            print("Invalid choice. Enter 'y', 'n', or 'l'.", file=sys.stderr)
+
+
+def pick_workflow_manually(
+    workflows: list[tuple[Path, str]],
+) -> Path | None:
+    """Present a numbered list of workflows and let the user pick one.
+
+    Args:
+        workflows: List of (workflow_path, description) tuples.
+
+    Returns:
+        The selected workflow path, or None if the user cancels.
+    """
+    print("\nAvailable workflows:", file=sys.stderr)
+    print("-" * 60, file=sys.stderr)
+    for i, (wf_path, description) in enumerate(workflows, 1):
+        desc_preview = (
+            description[:50] + "..." if len(description) > 50 else description
+        )
+        print(f"  {i}. {wf_path.name}", file=sys.stderr)
+        print(f"     {desc_preview}", file=sys.stderr)
+    print("-" * 60, file=sys.stderr)
+
+    while True:
+        response = input("Enter number (or 'c' to cancel): ").strip()
+        if response.lower() == "c":
+            return None
+        try:
+            idx = int(response) - 1
+            if 0 <= idx < len(workflows):
+                return workflows[idx][0]
+            else:
+                print(f"Invalid number. Enter 1-{len(workflows)}.", file=sys.stderr)
+        except ValueError:
+            print("Invalid input. Enter a number or 'c'.", file=sys.stderr)
+
+
+def resolve_workflow_for_task(
+    task_description: str,
+    workflows_dir: Path,
+    selector_config: WorkflowSelectorConfig,
+    auto_workflow: bool,
+) -> Path | None:
+    """Resolve which workflow to use for a task via auto-discovery and LLM selection.
+
+    Args:
+        task_description: Description of the task.
+        workflows_dir: Directory to discover workflows from.
+        selector_config: Configuration for the workflow selector LLM.
+        auto_workflow: If True, skip confirmation prompt.
+
+    Returns:
+        Path to the selected workflow, or None if the user cancels manual pick.
+    """
+    discovered = discover_workflows(workflows_dir)
+
+    if len(discovered) == 0:
+        raise ValueError(
+            f"No workflows found in {workflows_dir}. "
+            "Add workflow YAML files or configure workflows_dir in your config."
+        )
+
+    selected = select_workflow(task_description, discovered, selector_config)
+
+    if auto_workflow:
+        return selected
+
+    approved = confirm_workflow_selection(selected, task_description)
+    if approved:
+        return selected
+
+    picked = pick_workflow_manually(discovered)
+    return picked

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -1,9 +1,37 @@
 import json
 import re
 import shlex
+from pathlib import Path
 from typing import Any
 
 from fdsx.models.flow import Branch, Flow, ParallelState, State
+
+# Sub-directory inside run_dir where result files are written
+RESULT_FILE_DATA_DIR = "data"
+
+
+def write_result_to_file(varname: str, value: Any, run_dir: Path) -> str:
+    """Write a result value to a file inside <run_dir>/data/.
+
+    - str values are written as ``<varname>.md``
+    - All other values (dict, list, etc.) are JSON-serialized as ``<varname>.json``
+
+    The ``data/`` directory is created automatically if it does not exist.
+    Returns the absolute file path as a string.
+    """
+    data_dir = run_dir / RESULT_FILE_DATA_DIR
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(value, str):
+        file_path = data_dir / f"{varname}.md"
+        file_path.write_text(value, encoding="utf-8")
+    else:
+        file_path = data_dir / f"{varname}.json"
+        file_path.write_text(
+            json.dumps(value, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    return str(file_path.resolve())
 
 
 def resolve_template(template: str, variables: dict[str, Any]) -> str:

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -355,12 +355,22 @@ def analyze_variable_references(
                 if path.startswith("$."):
                     path = path[2:]
                 result_paths.add(path)
+            if state.result_file:
+                path = state.result_file
+                if path.startswith("$."):
+                    path = path[2:]
+                result_paths.add(path)
         elif isinstance(state, ParallelState):
             if state.result_path:
                 path = state.result_path
                 if path.startswith("$."):
                     path = path[2:]
                 result_paths.add(path)  # full path, not just root key
+            if state.result_file:
+                path = state.result_file
+                if path.startswith("$."):
+                    path = path[2:]
+                result_paths.add(path)
             # Do NOT register branch extract paths — they live inside
             # result array elements, not as top-level state variables.
         elif isinstance(state, PassState):

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -1,3 +1,4 @@
+import json
 import re
 import shlex
 from typing import Any
@@ -18,6 +19,8 @@ def resolve_template(template: str, variables: dict[str, Any]) -> str:
         value = resolve_jsonpath(var_path, variables)
         if value is None:
             return match.group(0)
+        if isinstance(value, (list, dict)):
+            return json.dumps(value, indent=2, ensure_ascii=False)
         return str(value)
 
     return pattern.sub(replace_match, template)
@@ -37,6 +40,8 @@ def resolve_template_shell_safe(template: str, variables: dict[str, Any]) -> str
         value = resolve_jsonpath(var_path, variables)
         if value is None:
             return match.group(0)
+        if isinstance(value, (list, dict)):
+            return shlex.quote(json.dumps(value, indent=2, ensure_ascii=False))
         return shlex.quote(str(value))
 
     return pattern.sub(replace_match, template)
@@ -277,7 +282,7 @@ def analyze_variable_references(
 
     def get_prompt_variables(state: State | Branch) -> set[str]:
         variables: set[str] = set()
-        from fdsx.models.flow import TaskState, Branch
+        from fdsx.models.flow import TaskState, Branch, PassState
 
         if isinstance(state, TaskState):
             prompt = state.prompt_template or ""
@@ -287,6 +292,13 @@ def analyze_variable_references(
             prompt = state.prompt_template or ""
             command = state.command or ""
             prompt = prompt + " " + command
+        elif isinstance(state, PassState):
+            parts = []
+            if state.parameters:
+                for val in state.parameters.values():
+                    if isinstance(val, str):
+                        parts.append(val)
+            prompt = " ".join(parts)
         else:
             return variables
 
@@ -302,7 +314,7 @@ def analyze_variable_references(
 
     def get_result_paths(state: State) -> set[str]:
         result_paths: set[str] = set()
-        from fdsx.models.flow import ParallelState, TaskState
+        from fdsx.models.flow import ParallelState, PassState, TaskState
 
         if isinstance(state, TaskState):
             if state.result_path:
@@ -323,6 +335,18 @@ def analyze_variable_references(
                 result_paths.add(path)  # full path, not just root key
             # Do NOT register branch extract paths — they live inside
             # result array elements, not as top-level state variables.
+        elif isinstance(state, PassState):
+            if state.parameters:
+                for key in state.parameters:
+                    path = key
+                    if path.startswith("$."):
+                        path = path[2:]
+                    result_paths.add(path)
+            if state.aggregate and state.aggregate.result_path:
+                path = state.aggregate.result_path
+                if path.startswith("$."):
+                    path = path[2:]
+                result_paths.add(path)
         return result_paths
 
     reachable_states = set()

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -1,6 +1,16 @@
 import sys
+import threading
 from datetime import datetime
-from typing import Any
+from typing import Any, TextIO
+
+
+def is_interactive() -> bool:
+    """Check if stderr is connected to an interactive terminal.
+
+    Returns:
+        True if stderr is a TTY, False otherwise.
+    """
+    return sys.stderr.isatty()
 
 
 def _sanitize_output(text: str) -> str:
@@ -16,6 +26,16 @@ def _sanitize_output(text: str) -> str:
         if ch in ("\t", "\n")
         or (ch >= " " and ch != "\x7f" and not ("\x80" <= ch <= "\x9f"))
     )
+
+
+def _sanitize_spinner_text(text: str) -> str:
+    """Sanitize text for single-line spinner display.
+
+    Strips control characters via _sanitize_output(), then replaces
+    newlines and tabs with spaces to prevent log/terminal line injection.
+    """
+    sanitized = _sanitize_output(text)
+    return sanitized.replace("\n", " ").replace("\r", " ").replace("\t", " ")
 
 
 def display_state_start(
@@ -238,3 +258,119 @@ def display_wait_prompt(state_name: str, message: str, choices: list[str]) -> st
                 f"Invalid input. Please enter a number between 1 and {len(choices)}.",
                 file=sys.stderr,
             )
+
+
+class Spinner:
+    """Terminal spinner with TTY and non-TTY fallback modes.
+
+    In TTY mode: displays rotating spinner characters that update in place.
+    In non-TTY mode: prints a simple message without animation (CI/log friendly).
+
+    Attributes:
+        _FRAMES: Sequence of spinner characters for TTY mode.
+        _stream: Output stream (defaults to sys.stderr).
+        _message: Current message to display.
+        _interactive: Whether stderr is connected to an interactive terminal (via is_interactive()).
+        _stop_event: Threading event to signal spinner stop.
+        _thread: Background thread running the spinner animation (TTY mode only).
+        _running: Whether the spinner is currently active.
+    """
+
+    _FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+    def __init__(self, message: str = "", stream: TextIO | None = None) -> None:
+        """Initialize the spinner.
+
+        Args:
+            message: Initial message to display next to the spinner.
+            stream: Output stream to write to. Defaults to sys.stderr.
+        """
+        self._stream = stream if stream is not None else sys.stderr
+        self._message = message
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._running = False
+        self._interactive = is_interactive()
+
+    def start(self) -> "Spinner":
+        """Start the spinner.
+
+        In TTY mode: spawns a background thread that animates the spinner.
+        In non-TTY mode: prints the message once and returns immediately (no thread).
+
+        Returns:
+            self, to allow use as a context manager value.
+        """
+        if self._running:
+            self.stop()
+        if self._interactive:
+            self._running = True
+            self._stop_event.clear()
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        else:
+            self._stream.write(f"{_sanitize_spinner_text(self._message)}\n")
+            self._stream.flush()
+        return self
+
+    def stop(self, final_message: str = "") -> None:
+        """Stop the spinner.
+
+        In TTY mode: joins the background thread, clears the spinner line,
+        and optionally prints a final message.
+        In non-TTY mode: optionally prints a final message.
+
+        Args:
+            final_message: Optional message to print after stopping.
+        """
+        if self._interactive:
+            self._stop_event.set()
+            if self._thread is not None:
+                self._thread.join(timeout=1.0)
+                self._thread = None
+            self._running = False
+            self._stream.write("\r\033[K")
+            if final_message:
+                self._stream.write(f"{_sanitize_spinner_text(final_message)}\n")
+            self._stream.flush()
+        else:
+            if final_message:
+                self._stream.write(f"{_sanitize_spinner_text(final_message)}\n")
+                self._stream.flush()
+
+    def update(self, message: str) -> None:
+        """Update the spinner message.
+
+        In TTY mode: updates the message shown on the next frame tick.
+        In non-TTY mode: immediately prints the new message as a new line.
+
+        Args:
+            message: New message to display.
+        """
+        self._message = message
+        if not self._interactive:
+            self._stream.write(f"{_sanitize_spinner_text(message)}\n")
+            self._stream.flush()
+
+    def _run(self) -> None:
+        """Main spinner loop running in background thread (TTY mode only)."""
+        idx = 0
+        while not self._stop_event.is_set():
+            frame = self._FRAMES[idx % len(self._FRAMES)]
+            self._stream.write(f"\r{frame} {_sanitize_spinner_text(self._message)}")
+            self._stream.flush()
+            idx += 1
+            self._stop_event.wait(0.08)
+
+    def __enter__(self) -> "Spinner":
+        """Start spinner when used as a context manager."""
+        return self.start()
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Stop spinner when exiting the context manager."""
+        self.stop()

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -1,6 +1,7 @@
 import sys
 import threading
 from datetime import datetime
+from pathlib import Path
 from typing import Any, TextIO
 
 
@@ -14,18 +15,50 @@ def is_interactive() -> bool:
 
 
 def _sanitize_output(text: str) -> str:
-    """Strip control characters from text, preserving only printable content.
+    """Strip control characters and ANSI escape sequences from text.
 
     Uses a whitelist approach: allows tab and newline, strips everything
     else in C0 (0x00-0x1F), DEL (0x7F), and C1 (0x80-0x9F) ranges.
-    This catches all ANSI/OSC/CSI escape sequences by removing the ESC byte.
+    Also strips complete ANSI escape sequences (ESC + bracket + params + letter).
     """
-    return "".join(
-        ch
-        for ch in text
-        if ch in ("\t", "\n")
-        or (ch >= " " and ch != "\x7f" and not ("\x80" <= ch <= "\x9f"))
-    )
+    result = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "\x1b" and i + 1 < len(text) and text[i + 1] == "[":
+            j = i + 2
+            while j < len(text) and text[j] in "0123456789;?":
+                j += 1
+            if j < len(text) and text[j] in (
+                "A",
+                "B",
+                "C",
+                "D",
+                "E",
+                "F",
+                "G",
+                "H",
+                "J",
+                "K",
+                "S",
+                "T",
+                "f",
+                "m",
+                "n",
+                "s",
+                "u",
+            ):
+                i = j + 1
+                continue
+            else:
+                i += 1
+                continue
+        if ch in ("\t", "\n") or (
+            ch >= " " and ch != "\x7f" and not ("\x80" <= ch <= "\x9f")
+        ):
+            result.append(ch)
+        i += 1
+    return "".join(result)
 
 
 def _sanitize_spinner_text(text: str) -> str:
@@ -374,3 +407,144 @@ class Spinner:
     ) -> None:
         """Stop spinner when exiting the context manager."""
         self.stop()
+
+
+def confirm_workflow_assignments_interactive(
+    display_keys: list[tuple[int, int]],
+    workflow_assignments: dict[tuple[int, int], Path],
+    task_files: list[tuple[Path, Any]],
+    available_workflows: list[tuple[Path, str]],
+    stream: TextIO | None = None,
+) -> dict[tuple[int, int], Path] | None:
+    """Present an interactive numbered-list CUI for workflow assignment confirmation.
+
+    Displays a table of all entries (assigned and unassigned), allows the user
+    to change individual assignments by number, and returns the (possibly
+    modified) assignments dict on confirm or None on cancel.
+
+    Args:
+        display_keys: Ordered list of (file_idx, entry_idx) keys to display.
+        workflow_assignments: Map of (file_idx, entry_idx) -> workflow path.
+        task_files: List of (file_path, task_file) tuples.
+        available_workflows: List of (workflow_path, description) tuples.
+        stream: Output stream for prompts (defaults to sys.stderr).
+
+    Returns:
+        The confirmed assignments dict on 'c' confirm,
+        or None if the user cancelled with 'q'.
+    """
+    if stream is None:
+        stream = sys.stderr
+
+    if not is_interactive():
+        return dict(workflow_assignments)
+
+    assignments = dict(workflow_assignments)
+
+    while True:
+        stream.write("\n")
+        stream.write("=" * 79 + "\n")
+        stream.write("WORKFLOW ASSIGNMENTS\n")
+        stream.write("=" * 79 + "\n")
+        stream.write(
+            f"{'#':<4} {'FILE':<30} {'ENTRY':<6} {'WORKFLOW':<30} {'TASK':<15}\n"
+        )
+        stream.write("-" * 79 + "\n")
+
+        for row_num, key in enumerate(display_keys, start=1):
+            file_idx, entry_idx = key
+            file_path, task_file = task_files[file_idx]
+            entry = task_file.entries[entry_idx]
+            wf_path = assignments.get(key)
+            wf_name = wf_path.name if wf_path else "(unassigned)"
+
+            file_name = file_path.name[:29]
+            entry_num = str(entry_idx + 1)
+            task_preview = _sanitize_output(entry.description)[:14]
+
+            stream.write(
+                f"{row_num:<4} "
+                f"{_sanitize_output(file_name):<30} "
+                f"{entry_num:<6} "
+                f"{_sanitize_output(wf_name):<30} "
+                f"{_sanitize_output(task_preview):<15}\n"
+            )
+
+        stream.write("=" * 79 + "\n")
+
+        has_unassigned = any(key not in assignments for key in display_keys)
+
+        if has_unassigned:
+            stream.write(
+                "Enter number to change workflow, 'c' to confirm, 'q' to cancel\n"
+            )
+            stream.write(
+                "(Note: unassigned entries must be assigned before confirming)\n"
+            )
+        else:
+            stream.write(
+                "Enter number to change workflow, 'c' to confirm, 'q' to cancel: "
+            )
+
+        stream.flush()
+        user_input = input().strip()
+
+        if user_input.lower() == "c":
+            if has_unassigned:
+                unassigned_count = sum(
+                    1 for key in display_keys if key not in assignments
+                )
+                stream.write(
+                    f"Cannot confirm: {unassigned_count} task(s) have no "
+                    f"workflow assigned. Assign workflows to all tasks first.\n"
+                )
+                stream.flush()
+                continue
+            return assignments
+
+        if user_input.lower() == "q":
+            return None
+
+        try:
+            row_num = int(user_input)
+            if not (1 <= row_num <= len(display_keys)):
+                stream.write(f"Invalid number. Enter 1-{len(display_keys)}.\n")
+                stream.flush()
+                continue
+        except ValueError:
+            stream.write("Invalid input. Enter a number, 'c', or 'q'.\n")
+            stream.flush()
+            continue
+
+        key = display_keys[row_num - 1]
+
+        if not available_workflows:
+            stream.write("No alternative workflows available to select.\n")
+            stream.flush()
+            continue
+
+        stream.write("\nAvailable workflows:\n")
+        stream.write("-" * 60 + "\n")
+        for i, (wf_path, description) in enumerate(available_workflows, 1):
+            desc_preview = (
+                description[:50] + "..." if len(description) > 50 else description
+            )
+            stream.write(f"  {i}. {_sanitize_output(wf_path.name)}\n")
+            stream.write(f"      {_sanitize_output(desc_preview)}\n")
+        stream.write("-" * 60 + "\n")
+        stream.write("Enter number (or 'c' to cancel): ")
+        stream.flush()
+
+        pick_input = input().strip()
+        if pick_input.lower() == "c":
+            continue
+        try:
+            pick_idx = int(pick_input) - 1
+            if 0 <= pick_idx < len(available_workflows):
+                assignments[key] = available_workflows[pick_idx][0]
+            else:
+                stream.write(f"Invalid number. Enter 1-{len(available_workflows)}.\n")
+                stream.flush()
+        except ValueError:
+            stream.write("Invalid input. Enter a number.\n")
+            stream.flush()

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -439,6 +439,10 @@ def confirm_workflow_assignments_interactive(
     if not is_interactive():
         return dict(workflow_assignments)
 
+    unassigned = [k for k in display_keys if k not in workflow_assignments]
+    if len(display_keys) == 1 and not unassigned:
+        return dict(workflow_assignments)
+
     assignments = dict(workflow_assignments)
 
     while True:

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -548,3 +548,60 @@ def confirm_workflow_assignments_interactive(
         except ValueError:
             stream.write("Invalid input. Enter a number.\n")
             stream.flush()
+
+
+def display_resume_command(
+    mode: str,
+    thread_id: str | None = None,
+    tasks_dir: Path | None = None,
+    extra_args: list[str] | None = None,
+    stream: TextIO | None = None,
+) -> None:
+    """Display a box-formatted resume command for error/interrupt scenarios.
+
+    Args:
+        mode: Either "single-flow" or "tasks-dir".
+        thread_id: Thread ID for single-flow mode.
+        tasks_dir: Tasks directory for tasks-dir mode.
+        extra_args: Additional command-line arguments to include.
+        stream: Output stream (defaults to sys.stderr).
+    """
+    if stream is None:
+        stream = sys.stderr
+
+    if mode == "single-flow":
+        if thread_id is None:
+            raise ValueError("thread_id is required for single-flow mode")
+        cmd_parts = ["fdsx", "resume", "--thread-id", _sanitize_output(thread_id)]
+    elif mode == "tasks-dir":
+        if tasks_dir is None:
+            raise ValueError("tasks_dir is required for tasks-dir mode")
+        cmd_parts = ["fdsx", "run", "--tasks-dir", _sanitize_output(str(tasks_dir))]
+    else:
+        raise ValueError(f"Invalid mode: {mode}. Use 'single-flow' or 'tasks-dir'.")
+
+    if extra_args:
+        for arg in extra_args:
+            cmd_parts.append(_sanitize_output(arg))
+
+    command = " ".join(cmd_parts)
+
+    width = max(len(command) + 4, 50)
+    border = "+" + "-" * (width - 2) + "+"
+    padding = " " * (width - 2)
+
+    stream.write("\n")
+    stream.write(border + "\n")
+    if mode == "single-flow":
+        stream.write(f"|{padding}|\n")
+        stream.write(f"|  To resume this flow, run:\n")
+        stream.write(f"|  $ {command}\n")
+        stream.write(f"|{padding}|\n")
+    else:
+        stream.write(f"|{padding}|\n")
+        stream.write(f"|  To continue processing, run:\n")
+        stream.write(f"|  $ {command}\n")
+        stream.write(f"|{padding}|\n")
+    stream.write(border + "\n")
+    stream.write("\n")
+    stream.flush()

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -245,6 +245,60 @@ def display_parallel_results(
                 print(_sanitize_output(line), file=sys.stderr)
 
 
+def _format_elapsed(seconds: float) -> str:
+    """Format elapsed time as a human-readable string.
+
+    Args:
+        seconds: Elapsed time in seconds
+
+    Returns:
+        Formatted string like '34s', '2m 34s', or '1h 2m 34s'
+    """
+    total = int(seconds)
+    h = total // 3600
+    m = (total % 3600) // 60
+    s = total % 60
+    if h > 0:
+        return f"{h}h {m}m {s}s"
+    elif m > 0:
+        return f"{m}m {s}s"
+    else:
+        return f"{s}s"
+
+
+def display_completion_summary(
+    flow_name: str,
+    elapsed_seconds: float,
+    failed_state: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Display workflow completion summary to stderr.
+
+    On success, prints a single line with flow name and elapsed time.
+    On failure, prints flow name, the failed state name, and a brief error.
+
+    Args:
+        flow_name: Name of the workflow
+        elapsed_seconds: Total elapsed time in seconds
+        failed_state: Name of the failed state (None on success)
+        error: Error message (None on success)
+    """
+    flow_name_safe = _sanitize_output(flow_name)
+    time_str = _format_elapsed(elapsed_seconds)
+    if failed_state is None:
+        print(
+            f"✓ Workflow '{flow_name_safe}' completed successfully in {time_str}",
+            file=sys.stderr,
+        )
+    else:
+        failed_state_safe = _sanitize_output(failed_state)
+        error_str = _sanitize_output(error) if error else "unknown error"
+        print(
+            f"✗ Workflow '{flow_name_safe}' failed at state '{failed_state_safe}' — {error_str}",
+            file=sys.stderr,
+        )
+
+
 def display_wait_prompt(state_name: str, message: str, choices: list[str]) -> str:
     """Display a wait prompt and get user selection.
 

--- a/src/fdsx/logging/__init__.py
+++ b/src/fdsx/logging/__init__.py
@@ -1,5 +1,6 @@
 """Logging utilities."""
 
 from fdsx.logging.recorder import RunRecorder
+from fdsx.logging.stream_logger import StreamLogger
 
-__all__ = ["RunRecorder"]
+__all__ = ["RunRecorder", "StreamLogger"]

--- a/src/fdsx/logging/recorder.py
+++ b/src/fdsx/logging/recorder.py
@@ -13,6 +13,7 @@ THREAD_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 # Directory layout constants
 FDSX_DIR_NAME = ".fdsx"
 RUNS_DIR_NAME = "runs"
+LOGS_DIR_NAME = "logs"
 RUN_FILENAME = "run.json"
 
 

--- a/src/fdsx/logging/recorder.py
+++ b/src/fdsx/logging/recorder.py
@@ -10,6 +10,11 @@ OUTPUT_PREVIEW_MAX_LENGTH = 500
 
 THREAD_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
+# Directory layout constants
+FDSX_DIR_NAME = ".fdsx"
+RUNS_DIR_NAME = "runs"
+RUN_FILENAME = "run.json"
+
 
 class RunRecorder:
     """Records per-state input/output/duration to a JSON run log."""
@@ -126,21 +131,28 @@ class RunRecorder:
         self.final_variables = final_variables
 
     def save(self, base_dir: Path | None = None) -> Path:
-        """Write JSON to runs/<thread_id>.json relative to CWD (or base_dir)."""
+        """Write JSON to <base_dir>/runs/<thread_id>/run.json.
+
+        When base_dir is None, defaults to <CWD>/.fdsx/runs/<thread_id>/run.json.
+        When base_dir is provided, writes to <base_dir>/runs/<thread_id>/run.json.
+        """
         if base_dir is not None:
-            runs_dir = (base_dir / "runs").resolve()
+            runs_dir = (base_dir / RUNS_DIR_NAME).resolve()
         else:
-            runs_dir = (Path.cwd() / "runs").resolve()
+            runs_dir = (Path.cwd() / FDSX_DIR_NAME / RUNS_DIR_NAME).resolve()
 
         os.makedirs(runs_dir, mode=0o700, exist_ok=True)
         os.chmod(str(runs_dir), 0o700)
 
-        file_path = (runs_dir / f"{self.thread_id}").resolve()
+        thread_dir = (runs_dir / self.thread_id).resolve()
 
-        if not str(file_path).startswith(str(runs_dir)):
+        if not str(thread_dir).startswith(str(runs_dir)):
             raise ValueError("Invalid thread_id: path resolved outside runs directory")
 
-        file_path = file_path.with_suffix(".json")
+        os.makedirs(thread_dir, mode=0o700, exist_ok=True)
+        os.chmod(str(thread_dir), 0o700)
+
+        file_path = thread_dir / RUN_FILENAME
 
         if file_path.exists():
             with open(file_path, "r") as f:

--- a/src/fdsx/logging/stream_logger.py
+++ b/src/fdsx/logging/stream_logger.py
@@ -32,11 +32,19 @@ class StreamLogger:
                     log file stem ``<state_name>.log``.
         log_dir: Directory for per-state log files. When None, terminal
                  streaming still works but no log file is written.
+        quiet: When True, suppresses print to stderr. Log file writes are
+               unaffected.
     """
 
-    def __init__(self, state_name: str, log_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        state_name: str,
+        log_dir: Path | None = None,
+        quiet: bool = False,
+    ) -> None:
         self.state_name = state_name
         self.log_dir = log_dir
+        self.quiet = quiet
         self._lock = threading.Lock()
         self._file: IO[str] | None = None
 
@@ -45,8 +53,10 @@ class StreamLogger:
 
         Prefixes the line with ``[state_name]`` and prints to stderr,
         then appends the raw line to the log file.
+        When quiet=True, the print to stderr is suppressed.
         """
-        print(f"[{self.state_name}] {line}", file=sys.stderr)
+        if not self.quiet:
+            print(f"[{self.state_name}] {line}", file=sys.stderr)
         self._write_to_file(line)
 
     def on_stderr(self, line: str) -> None:
@@ -54,8 +64,10 @@ class StreamLogger:
 
         Prefixes the line with ``[state_name]`` and prints to stderr,
         then appends the raw line to the log file.
+        When quiet=True, the print to stderr is suppressed.
         """
-        print(f"[{self.state_name}] {line}", file=sys.stderr)
+        if not self.quiet:
+            print(f"[{self.state_name}] {line}", file=sys.stderr)
         self._write_to_file(line)
 
     def _write_to_file(self, line: str) -> None:

--- a/src/fdsx/logging/stream_logger.py
+++ b/src/fdsx/logging/stream_logger.py
@@ -57,6 +57,7 @@ class StreamLogger:
         """
         if not self.quiet:
             print(f"[{self.state_name}] {line}", file=sys.stderr)
+            sys.stderr.flush()
         self._write_to_file(line)
 
     def on_stderr(self, line: str) -> None:
@@ -68,6 +69,7 @@ class StreamLogger:
         """
         if not self.quiet:
             print(f"[{self.state_name}] {line}", file=sys.stderr)
+            sys.stderr.flush()
         self._write_to_file(line)
 
     def _write_to_file(self, line: str) -> None:

--- a/src/fdsx/logging/stream_logger.py
+++ b/src/fdsx/logging/stream_logger.py
@@ -1,0 +1,78 @@
+"""StreamLogger: real-time provider output streaming with per-state log files.
+
+Streams provider stdout/stderr to the terminal's stderr with a ``[state_name]``
+prefix, and writes complete output to a per-state log file under log_dir.
+
+Design notes:
+- ANSI escape codes pass through as-is (no sanitization) per FR-2.7.
+- Log files are created lazily on the first line of output per FR-2.6.
+- Log directory is created with mode 0o700 consistent with runs directory.
+- File writes are protected by a per-instance lock; for parallel branches that
+  share a log file, each branch opens its own file handle in append ("a") mode.
+  Line-level OS append writes are atomic for typical log line sizes.
+"""
+
+import os
+import sys
+import threading
+from pathlib import Path
+from typing import IO
+
+LOG_FILE_SUFFIX = ".log"
+
+
+class StreamLogger:
+    """Streams provider output to terminal (stderr) with state-name prefix.
+
+    Writes complete per-state output to a log file under log_dir.
+
+    Args:
+        state_name: Name of the state (or parallel state for branches).
+                    Used as the terminal prefix ``[state_name]`` and as the
+                    log file stem ``<state_name>.log``.
+        log_dir: Directory for per-state log files. When None, terminal
+                 streaming still works but no log file is written.
+    """
+
+    def __init__(self, state_name: str, log_dir: Path | None = None) -> None:
+        self.state_name = state_name
+        self.log_dir = log_dir
+        self._lock = threading.Lock()
+        self._file: IO[str] | None = None
+
+    def on_stdout(self, line: str) -> None:
+        """Handle a stdout line from the provider.
+
+        Prefixes the line with ``[state_name]`` and prints to stderr,
+        then appends the raw line to the log file.
+        """
+        print(f"[{self.state_name}] {line}", file=sys.stderr)
+        self._write_to_file(line)
+
+    def on_stderr(self, line: str) -> None:
+        """Handle a stderr line from the provider.
+
+        Prefixes the line with ``[state_name]`` and prints to stderr,
+        then appends the raw line to the log file.
+        """
+        print(f"[{self.state_name}] {line}", file=sys.stderr)
+        self._write_to_file(line)
+
+    def _write_to_file(self, line: str) -> None:
+        """Write a line to the per-state log file, creating it lazily."""
+        if self.log_dir is None:
+            return
+        with self._lock:
+            if self._file is None:
+                os.makedirs(str(self.log_dir), mode=0o700, exist_ok=True)
+                log_path = self.log_dir / f"{self.state_name}{LOG_FILE_SUFFIX}"
+                self._file = open(log_path, "a", encoding="utf-8")
+            self._file.write(line + "\n")
+            self._file.flush()
+
+    def close(self) -> None:
+        """Flush and close the log file handle if open."""
+        with self._lock:
+            if self._file is not None:
+                self._file.close()
+                self._file = None

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -2,6 +2,8 @@ from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from fdsx.models.validators import validate_llm_provider
+
 
 def _parse_path_segments(path: str) -> list[str | int]:
     """Parse a JSONPath-like string into typed segments.
@@ -49,12 +51,7 @@ class LLMClassifyFallback(BaseModel):
 
     @model_validator(mode="after")
     def validate_provider(self) -> "LLMClassifyFallback":
-        valid_llm_providers = {"claude", "opencode", "codex"}
-        if self.provider not in valid_llm_providers:
-            raise ValueError(
-                f"LLM classify fallback provider must be one of "
-                f"{', '.join(sorted(valid_llm_providers))}, got '{self.provider}'"
-            )
+        validate_llm_provider(self.provider, "LLM classify fallback")
         return self
 
 
@@ -66,12 +63,7 @@ class TaskSplitter(BaseModel):
 
     @model_validator(mode="after")
     def validate_provider(self) -> "TaskSplitter":
-        valid_llm_providers = {"claude", "opencode", "codex"}
-        if self.provider not in valid_llm_providers:
-            raise ValueError(
-                f"task_splitter provider must be one of "
-                f"{', '.join(sorted(valid_llm_providers))}, got '{self.provider}'"
-            )
+        validate_llm_provider(self.provider, "task_splitter")
         return self
 
 

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -102,6 +102,26 @@ class NotifyConfig(BaseModel):
     webhook: WebhookConfig = Field(..., description="Webhook configuration")
 
 
+class HookEntry(BaseModel):
+    """Single hook entry with a command and failure handling policy."""
+
+    command: str = Field(..., min_length=1, description="Shell command to execute")
+    on_failure: Literal["abort", "warn"] = Field(
+        default="warn", description="Action on hook failure: abort or warn"
+    )
+
+
+class HookConfig(BaseModel):
+    """Hook configuration for a state or flow."""
+
+    on_start: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run before execution"
+    )
+    on_complete: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run after execution"
+    )
+
+
 class ChoiceRule(BaseModel):
     """Choice rule for branching."""
 
@@ -233,6 +253,7 @@ class TaskState(BaseModel):
     provider_options: dict[str, Any] | None = Field(
         default=None, description="Per-task provider option overrides"
     )
+    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -288,6 +309,7 @@ class ChoiceState(BaseModel):
     type: Literal["choice"] = "choice"
     choices: list[ChoiceRule] = Field(..., description="Condition-transition pairs")
     default: str | None = Field(default=None, description="Fallback transition")
+    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
 
 
 class ParallelState(BaseModel):
@@ -297,6 +319,7 @@ class ParallelState(BaseModel):
     branches: list[Branch] = Field(..., description="Parallel branch definitions")
     result_path: str = Field(..., description="JSONPath for results array")
     min_success: int | None = Field(default=None, description="Min successful branches")
+    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -319,6 +342,7 @@ class PassState(BaseModel):
     aggregate: AggregateRule | None = Field(
         default=None, description="Parallel result aggregation"
     )
+    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -342,6 +366,7 @@ class WaitState(BaseModel):
     notify: NotifyConfig | None = Field(
         default=None, description="Webhook notification"
     )
+    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -371,6 +396,9 @@ class Flow(BaseModel):
     max_loop: int = Field(default=10, description="Max loop iterations")
     providers: dict[str, dict[str, Any]] | None = Field(
         default=None, description="Workflow-level provider configurations keyed by name"
+    )
+    hooks: HookConfig | None = Field(
+        default=None, description="Flow-level hook configuration"
     )
 
     @model_validator(mode="before")

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -55,18 +55,6 @@ class LLMClassifyFallback(BaseModel):
         return self
 
 
-class TaskSplitter(BaseModel):
-    """Configuration for batch task splitting."""
-
-    provider: str = Field(..., description="Provider name (claude/opencode/codex)")
-    model: str = Field(..., description="Model name")
-
-    @model_validator(mode="after")
-    def validate_provider(self) -> "TaskSplitter":
-        validate_llm_provider(self.provider, "task_splitter")
-        return self
-
-
 class ExtractRule(BaseModel):
     """Output extraction configuration."""
 
@@ -370,14 +358,23 @@ class Flow(BaseModel):
     """Top-level workflow definition."""
 
     name: str = Field(..., description="Flow name")
+    description: str = Field(..., min_length=1, description="Flow description")
     start_at: str = Field(..., description="Initial state name")
     states: dict[str, State] = Field(..., description="State definitions keyed by name")
-    comment: str | None = Field(default=None, description="Flow description")
     version: str | None = Field(default=None, description="Flow version")
-    task_splitter: TaskSplitter | None = Field(
-        default=None, description="Batch task splitting config"
-    )
     max_loop: int = Field(default=10, description="Max loop iterations")
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_task_splitter(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Reject task_splitter field and provide migration guidance."""
+        if "task_splitter" in values:
+            raise ValueError(
+                "task_splitter has been removed from Flow model. "
+                "Configure task splitting in your fdsx config file instead. "
+                "See: https://fdsx.dev/docs/config#task-splitter"
+            )
+        return values
 
     @model_validator(mode="after")
     def validate_start_at_exists(self) -> "Flow":

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -233,6 +233,34 @@ class AggregateRule(BaseModel):
     result_path: str = Field(..., description="JSONPath for result")
 
 
+def _validate_result_file(v: str | None) -> str | None:
+    """Validate that result_file uses a top-level '$.varname' path.
+
+    Requirements:
+    - Must start with '$.'
+    - Must be a single top-level key (no dots or brackets after '$.')
+    """
+    if v is None:
+        return v
+    if not v.startswith("$."):
+        raise ValueError(
+            f"result_file must start with '$.' (got '{v}'). "
+            "Example: '$.plan_ref'"
+        )
+    remainder = v[2:]
+    if not remainder or not remainder.strip():
+        raise ValueError(
+            f"result_file must specify a variable name after '$.' (got '{v}'). "
+            "Example: '$.plan_ref'"
+        )
+    if "." in remainder or "[" in remainder:
+        raise ValueError(
+            f"result_file must be a top-level variable path — nested paths are not allowed (got '{v}'). "
+            "Example: '$.plan_ref'"
+        )
+    return v
+
+
 class TaskState(BaseModel):
     """Task state - executes a provider to generate output."""
 
@@ -247,6 +275,10 @@ class TaskState(BaseModel):
     )
     command: str | None = Field(default=None, description="Command for system provider")
     result_path: str = Field(..., description="JSONPath for result")
+    result_file: str | None = Field(
+        default=None,
+        description="Top-level JSONPath variable to store the absolute path of a result file",
+    )
     extract: ExtractRule | None = Field(default=None, description="Output extraction")
     retry: int = Field(default=3, description="Retry count")
     timeout_seconds: int | None = Field(default=None, description="Timeout in seconds")
@@ -258,6 +290,11 @@ class TaskState(BaseModel):
         default=None, description="Next state (exclusive with end)"
     )
     end: bool | None = Field(default=None, description="End flow (exclusive with next)")
+
+    @field_validator("result_file")
+    @classmethod
+    def validate_result_file(cls, v: str | None) -> str | None:
+        return _validate_result_file(v)
 
     @model_validator(mode="after")
     def validate_provider_fields(self) -> "TaskState":
@@ -318,12 +355,21 @@ class ParallelState(BaseModel):
     type: Literal["parallel"] = "parallel"
     branches: list[Branch] = Field(..., description="Parallel branch definitions")
     result_path: str = Field(..., description="JSONPath for results array")
+    result_file: str | None = Field(
+        default=None,
+        description="Top-level JSONPath variable to store the absolute path of a result file",
+    )
     min_success: int | None = Field(default=None, description="Min successful branches")
     hooks: HookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
     end: bool | None = Field(default=None, description="End flow (exclusive with next)")
+
+    @field_validator("result_file")
+    @classmethod
+    def validate_result_file(cls, v: str | None) -> str | None:
+        return _validate_result_file(v)
 
     @model_validator(mode="after")
     def validate_next_end_exclusive(self) -> "ParallelState":

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -167,6 +167,9 @@ class Branch(BaseModel):
     extract: ExtractRule | None = Field(default=None, description="Output extraction")
     retry: int = Field(default=3, description="Retry count")
     timeout_seconds: int | None = Field(default=None, description="Timeout in seconds")
+    provider_options: dict[str, Any] | None = Field(
+        default=None, description="Per-branch provider option overrides"
+    )
 
     @model_validator(mode="after")
     def validate_provider(self) -> "Branch":
@@ -227,6 +230,9 @@ class TaskState(BaseModel):
     extract: ExtractRule | None = Field(default=None, description="Output extraction")
     retry: int = Field(default=3, description="Retry count")
     timeout_seconds: int | None = Field(default=None, description="Timeout in seconds")
+    provider_options: dict[str, Any] | None = Field(
+        default=None, description="Per-task provider option overrides"
+    )
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -363,6 +369,9 @@ class Flow(BaseModel):
     states: dict[str, State] = Field(..., description="State definitions keyed by name")
     version: str | None = Field(default=None, description="Flow version")
     max_loop: int = Field(default=10, description="Max loop iterations")
+    providers: dict[str, dict[str, Any]] | None = Field(
+        default=None, description="Workflow-level provider configurations keyed by name"
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -15,6 +15,7 @@ Supports both flat single-task format and list multi-task format:
 
 from __future__ import annotations
 
+import errno
 import os
 from pathlib import Path
 from typing import Literal
@@ -95,11 +96,27 @@ def load_task_file(path: Path) -> TaskFile:
     if not path.exists():
         raise FileNotFoundError(f"Task file not found: {path}")
 
-    with open(path, encoding="utf-8") as f:
-        try:
-            raw = yaml.safe_load(f)
-        except yaml.YAMLError as e:
-            raise ValueError(f"Invalid YAML in task file {path}: {e}") from e
+    open_flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        open_flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(str(path), open_flags)
+    except OSError as e:
+        if e.errno == errno.ELOOP:
+            raise ValueError(
+                f"Refusing to read task file: {path} is a symlink"
+            ) from e
+        raise
+    try:
+        data = os.read(fd, os.fstat(fd).st_size)
+        content = data.decode("utf-8")
+    finally:
+        os.close(fd)
+
+    try:
+        raw = yaml.safe_load(content)
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in task file {path}: {e}") from e
 
     if raw is None:
         return TaskFile()

--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -1,0 +1,183 @@
+"""Task file models for batch task persistence.
+
+Supports both flat single-task format and list multi-task format:
+  # Flat (single task)
+  description: "Fix the bug in the login flow"
+  status: pending
+
+  # List (multi-task)
+  tasks:
+    - description: "Fix the bug in the login flow"
+      status: pending
+    - description: "Write tests for the fix"
+      status: pending
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError, field_validator
+
+
+class TaskEntry(BaseModel):
+    """A single task within a task file."""
+
+    description: str = Field(..., description="Human-readable task description")
+    status: Literal["pending", "running", "completed", "failed"] = Field(
+        default="pending", description="Task execution status"
+    )
+    workflow: str | None = Field(
+        default=None,
+        description="Workflow filename, resolved from workflows_dir",
+    )
+    thread_id: str | None = Field(
+        default=None,
+        description="Thread/connection ID for resuming a running task",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Error message from last execution attempt",
+    )
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        valid = {"pending", "running", "completed", "failed"}
+        if v not in valid:
+            raise ValueError(
+                f"status must be one of {', '.join(sorted(valid))}, got '{v}'"
+            )
+        return v
+
+    @field_validator("workflow")
+    @classmethod
+    def validate_workflow_filename(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        if v in (".", "..") or "/" in v or "\\" in v or v != Path(v).name:
+            raise ValueError(
+                f"workflow must be a filename (no path separators), got '{v}'"
+            )
+        return v
+
+
+class TaskFile(BaseModel):
+    """A task file containing one or more task entries.
+
+    Internally always represented as a list of entries. On load, both flat
+    (single-task) and list (multi-task) YAML formats are normalized to this
+    unified representation.
+    """
+
+    entries: list[TaskEntry] = Field(
+        default_factory=list,
+        description="List of task entries in this file",
+    )
+
+
+def load_task_file(path: Path) -> TaskFile:
+    """Load a task file, normalizing flat or list format into TaskFile.
+
+    Args:
+        path: Path to the YAML task file.
+
+    Returns:
+        TaskFile with normalized entries list.
+
+    Raises:
+        FileNotFoundError: If the task file does not exist.
+        ValueError: If the YAML is malformed.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Task file not found: {path}")
+
+    with open(path, encoding="utf-8") as f:
+        try:
+            raw = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            raise ValueError(f"Invalid YAML in task file {path}: {e}") from e
+
+    if raw is None:
+        return TaskFile()
+
+    if isinstance(raw, dict):
+        if "tasks" in raw:
+            tasks_raw = raw["tasks"]
+            if not isinstance(tasks_raw, list):
+                raise ValueError(
+                    f"'tasks' key in {path} must be a list, "
+                    f"got {type(tasks_raw).__name__}"
+                )
+            for i, t in enumerate(tasks_raw):
+                if not isinstance(t, dict):
+                    raise ValueError(
+                        f"Task entry {i} in {path} must be a mapping, "
+                        f"got {type(t).__name__}"
+                    )
+            entries = []
+            for i, t in enumerate(tasks_raw):
+                try:
+                    entries.append(TaskEntry.model_validate(t))
+                except ValidationError as e:
+                    raise ValueError(f"Invalid task entry {i} in {path}: {e}") from e
+        else:
+            try:
+                entries = [TaskEntry.model_validate(raw)]
+            except ValidationError as e:
+                raise ValueError(f"Invalid task entry in {path}: {e}") from e
+    else:
+        raise ValueError(
+            f"Unexpected task file format at {path}: expected a YAML mapping"
+        )
+
+    return TaskFile(entries=entries)
+
+
+def save_task_file(path: Path, task_file: TaskFile) -> None:
+    """Save a task file to disk.
+
+    Single-entry files are written in flat format; multi-entry files use the
+    list format. None-valued fields are excluded for cleanliness.
+
+    Args:
+        path: Destination path.
+        task_file: TaskFile to serialize.
+    """
+    # Walk every existing ancestor to reject any symlinked directory before
+    # creating any directories. Non-existent ancestors cannot be symlinks.
+    current = path.parent
+    while current != current.parent:
+        if current.exists() and current.is_symlink():
+            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
+        current = current.parent
+
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    os.chmod(str(path.parent), 0o700)  # tighten existing dirs too
+
+    if len(task_file.entries) == 1:
+        data = task_file.entries[0].model_dump(exclude_none=True)
+    else:
+        data = {"tasks": [e.model_dump(exclude_none=True) for e in task_file.entries]}
+
+    content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+    if path.is_symlink():
+        raise ValueError(f"Refusing to write: target is a symlink: {path}")
+
+    open_flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        open_flags |= os.O_NOFOLLOW
+    fd = os.open(str(path), open_flags, 0o600)
+    try:
+        os.fchmod(fd, 0o600)  # tighten existing files too
+        mv = memoryview(content.encode("utf-8"))
+        while mv:
+            written = os.write(fd, mv)
+            mv = mv[written:]
+    finally:
+        os.close(fd)

--- a/src/fdsx/models/validators.py
+++ b/src/fdsx/models/validators.py
@@ -1,0 +1,30 @@
+"""Shared model validators for fdsx.
+
+Centralised provider validation to prevent cross-module drift between
+config.py and flow.py.
+"""
+
+from __future__ import annotations
+
+VALID_PROVIDERS = frozenset({"claude", "opencode", "codex"})
+
+
+def validate_llm_provider(v: str, context: str) -> str:
+    """Validate that a provider name is one of the known LLM providers.
+
+    Args:
+        v: Provider name to validate.
+        context: Human-readable context label used in the error message.
+
+    Returns:
+        The validated provider name (unchanged).
+
+    Raises:
+        ValueError: If v is not a recognised provider.
+    """
+    if v not in VALID_PROVIDERS:
+        raise ValueError(
+            f"{context} provider must be one of "
+            f"{', '.join(sorted(VALID_PROVIDERS))}, got '{v}'"
+        )
+    return v

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -131,7 +131,10 @@ def _run_subprocess(
         def _read_stderr() -> None:
             if process.stderr:
                 try:
-                    for raw_line in process.stderr:
+                    while True:
+                        raw_line = process.stderr.readline()
+                        if not raw_line:
+                            break
                         line = raw_line.rstrip("\n")
                         stderr_lines.append(line)
                         if stderr_callback:
@@ -145,7 +148,10 @@ def _run_subprocess(
         stdout_lines: list[str] = []
         try:
             if process.stdout:
-                for line in process.stdout:
+                while True:
+                    line = process.stdout.readline()
+                    if not line:
+                        break
                     line = line.rstrip("\n")
                     stdout_lines.append(line)
                     if output_callback:

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -2,7 +2,7 @@ import logging
 import subprocess
 import threading
 from dataclasses import dataclass
-from typing import Callable, Protocol
+from typing import Any, Callable, Protocol
 
 logger = logging.getLogger(__name__)
 
@@ -171,23 +171,38 @@ def _run_subprocess(
         )
 
 
-def get_provider(name: str) -> ProviderBase:
-    """Factory function to get a provider by name."""
+def get_provider(name: str, options: dict[str, Any] | None = None) -> ProviderBase:
+    """Factory function to get a provider by name.
+
+    Args:
+        name: Provider name (claude, codex, opencode, system).
+        options: Optional dict of provider-specific options. Converted to the
+                 appropriate typed options model internally. Ignored for system provider.
+
+    Returns:
+        A ProviderBase instance configured with the given options.
+
+    Raises:
+        ValueError: If the provider name is unknown.
+    """
     if name == "system":
         from fdsx.providers.system import SystemProvider
 
         return SystemProvider()
     elif name == "claude":
-        from fdsx.providers.claude import ClaudeProvider
+        from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
 
-        return ClaudeProvider()
+        claude_opts = ClaudeOptions.model_validate(options) if options else None
+        return ClaudeProvider(claude_opts)
     elif name == "opencode":
-        from fdsx.providers.opencode import OpenCodeProvider
+        from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
 
-        return OpenCodeProvider()
+        opencode_opts = OpenCodeOptions.model_validate(options) if options else None
+        return OpenCodeProvider(opencode_opts)
     elif name == "codex":
-        from fdsx.providers.codex import CodexProvider
+        from fdsx.providers.codex import CodexOptions, CodexProvider
 
-        return CodexProvider()
+        codex_opts = CodexOptions.model_validate(options) if options else None
+        return CodexProvider(codex_opts)
     else:
         raise ValueError(f"Unknown provider: {name}")

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -1,7 +1,13 @@
+import logging
 import subprocess
 import threading
 from dataclasses import dataclass
 from typing import Callable, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Commands at or above this byte length are piped via stdin to avoid ARG_MAX limits.
+ARG_MAX_STDIN_THRESHOLD = 131072  # 128 KB
 
 
 @dataclass
@@ -56,17 +62,29 @@ def _run_subprocess(
     """Shared subprocess execution helper for all providers.
 
     Args:
-        args: Command arguments list. If shell=True, args[0] is passed to sh -c.
+        args: Command arguments list. If shell=True, args[0] is the shell command
+            (passed to sh -c, or piped via stdin for large commands).
         timeout: Timeout in seconds.
         output_callback: Optional callback for streaming stdout lines.
         stdin_data: Optional data to pass via stdin.
-        shell: If True, execute via sh -c (for system provider).
+        shell: If True, execute as shell command (via sh -c, or stdin fallback
+            if command exceeds ARG_MAX_STDIN_THRESHOLD).
 
     Returns:
         ProviderResult with exit code and output.
     """
     if shell:
-        cmd: list[str] = ["sh", "-c", args[0]]
+        command_size = len(args[0].encode("utf-8"))
+        if command_size >= ARG_MAX_STDIN_THRESHOLD:
+            logger.debug(
+                "Command size %d bytes exceeds ARG_MAX_STDIN_THRESHOLD (%d bytes); piping via stdin",
+                command_size,
+                ARG_MAX_STDIN_THRESHOLD,
+            )
+            cmd: list[str] = ["sh"]
+            stdin_data = args[0]
+        else:
+            cmd = ["sh", "-c", args[0]]
     else:
         cmd = args
 

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -29,6 +29,7 @@ class ProviderBase(Protocol):
         timeout: int | None = None,
         command: str | None = None,
         output_callback: Callable[[str], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> ProviderResult:
         """Execute a provider.
 
@@ -37,7 +38,8 @@ class ProviderBase(Protocol):
             model: Model name (provider-specific)
             timeout: Timeout in seconds
             command: Command for system provider
-            output_callback: Optional callback for streaming output
+            output_callback: Optional callback for streaming stdout lines
+            stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
             ProviderResult with exit code and output
@@ -56,6 +58,7 @@ def _run_subprocess(
     args: list[str],
     timeout: int | None = None,
     output_callback: Callable[[str], None] | None = None,
+    stderr_callback: Callable[[str], None] | None = None,
     stdin_data: str | None = None,
     shell: bool = False,
 ) -> ProviderResult:
@@ -66,6 +69,7 @@ def _run_subprocess(
             (passed to sh -c, or piped via stdin for large commands).
         timeout: Timeout in seconds.
         output_callback: Optional callback for streaming stdout lines.
+        stderr_callback: Optional callback for streaming stderr lines.
         stdin_data: Optional data to pass via stdin.
         shell: If True, execute as shell command (via sh -c, or stdin fallback
             if command exceeds ARG_MAX_STDIN_THRESHOLD).
@@ -122,11 +126,18 @@ def _run_subprocess(
             except BrokenPipeError:
                 pass
 
-        stderr_output: list[str] = []
+        stderr_lines: list[str] = []
 
         def _read_stderr() -> None:
             if process.stderr:
-                stderr_output.append(process.stderr.read())
+                try:
+                    for raw_line in process.stderr:
+                        line = raw_line.rstrip("\n")
+                        stderr_lines.append(line)
+                        if stderr_callback:
+                            stderr_callback(line)
+                except BrokenPipeError:
+                    pass
 
         stderr_thread = threading.Thread(target=_read_stderr, daemon=True)
         stderr_thread.start()
@@ -155,7 +166,7 @@ def _run_subprocess(
             )
 
         stdout = "\n".join(stdout_lines)
-        stderr = stderr_output[0] if stderr_output else ""
+        stderr = "\n".join(stderr_lines)
 
         return ProviderResult(
             exit_code=process.returncode,

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -2,7 +2,7 @@ from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from fdsx.providers.base import ProviderBase, ProviderResult, _run_subprocess
+from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
 
 
 class ClaudeOptions(BaseModel):
@@ -57,7 +57,13 @@ class ClaudeProvider(ProviderBase):
         Returns:
             ProviderResult with exit code and output
         """
-        args = ["claude", "-p", prompt]
+        use_stdin = len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
+        if use_stdin:
+            args = ["claude", "-p", "-"]
+            stdin_data: str | None = prompt
+        else:
+            args = ["claude", "-p", prompt]
+            stdin_data = None
         if model:
             args.extend(["--model", model])
         args.extend(self.options.to_cli_flags())
@@ -67,4 +73,5 @@ class ClaudeProvider(ProviderBase):
             timeout=timeout,
             output_callback=output_callback,
             stderr_callback=stderr_callback,
+            stdin_data=stdin_data,
         )

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -18,6 +18,7 @@ _STREAM_FORMAT_FLAGS = ["--output-format", "stream-json", "--verbose", "--includ
 # NDJSON event type strings
 _EVENT_CONTENT_BLOCK_START = "content_block_start"
 _EVENT_CONTENT_BLOCK_DELTA = "content_block_delta"
+_EVENT_CONTENT_BLOCK_STOP = "content_block_stop"
 _EVENT_RESULT = "result"
 
 # Delta type strings within content_block_delta events
@@ -60,14 +61,15 @@ class ClaudeProvider(ProviderBase):
 
     def _make_stream_callback(
         self, output_callback: Callable[[str], None]
-    ) -> tuple[Callable[[str], None], Callable[[], str | None]]:
+    ) -> tuple[Callable[[str], None], Callable[[], str | None], Callable[[], None]]:
         """Create a streaming callback that parses stream-json NDJSON lines.
 
         Wraps ``output_callback`` so that human-readable text extracted from
         Claude's ``stream-json`` NDJSON events is forwarded to the caller while
-        the raw JSON lines are silently consumed.
+        the raw JSON lines are silently consumed.  Fragments are buffered and
+        emitted as complete lines (on newline boundaries or content block end).
 
-        Returns a ``(stream_callback, get_result)`` tuple:
+        Returns a ``(stream_callback, get_result, flush)`` tuple:
         - ``stream_callback``: parses each JSON line and dispatches text to
           ``output_callback``. Malformed JSON lines are skipped with a warning
           logged via ``logger.warning``.
@@ -75,10 +77,58 @@ class ClaudeProvider(ProviderBase):
           complete. Uses the ``result`` event's ``result`` field when available,
           falling back to concatenated ``text_delta`` content on crash/missing
           result.
+        - ``flush``: emits any remaining buffered text. Call after streaming ends.
         """
         text_parts: list[str] = []
         # Single-element list so the inner closure can rebind the value.
         final_result: list[str | None] = [None]
+
+        # Line buffer: accumulates text/thinking fragments, emits on '\n' or flush.
+        _buffer: list[str] = []
+        # Tracks current buffer content type: "text", "thinking", or None.
+        _buffer_type: list[str | None] = [None]
+
+        def _flush_buffer() -> None:
+            """Emit buffered content as complete lines via output_callback."""
+            if not _buffer:
+                return
+            joined = "".join(_buffer)
+            _buffer.clear()
+            buf_type = _buffer_type[0]
+            _buffer_type[0] = None
+            if not joined:
+                return
+            # Split on newlines; emit each complete line.
+            lines = joined.split("\n")
+            for line in lines:
+                if not line:
+                    continue
+                if buf_type == "thinking":
+                    output_callback(f"[thinking] {line}")
+                else:
+                    output_callback(line)
+
+        def _append_and_emit(fragment: str, buf_type: str) -> None:
+            """Append a fragment to the buffer, flushing type transitions and newlines."""
+            # Type transition → flush previous buffer first.
+            if _buffer_type[0] is not None and _buffer_type[0] != buf_type:
+                _flush_buffer()
+            _buffer_type[0] = buf_type
+            _buffer.append(fragment)
+            # If the fragment contains newlines, flush complete lines now.
+            if "\n" in fragment:
+                joined = "".join(_buffer)
+                parts = joined.split("\n")
+                # Last element is the incomplete trailing portion — keep in buffer.
+                _buffer.clear()
+                _buffer.append(parts[-1])
+                for line in parts[:-1]:
+                    if not line:
+                        continue
+                    if buf_type == "thinking":
+                        output_callback(f"[thinking] {line}")
+                    else:
+                        output_callback(line)
 
         def stream_callback(line: str) -> None:
             if not line.strip():
@@ -89,11 +139,16 @@ class ClaudeProvider(ProviderBase):
                 logger.warning("Malformed JSON line skipped: %s", line)
                 return
 
+            # Unwrap stream_event envelope from Claude CLI stream-json format
+            if event.get("type") == "stream_event":
+                event = event.get("event", {})
+
             event_type = event.get("type")
 
             if event_type == _EVENT_CONTENT_BLOCK_START:
                 content_block = event.get("content_block", {})
                 if content_block.get("type") == _CONTENT_TYPE_TOOL_USE:
+                    _flush_buffer()
                     tool_name = content_block.get("name", "unknown")
                     output_callback(f"[tool: {tool_name}]")
 
@@ -104,14 +159,22 @@ class ClaudeProvider(ProviderBase):
                     text = delta.get("text", "")
                     if text:
                         text_parts.append(text)
-                        output_callback(text)
+                        _append_and_emit(text, "text")
                 elif delta_type == _DELTA_TYPE_THINKING:
                     thinking = delta.get("thinking", "")
                     if thinking:
-                        output_callback(f"[thinking] {thinking}")
+                        _append_and_emit(thinking, "thinking")
+
+            elif event_type == _EVENT_CONTENT_BLOCK_STOP:
+                _flush_buffer()
 
             elif event_type == _EVENT_RESULT:
+                _flush_buffer()
                 final_result[0] = event.get("result", "")
+
+        def flush() -> None:
+            """Flush any remaining buffered text after streaming ends."""
+            _flush_buffer()
 
         def get_result() -> str | None:
             result_text = final_result[0]
@@ -122,7 +185,7 @@ class ClaudeProvider(ProviderBase):
                 return "".join(text_parts)
             return None
 
-        return stream_callback, get_result
+        return stream_callback, get_result, flush
 
     def execute(
         self,
@@ -163,7 +226,7 @@ class ClaudeProvider(ProviderBase):
 
         if output_callback is not None:
             args.extend(_STREAM_FORMAT_FLAGS)
-            stream_callback, get_result = self._make_stream_callback(output_callback)
+            stream_callback, get_result, flush = self._make_stream_callback(output_callback)
             result = _run_subprocess(
                 args=args,
                 timeout=timeout,
@@ -171,6 +234,7 @@ class ClaudeProvider(ProviderBase):
                 stderr_callback=stderr_callback,
                 stdin_data=stdin_data,
             )
+            flush()
             parsed_stdout = get_result()
             if parsed_stdout is not None:
                 return ProviderResult(

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -32,6 +32,9 @@ class ClaudeOptions(BaseModel):
 class ClaudeProvider(ProviderBase):
     """Claude provider - executes Claude CLI."""
 
+    def __init__(self, options: ClaudeOptions | None = None) -> None:
+        self.options: ClaudeOptions = options if options is not None else ClaudeOptions()
+
     def execute(
         self,
         prompt: str,
@@ -55,6 +58,7 @@ class ClaudeProvider(ProviderBase):
         args = ["claude", "-p", prompt]
         if model:
             args.extend(["--model", model])
+        args.extend(self.options.to_cli_flags())
 
         return _run_subprocess(
             args=args,

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -1,6 +1,32 @@
-from typing import Callable
+from typing import Callable, Literal
+
+from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import ProviderBase, ProviderResult, _run_subprocess
+
+
+class ClaudeOptions(BaseModel):
+    """Options for the Claude CLI provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    permission_mode: Literal["default", "acceptEdits", "bypassPermissions", "dontAsk", "plan", "auto"] | None = None
+    dangerously_skip_permissions: bool = False
+    allowed_tools: list[str] = []
+    disallowed_tools: list[str] = []
+
+    def to_cli_flags(self) -> list[str]:
+        """Translate options to Claude CLI flags."""
+        flags: list[str] = []
+        if self.permission_mode is not None:
+            flags.extend(["--permission-mode", self.permission_mode])
+        if self.dangerously_skip_permissions:
+            flags.append("--dangerously-skip-permissions")
+        for tool in self.allowed_tools:
+            flags.extend(["--allowedTools", tool])
+        for tool in self.disallowed_tools:
+            flags.extend(["--disallowedTools", tool])
+        return flags
 
 
 class ClaudeProvider(ProviderBase):

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -42,6 +42,7 @@ class ClaudeProvider(ProviderBase):
         timeout: int | None = None,
         command: str | None = None,
         output_callback: Callable[[str], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> ProviderResult:
         """Execute Claude CLI with a prompt.
 
@@ -50,7 +51,8 @@ class ClaudeProvider(ProviderBase):
             model: Model name (e.g., opus, sonnet)
             timeout: Timeout in seconds
             command: Ignored for claude provider
-            output_callback: Optional callback for streaming output
+            output_callback: Optional callback for streaming stdout lines
+            stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
             ProviderResult with exit code and output
@@ -64,4 +66,5 @@ class ClaudeProvider(ProviderBase):
             args=args,
             timeout=timeout,
             output_callback=output_callback,
+            stderr_callback=stderr_callback,
         )

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -1,8 +1,31 @@
+import json
+import logging
 from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Stream-JSON format constants
+# ---------------------------------------------------------------------------
+
+# CLI flags added to enable stream-json output when output_callback is provided
+_STREAM_FORMAT_FLAGS = ["--output-format", "stream-json", "--verbose", "--include-partial-messages"]
+
+# NDJSON event type strings
+_EVENT_CONTENT_BLOCK_START = "content_block_start"
+_EVENT_CONTENT_BLOCK_DELTA = "content_block_delta"
+_EVENT_RESULT = "result"
+
+# Delta type strings within content_block_delta events
+_DELTA_TYPE_TEXT = "text_delta"
+_DELTA_TYPE_THINKING = "thinking_delta"
+
+# Content block type for tool use
+_CONTENT_TYPE_TOOL_USE = "tool_use"
 
 
 class ClaudeOptions(BaseModel):
@@ -35,6 +58,72 @@ class ClaudeProvider(ProviderBase):
     def __init__(self, options: ClaudeOptions | None = None) -> None:
         self.options: ClaudeOptions = options if options is not None else ClaudeOptions()
 
+    def _make_stream_callback(
+        self, output_callback: Callable[[str], None]
+    ) -> tuple[Callable[[str], None], Callable[[], str | None]]:
+        """Create a streaming callback that parses stream-json NDJSON lines.
+
+        Wraps ``output_callback`` so that human-readable text extracted from
+        Claude's ``stream-json`` NDJSON events is forwarded to the caller while
+        the raw JSON lines are silently consumed.
+
+        Returns a ``(stream_callback, get_result)`` tuple:
+        - ``stream_callback``: parses each JSON line and dispatches text to
+          ``output_callback``. Malformed JSON lines are skipped with a warning
+          logged via ``logger.warning``.
+        - ``get_result``: returns the final stdout string after streaming is
+          complete. Uses the ``result`` event's ``result`` field when available,
+          falling back to concatenated ``text_delta`` content on crash/missing
+          result.
+        """
+        text_parts: list[str] = []
+        # Single-element list so the inner closure can rebind the value.
+        final_result: list[str | None] = [None]
+
+        def stream_callback(line: str) -> None:
+            if not line.strip():
+                return
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Malformed JSON line skipped: %s", line)
+                return
+
+            event_type = event.get("type")
+
+            if event_type == _EVENT_CONTENT_BLOCK_START:
+                content_block = event.get("content_block", {})
+                if content_block.get("type") == _CONTENT_TYPE_TOOL_USE:
+                    tool_name = content_block.get("name", "unknown")
+                    output_callback(f"[tool: {tool_name}]")
+
+            elif event_type == _EVENT_CONTENT_BLOCK_DELTA:
+                delta = event.get("delta", {})
+                delta_type = delta.get("type")
+                if delta_type == _DELTA_TYPE_TEXT:
+                    text = delta.get("text", "")
+                    if text:
+                        text_parts.append(text)
+                        output_callback(text)
+                elif delta_type == _DELTA_TYPE_THINKING:
+                    thinking = delta.get("thinking", "")
+                    if thinking:
+                        output_callback(f"[thinking] {thinking}")
+
+            elif event_type == _EVENT_RESULT:
+                final_result[0] = event.get("result", "")
+
+        def get_result() -> str | None:
+            result_text = final_result[0]
+            if result_text is not None:
+                return result_text
+            # Fallback: reconstruct from accumulated text_delta content
+            if text_parts:
+                return "".join(text_parts)
+            return None
+
+        return stream_callback, get_result
+
     def execute(
         self,
         prompt: str,
@@ -51,7 +140,11 @@ class ClaudeProvider(ProviderBase):
             model: Model name (e.g., opus, sonnet)
             timeout: Timeout in seconds
             command: Ignored for claude provider
-            output_callback: Optional callback for streaming stdout lines
+            output_callback: Optional callback for streaming stdout lines.
+                When provided, ``--output-format stream-json --verbose
+                --include-partial-messages`` is appended to the CLI invocation
+                and ``ProviderResult.stdout`` is populated from the ``result``
+                event (falling back to concatenated ``text_delta`` content).
             stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
@@ -67,6 +160,25 @@ class ClaudeProvider(ProviderBase):
         if model:
             args.extend(["--model", model])
         args.extend(self.options.to_cli_flags())
+
+        if output_callback is not None:
+            args.extend(_STREAM_FORMAT_FLAGS)
+            stream_callback, get_result = self._make_stream_callback(output_callback)
+            result = _run_subprocess(
+                args=args,
+                timeout=timeout,
+                output_callback=stream_callback,
+                stderr_callback=stderr_callback,
+                stdin_data=stdin_data,
+            )
+            parsed_stdout = get_result()
+            if parsed_stdout is not None:
+                return ProviderResult(
+                    exit_code=result.exit_code,
+                    stdout=parsed_stdout,
+                    stderr=result.stderr,
+                )
+            return result
 
         return _run_subprocess(
             args=args,

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -2,7 +2,7 @@ from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from fdsx.providers.base import ProviderBase, ProviderResult, _run_subprocess
+from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
 
 
 class CodexOptions(BaseModel):
@@ -57,15 +57,21 @@ class CodexProvider(ProviderBase):
         Returns:
             ProviderResult with exit code and output
         """
+        use_stdin = len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
         args = ["codex", "exec"]
         if model:
             args.extend(["--model", model])
         args.extend(self.options.to_cli_flags())
-        args.append(prompt)
+        if use_stdin:
+            stdin_data: str | None = prompt
+        else:
+            args.append(prompt)
+            stdin_data = None
 
         return _run_subprocess(
             args=args,
             timeout=timeout,
             output_callback=output_callback,
             stderr_callback=stderr_callback,
+            stdin_data=stdin_data,
         )

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -42,6 +42,7 @@ class CodexProvider(ProviderBase):
         timeout: int | None = None,
         command: str | None = None,
         output_callback: Callable[[str], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> ProviderResult:
         """Execute Codex CLI with a prompt.
 
@@ -50,7 +51,8 @@ class CodexProvider(ProviderBase):
             model: Model name
             timeout: Timeout in seconds
             command: Ignored for codex provider
-            output_callback: Optional callback for streaming output
+            output_callback: Optional callback for streaming stdout lines
+            stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
             ProviderResult with exit code and output
@@ -65,4 +67,5 @@ class CodexProvider(ProviderBase):
             args=args,
             timeout=timeout,
             output_callback=output_callback,
+            stderr_callback=stderr_callback,
         )

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -1,8 +1,32 @@
+import json
+import logging
 from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# JSONL streaming format constants
+# ---------------------------------------------------------------------------
+
+# CLI flags added to enable JSONL output when output_callback is provided
+_STREAM_FORMAT_FLAGS = ["--json"]
+
+# Top-level JSONL event type strings
+_EVENT_ITEM_STARTED = "item.started"
+_EVENT_ITEM_COMPLETED = "item.completed"
+_EVENT_TURN_FAILED = "turn.failed"
+_EVENT_ERROR = "error"
+
+# Item type strings within item.started / item.completed events
+_ITEM_TYPE_AGENT_MESSAGE = "agent_message"
+_ITEM_TYPE_REASONING = "reasoning"
+_ITEM_TYPE_COMMAND_EXECUTION = "command_execution"
+_ITEM_TYPE_FILE_CHANGE = "file_change"
+_ITEM_TYPE_MCP_TOOL_CALL = "mcp_tool_call"
 
 
 class CodexOptions(BaseModel):
@@ -35,6 +59,83 @@ class CodexProvider(ProviderBase):
     def __init__(self, options: CodexOptions | None = None) -> None:
         self.options: CodexOptions = options if options is not None else CodexOptions()
 
+    def _make_stream_callback(
+        self, output_callback: Callable[[str], None]
+    ) -> tuple[Callable[[str], None], Callable[[], str | None]]:
+        """Create a streaming callback that parses Codex ``--json`` JSONL lines.
+
+        Wraps ``output_callback`` so that human-readable content extracted from
+        Codex's JSONL events is forwarded to the caller while the raw JSON lines
+        are silently consumed.
+
+        Returns a ``(stream_callback, get_result)`` tuple:
+        - ``stream_callback``: parses each JSON line and dispatches content to
+          ``output_callback``. Malformed JSON lines are skipped with a warning
+          logged via ``logger.warning``.
+        - ``get_result``: returns the final stdout string after streaming is
+          complete. Concatenates all ``agent_message`` item texts. Returns
+          ``None`` if no ``agent_message`` events were received (including
+          partial collection on unexpected provider exit).
+
+        Event routing:
+        - ``item.started`` + ``command_execution`` → ``[tool: {command}]``
+        - ``item.started`` + ``file_change`` → ``[tool: file_change]``
+        - ``item.started`` + ``mcp_tool_call`` → ``[tool: {name}]``
+        - ``item.completed`` + ``agent_message`` → ``item.text`` (accumulated)
+        - ``item.completed`` + ``reasoning`` → ``[thinking] {text}``
+        - ``turn.failed`` → ``logger.warning``, no callback dispatch
+        """
+        agent_message_parts: list[str] = []
+
+        def stream_callback(line: str) -> None:
+            if not line.strip():
+                return
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("Malformed JSON line skipped: %s", line)
+                return
+
+            event_type = event.get("type")
+
+            if event_type == _EVENT_ITEM_STARTED:
+                item = event.get("item", {})
+                item_type = item.get("type")
+                if item_type == _ITEM_TYPE_COMMAND_EXECUTION:
+                    command = item.get("command", "unknown")
+                    output_callback(f"[tool: {command}]")
+                elif item_type == _ITEM_TYPE_FILE_CHANGE:
+                    output_callback("[tool: file_change]")
+                elif item_type == _ITEM_TYPE_MCP_TOOL_CALL:
+                    name = item.get("name", "unknown")
+                    output_callback(f"[tool: {name}]")
+
+            elif event_type == _EVENT_ITEM_COMPLETED:
+                item = event.get("item", {})
+                item_type = item.get("type")
+                if item_type == _ITEM_TYPE_AGENT_MESSAGE:
+                    text = item.get("text", "")
+                    if text:
+                        agent_message_parts.append(text)
+                        output_callback(text)
+                elif item_type == _ITEM_TYPE_REASONING:
+                    text = item.get("text", "")
+                    if text:
+                        output_callback(f"[thinking] {text}")
+
+            elif event_type == _EVENT_TURN_FAILED:
+                logger.warning("turn.failed event received: %s", event.get("error", ""))
+
+            elif event_type == _EVENT_ERROR:
+                logger.warning("Codex error event: %s", event.get("message", str(event)))
+
+        def get_result() -> str | None:
+            if agent_message_parts:
+                return "\n".join(agent_message_parts)
+            return None
+
+        return stream_callback, get_result
+
     def execute(
         self,
         prompt: str,
@@ -51,7 +152,11 @@ class CodexProvider(ProviderBase):
             model: Model name
             timeout: Timeout in seconds
             command: Ignored for codex provider
-            output_callback: Optional callback for streaming stdout lines
+            output_callback: Optional callback for streaming stdout lines.
+                When provided, ``--json`` is appended to the CLI invocation
+                and ``ProviderResult.stdout`` is populated from concatenated
+                ``agent_message`` item texts (falling back to partial content
+                on unexpected provider exit).
             stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
@@ -67,6 +172,25 @@ class CodexProvider(ProviderBase):
         else:
             args.append(prompt)
             stdin_data = None
+
+        if output_callback is not None:
+            args.extend(_STREAM_FORMAT_FLAGS)
+            stream_callback, get_result = self._make_stream_callback(output_callback)
+            result = _run_subprocess(
+                args=args,
+                timeout=timeout,
+                output_callback=stream_callback,
+                stderr_callback=stderr_callback,
+                stdin_data=stdin_data,
+            )
+            parsed_stdout = get_result()
+            if parsed_stdout is not None:
+                return ProviderResult(
+                    exit_code=result.exit_code,
+                    stdout=parsed_stdout,
+                    stderr=result.stderr,
+                )
+            return result
 
         return _run_subprocess(
             args=args,

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -1,6 +1,32 @@
-from typing import Callable
+from typing import Callable, Literal
+
+from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import ProviderBase, ProviderResult, _run_subprocess
+
+
+class CodexOptions(BaseModel):
+    """Options for the Codex CLI provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sandbox: Literal["read-only", "workspace-write", "danger-full-access"] | None = None
+    approval_policy: Literal["untrusted", "on-request", "never"] | None = None
+    full_auto: bool = False
+    dangerously_bypass_approvals_and_sandbox: bool = False
+
+    def to_cli_flags(self) -> list[str]:
+        """Translate options to Codex CLI flags."""
+        flags: list[str] = []
+        if self.sandbox is not None:
+            flags.extend(["--sandbox", self.sandbox])
+        if self.approval_policy is not None:
+            flags.extend(["--approval-policy", self.approval_policy])
+        if self.full_auto:
+            flags.append("--full-auto")
+        if self.dangerously_bypass_approvals_and_sandbox:
+            flags.append("--dangerously-bypass-approvals-and-sandbox")
+        return flags
 
 
 class CodexProvider(ProviderBase):

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -32,6 +32,9 @@ class CodexOptions(BaseModel):
 class CodexProvider(ProviderBase):
     """Codex provider - executes Codex CLI."""
 
+    def __init__(self, options: CodexOptions | None = None) -> None:
+        self.options: CodexOptions = options if options is not None else CodexOptions()
+
     def execute(
         self,
         prompt: str,
@@ -55,6 +58,7 @@ class CodexProvider(ProviderBase):
         args = ["codex", "exec"]
         if model:
             args.extend(["--model", model])
+        args.extend(self.options.to_cli_flags())
         args.append(prompt)
 
         return _run_subprocess(

--- a/src/fdsx/providers/opencode.py
+++ b/src/fdsx/providers/opencode.py
@@ -18,6 +18,9 @@ class OpenCodeOptions(BaseModel):
 class OpenCodeProvider(ProviderBase):
     """OpenCode provider - executes OpenCode CLI."""
 
+    def __init__(self, options: OpenCodeOptions | None = None) -> None:
+        self.options: OpenCodeOptions = options if options is not None else OpenCodeOptions()
+
     def execute(
         self,
         prompt: str,
@@ -41,6 +44,7 @@ class OpenCodeProvider(ProviderBase):
         args = ["opencode", "run"]
         if model:
             args.extend(["-m", model])
+        args.extend(self.options.to_cli_flags())
         args.append(prompt)
 
         return _run_subprocess(

--- a/src/fdsx/providers/opencode.py
+++ b/src/fdsx/providers/opencode.py
@@ -2,7 +2,7 @@ from typing import Callable
 
 from pydantic import BaseModel, ConfigDict
 
-from fdsx.providers.base import ProviderBase, ProviderResult, _run_subprocess
+from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
 
 
 class OpenCodeOptions(BaseModel):
@@ -43,15 +43,21 @@ class OpenCodeProvider(ProviderBase):
         Returns:
             ProviderResult with exit code and output
         """
+        use_stdin = len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
         args = ["opencode", "run"]
         if model:
             args.extend(["-m", model])
         args.extend(self.options.to_cli_flags())
-        args.append(prompt)
+        if use_stdin:
+            stdin_data: str | None = prompt
+        else:
+            args.append(prompt)
+            stdin_data = None
 
         return _run_subprocess(
             args=args,
             timeout=timeout,
             output_callback=output_callback,
             stderr_callback=stderr_callback,
+            stdin_data=stdin_data,
         )

--- a/src/fdsx/providers/opencode.py
+++ b/src/fdsx/providers/opencode.py
@@ -1,6 +1,18 @@
 from typing import Callable
 
+from pydantic import BaseModel, ConfigDict
+
 from fdsx.providers.base import ProviderBase, ProviderResult, _run_subprocess
+
+
+class OpenCodeOptions(BaseModel):
+    """Options for the OpenCode CLI provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    def to_cli_flags(self) -> list[str]:
+        """Translate options to OpenCode CLI flags (none currently defined)."""
+        return []
 
 
 class OpenCodeProvider(ProviderBase):

--- a/src/fdsx/providers/opencode.py
+++ b/src/fdsx/providers/opencode.py
@@ -28,6 +28,7 @@ class OpenCodeProvider(ProviderBase):
         timeout: int | None = None,
         command: str | None = None,
         output_callback: Callable[[str], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> ProviderResult:
         """Execute OpenCode CLI with a prompt.
 
@@ -36,7 +37,8 @@ class OpenCodeProvider(ProviderBase):
             model: Model name
             timeout: Timeout in seconds
             command: Ignored for opencode provider
-            output_callback: Optional callback for streaming output
+            output_callback: Optional callback for streaming stdout lines
+            stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
             ProviderResult with exit code and output
@@ -51,4 +53,5 @@ class OpenCodeProvider(ProviderBase):
             args=args,
             timeout=timeout,
             output_callback=output_callback,
+            stderr_callback=stderr_callback,
         )

--- a/src/fdsx/providers/system.py
+++ b/src/fdsx/providers/system.py
@@ -13,6 +13,7 @@ class SystemProvider(ProviderBase):
         timeout: int | None = None,
         command: str | None = None,
         output_callback: Callable[[str], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
     ) -> ProviderResult:
         """Execute a shell command.
 
@@ -21,7 +22,8 @@ class SystemProvider(ProviderBase):
             model: Ignored for system provider
             timeout: Timeout in seconds
             command: Shell command to execute
-            output_callback: Optional callback for streaming output
+            output_callback: Optional callback for streaming stdout lines
+            stderr_callback: Optional callback for streaming stderr lines
 
         Returns:
             ProviderResult with exit code and output
@@ -39,5 +41,6 @@ class SystemProvider(ProviderBase):
             args=[cmd],
             timeout=timeout,
             output_callback=output_callback,
+            stderr_callback=stderr_callback,
             shell=True,
         )

--- a/tests/fixtures/batch_flow.yaml
+++ b/tests/fixtures/batch_flow.yaml
@@ -1,10 +1,7 @@
 name: Batch Task Execution Flow
+description: Batch task execution flow for testing
 start_at: plan
 version: '1.0'
-
-task_splitter:
-  provider: claude
-  model: claude-3-5-sonnet-20241022
 
 states:
   plan:

--- a/tests/fixtures/choice_flow.yaml
+++ b/tests/fixtures/choice_flow.yaml
@@ -1,4 +1,5 @@
 name: Choice Flow
+description: Choice flow for testing branching logic
 start_at: check_status
 version: '1.0'
 

--- a/tests/fixtures/choice_flow_default.yaml
+++ b/tests/fixtures/choice_flow_default.yaml
@@ -1,4 +1,5 @@
 name: Choice Flow - Default Branch Test
+description: Choice flow testing default branch behavior
 start_at: check_status
 version: '1.0'
 

--- a/tests/fixtures/claude_stream.ndjson
+++ b/tests/fixtures/claude_stream.ndjson
@@ -1,0 +1,10 @@
+{"type":"system","subtype":"init","cwd":"/tmp","session_id":"abc123","tools":[],"mcp_servers":[]}
+{"type":"assistant","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-opus-4-5","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}},"session_id":"abc123"}
+{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""},"session_id":"abc123"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"},"session_id":"abc123"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"! Here are 3 items:\n\n"},"session_id":"abc123"}
+{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1. Apple\n2. Banana\n3. Cherry"},"session_id":"abc123"}
+{"type":"content_block_stop","index":0,"session_id":"abc123"}
+{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":30},"session_id":"abc123"}
+{"type":"message_stop","session_id":"abc123"}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":1500,"duration_api_ms":1200,"num_turns":1,"result":"Hello! Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry","session_id":"abc123","total_cost_usd":0.002}

--- a/tests/fixtures/codex_stream.jsonl
+++ b/tests/fixtures/codex_stream.jsonl
@@ -1,0 +1,12 @@
+{"type":"item.started","item":{"id":"item_001","type":"reasoning","text":""}}
+{"type":"item.completed","item":{"id":"item_001","type":"reasoning","text":"I need to say hello in a friendly way."}}
+{"type":"item.started","item":{"id":"item_002","type":"command_execution","command":"echo hello","output":""}}
+{"type":"item.completed","item":{"id":"item_002","type":"command_execution","command":"echo hello","output":"hello"}}
+{"type":"item.started","item":{"id":"item_003","type":"file_change","path":"output.txt"}}
+{"type":"item.completed","item":{"id":"item_003","type":"file_change","path":"output.txt"}}
+{"type":"item.started","item":{"id":"item_004","type":"mcp_tool_call","name":"web_search","arguments":{}}}
+{"type":"item.completed","item":{"id":"item_004","type":"mcp_tool_call","name":"web_search","result":""}}
+{"type":"item.started","item":{"id":"item_005","type":"agent_message","text":""}}
+{"type":"item.completed","item":{"id":"item_005","type":"agent_message","text":"Hello! "}}
+{"type":"item.started","item":{"id":"item_006","type":"agent_message","text":""}}
+{"type":"item.completed","item":{"id":"item_006","type":"agent_message","text":"Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"}}

--- a/tests/fixtures/extraction_flow.yaml
+++ b/tests/fixtures/extraction_flow.yaml
@@ -1,4 +1,5 @@
 name: Extraction Flow
+description: Extraction test flow for testing output extraction
 start_at: echo_state
 version: '1.0'
 

--- a/tests/fixtures/input_flow.yaml
+++ b/tests/fixtures/input_flow.yaml
@@ -1,4 +1,5 @@
 name: Input Test Flow
+description: Input test flow for testing variable substitution
 start_at: greet
 version: '1.0'
 

--- a/tests/fixtures/invalid_flows/bad_next_ref.yaml
+++ b/tests/fixtures/invalid_flows/bad_next_ref.yaml
@@ -1,4 +1,5 @@
 name: Invalid Flow - Bad Next Reference
+description: Invalid flow for testing next reference validation
 start_at: start
 version: '1.0'
 

--- a/tests/fixtures/invalid_flows/missing_start_at.yaml
+++ b/tests/fixtures/invalid_flows/missing_start_at.yaml
@@ -1,4 +1,5 @@
 name: Invalid Flow - Missing Start At
+description: Invalid flow for testing start_at validation
 start_at: nonexistent_state
 version: '1.0'
 

--- a/tests/fixtures/invalid_flows/mutual_exclusive.yaml
+++ b/tests/fixtures/invalid_flows/mutual_exclusive.yaml
@@ -1,4 +1,5 @@
 name: Invalid Flow - Mutual Exclusive Fields
+description: Invalid flow for testing mutual exclusivity validation
 start_at: start
 version: '1.0'
 

--- a/tests/fixtures/json_codeblock_extraction_flow.yaml
+++ b/tests/fixtures/json_codeblock_extraction_flow.yaml
@@ -1,4 +1,5 @@
 name: JSON Code Block Extraction Flow
+description: JSON extraction from code block test flow
 start_at: echo_state
 version: '1.0'
 

--- a/tests/fixtures/json_extraction_flow.yaml
+++ b/tests/fixtures/json_extraction_flow.yaml
@@ -1,4 +1,5 @@
 name: JSON Extraction Flow
+description: JSON extraction test flow
 start_at: echo_state
 version: '1.0'
 

--- a/tests/fixtures/loop_flow.yaml
+++ b/tests/fixtures/loop_flow.yaml
@@ -1,4 +1,5 @@
 name: Loop Test Flow
+description: Loop test flow for testing max_loop behavior
 start_at: plan
 max_loop: 3
 

--- a/tests/fixtures/parallel_min_success.yaml
+++ b/tests/fixtures/parallel_min_success.yaml
@@ -1,4 +1,5 @@
 name: Parallel Min Success Flow
+description: Parallel flow testing min_success parameter
 start_at: parallel_with_failure
 version: '1.0'
 

--- a/tests/fixtures/parallel_review.yaml
+++ b/tests/fixtures/parallel_review.yaml
@@ -1,4 +1,5 @@
 name: Parallel Review Flow
+description: Parallel review flow for testing parallel state execution
 start_at: review_parallel
 version: '1.0'
 

--- a/tests/fixtures/prompt_file_test/flow.yaml
+++ b/tests/fixtures/prompt_file_test/flow.yaml
@@ -1,4 +1,5 @@
 name: Prompt File Test Flow
+description: Test flow for prompt file resolution
 start_at: task1
 version: '1.0'
 

--- a/tests/fixtures/regex_extraction_flow.yaml
+++ b/tests/fixtures/regex_extraction_flow.yaml
@@ -1,4 +1,5 @@
 name: Regex Extraction Flow
+description: Regex extraction test flow
 start_at: echo_state
 version: '1.0'
 

--- a/tests/fixtures/simple_flow.yaml
+++ b/tests/fixtures/simple_flow.yaml
@@ -1,4 +1,5 @@
 name: Simple Plan-Implement-Review Flow
+description: A simple 3-step workflow for testing
 start_at: plan
 version: '1.0'
 

--- a/tests/fixtures/wait_approval.yaml
+++ b/tests/fixtures/wait_approval.yaml
@@ -1,4 +1,5 @@
 name: Wait Approval Flow
+description: Wait state flow for testing human approval
 start_at: plan
 version: '1.0'
 

--- a/tests/fixtures/wait_webhook.yaml
+++ b/tests/fixtures/wait_webhook.yaml
@@ -1,4 +1,5 @@
 name: Wait Webhook Flow
+description: Wait state with webhook for testing notifications
 start_at: plan
 version: '1.0'
 

--- a/tests/integration/test_auto_select.py
+++ b/tests/integration/test_auto_select.py
@@ -1,0 +1,223 @@
+"""Integration tests for workflow auto-selection end-to-end."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from fdsx.core.selector import (
+    discover_workflows,
+    resolve_workflow_for_task,
+    select_workflow,
+)
+from fdsx.core.config import WorkflowSelectorConfig
+
+
+class TestDiscoverWorkflowsIntegration:
+    def test_end_to_end_with_real_workflows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+
+            (workflows_dir / "plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Plan",
+                        "description": "Planning workflow for creating project plans",
+                        "start_at": "plan",
+                        "states": {
+                            "plan": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo plan",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            (workflows_dir / "implement.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Implement",
+                        "description": "Implementation workflow for coding features",
+                        "start_at": "implement",
+                        "states": {
+                            "implement": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo implement",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+
+            results = discover_workflows(workflows_dir)
+
+            assert len(results) == 2
+            assert all(isinstance(p, Path) for p, _ in results)
+            assert all(isinstance(d, str) for _, d in results)
+
+
+class TestSelectWorkflowIntegration:
+    def test_single_workflow_auto_selects(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "only.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Only",
+                        "description": "The only workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo only",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+
+            workflows = discover_workflows(workflows_dir)
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            selected = select_workflow("Build a feature", workflows, config)
+
+            assert selected.name == "only.yaml"
+
+    def test_multiple_workflows_llm_selection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Plan",
+                        "description": "Planning workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo plan",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            (workflows_dir / "implement.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Implement",
+                        "description": "Implementation workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo implement",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+
+            mock_provider = MagicMock()
+            mock_provider.execute.return_value = MagicMock(
+                exit_code=0,
+                stdout="implement.yaml",
+                stderr="",
+            )
+
+            workflows = discover_workflows(workflows_dir)
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+                selected = select_workflow(
+                    "Implement a new API endpoint for user authentication",
+                    workflows,
+                    config,
+                )
+
+            assert selected.name == "implement.yaml"
+
+    def test_empty_workflows_dir_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            workflows = discover_workflows(workflows_dir)
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            with pytest.raises(ValueError, match="No workflows found"):
+                select_workflow("Do something", workflows, config)
+
+
+class TestResolveWorkflowForTaskIntegration:
+    def test_auto_workflow_returns_workflow(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "only.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Only",
+                        "description": "Only workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo only",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            result = resolve_workflow_for_task(
+                task_description="Build a feature",
+                workflows_dir=workflows_dir,
+                selector_config=config,
+                auto_workflow=True,
+            )
+
+            assert result is not None
+            assert result.name == "only.yaml"
+
+    def test_empty_workflows_dir_raises_on_resolve(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            with pytest.raises(ValueError, match="No workflows found"):
+                resolve_workflow_for_task(
+                    task_description="Build a feature",
+                    workflows_dir=workflows_dir,
+                    selector_config=config,
+                    auto_workflow=True,
+                )

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from fdsx.core import engine
-from fdsx.models.flow import Flow, TaskState
+from fdsx.core.config import FdsxConfig, TaskSplitterConfig
 
 
 class TestBatchExecution:
@@ -23,11 +23,12 @@ class TestBatchExecution:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.display_task_list", return_value=True):
-                with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        base_dir = Path(tmpdir)
-                        results = engine.run_batch(flow_path, tasks_file, base_dir)
+            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+                with patch("fdsx.core.engine.display_task_list", return_value=True):
+                    with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            base_dir = Path(tmpdir)
+                            results = engine.run_batch(flow_path, tasks_file, base_dir)
 
         assert len(results) == 3
         thread_ids = [r["thread_id"] for r in results]
@@ -51,46 +52,24 @@ class TestBatchExecution:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.display_task_list", return_value=False):
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    base_dir = Path(tmpdir)
-                    results = engine.run_batch(flow_path, tasks_file, base_dir)
+            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+                with patch("fdsx.core.engine.display_task_list", return_value=False):
+                    with tempfile.TemporaryDirectory() as tmpdir:
+                        base_dir = Path(tmpdir)
+                        results = engine.run_batch(flow_path, tasks_file, base_dir)
 
         assert results == []
 
-    def test_missing_task_splitter(self):
-        flow = Flow(
-            name="Test Flow",
-            start_at="plan",
-            states={
-                "plan": TaskState(
-                    type="task",
-                    provider="system",
-                    command="echo test",
-                    result_path="$.result",
-                    end=True,
-                )
-            },
-        )
+    def test_batch_fails_when_task_splitter_not_configured(self):
+        """Regression: run_batch must raise FlowValidationError when task_splitter is None in config."""
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
-            import yaml
-
-            yaml.dump(flow.model_dump(), f)
-            flow_path = Path(f.name)
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-            f.write("Test task\n")
-            tasks_file = Path(f.name)
-
-        try:
+        with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=None)):
             with tempfile.TemporaryDirectory() as tmpdir:
                 base_dir = Path(tmpdir)
                 with pytest.raises(engine.FlowValidationError, match="task_splitter"):
                     engine.run_batch(flow_path, tasks_file, base_dir)
-        finally:
-            flow_path.unlink()
-            tasks_file.unlink()
 
     def test_mutual_exclusion_validation(self):
         result = subprocess.run(
@@ -134,12 +113,13 @@ class TestBatchIntegrationWithMockedInput:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.display_task_list", return_value=True):
-                with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        base_dir = Path(tmpdir)
-                        with patch("fdsx.core.engine.input", side_effect=["y", "y"]):
-                            results = engine.run_batch(flow_path, tasks_file, base_dir)
+            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+                with patch("fdsx.core.engine.display_task_list", return_value=True):
+                    with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            base_dir = Path(tmpdir)
+                            with patch("fdsx.core.engine.input", side_effect=["y", "y"]):
+                                results = engine.run_batch(flow_path, tasks_file, base_dir)
 
         assert len(results) == 3
 
@@ -163,11 +143,12 @@ class TestBatchIntegrationWithMockedInput:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.display_task_list", return_value=True):
-                with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        base_dir = Path(tmpdir)
-                        with patch("fdsx.core.engine.input", side_effect=["n"]):
-                            results = engine.run_batch(flow_path, tasks_file, base_dir)
+            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+                with patch("fdsx.core.engine.display_task_list", return_value=True):
+                    with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            base_dir = Path(tmpdir)
+                            with patch("fdsx.core.engine.input", side_effect=["n"]):
+                                results = engine.run_batch(flow_path, tasks_file, base_dir)
 
         assert len(results) == 2

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -99,7 +99,7 @@ class TestBatchIntegrationWithMockedInput:
 
         call_count = [0]
 
-        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
                 raise RuntimeError("Task failed intentionally")
@@ -129,7 +129,7 @@ class TestBatchIntegrationWithMockedInput:
 
         call_count = [0]
 
-        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
             call_count[0] += 1
             if call_count[0] == 2:
                 raise RuntimeError("Task failed intentionally")
@@ -152,3 +152,51 @@ class TestBatchIntegrationWithMockedInput:
                                 results = engine.run_batch(flow_path, tasks_file, base_dir)
 
         assert len(results) == 2
+
+
+class TestBatchQuietFlagPropagation:
+    def test_run_batch_passes_quiet_true_to_run_flow(self):
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1\n2. Task 2",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+                with patch("fdsx.core.engine.display_task_list", return_value=True):
+                    with patch("fdsx.core.engine.run_flow") as mock_run_flow:
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            base_dir = Path(tmpdir)
+                            engine.run_batch(flow_path, tasks_file, base_dir, quiet=True)
+
+        assert mock_run_flow.called
+        for call_args in mock_run_flow.call_args_list:
+            assert call_args.kwargs.get("quiet") is True
+
+    def test_run_batch_passes_quiet_false_by_default(self):
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+        tasks_file = Path("tests/fixtures/sample_tasks.md")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+                with patch("fdsx.core.engine.display_task_list", return_value=True):
+                    with patch("fdsx.core.engine.run_flow") as mock_run_flow:
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            base_dir = Path(tmpdir)
+                            engine.run_batch(flow_path, tasks_file, base_dir)
+
+        assert mock_run_flow.called
+        for call_args in mock_run_flow.call_args_list:
+            assert call_args.kwargs.get("quiet") is False

--- a/tests/integration/test_claude_streaming.py
+++ b/tests/integration/test_claude_streaming.py
@@ -25,6 +25,8 @@ FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "claude_stream.ndjson
 # Expected values derived from the fixture file
 FIXTURE_RESULT_TEXT = "Hello! Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"
 FIXTURE_TEXT_DELTAS = ["Hello", "! Here are 3 items:\n\n", "1. Apple\n2. Banana\n3. Cherry"]
+# After line buffering, fragments are combined and split at newlines
+FIXTURE_BUFFERED_LINES = ["Hello! Here are 3 items:", "1. Apple", "2. Banana", "3. Cherry"]
 
 
 def _load_fixture_lines() -> list[str]:
@@ -76,16 +78,15 @@ class TestClaudeStreamingEndToEnd:
 
         assert result.stdout == FIXTURE_RESULT_TEXT
 
-    def test_output_callback_receives_text_fragments(self) -> None:
-        """output_callback must be called with human-readable text fragments."""
+    def test_output_callback_receives_text_lines(self) -> None:
+        """output_callback must be called with buffered, line-delimited text."""
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.claude._run_subprocess", mock_run):
             self.provider.execute("Say hello and list 3 items", output_callback=received.append)
 
-        # Must have received each text_delta fragment
-        for fragment in FIXTURE_TEXT_DELTAS:
-            assert fragment in received, f"Expected fragment not received: {fragment!r}"
+        # Fragments are buffered and emitted as complete lines
+        assert received == FIXTURE_BUFFERED_LINES
 
     def test_no_raw_json_leaks_to_callback(self) -> None:
         """output_callback must not receive any raw JSON NDJSON lines."""

--- a/tests/integration/test_claude_streaming.py
+++ b/tests/integration/test_claude_streaming.py
@@ -1,0 +1,156 @@
+"""Integration test for Claude provider streaming end-to-end.
+
+Uses a mocked subprocess that replays the ``tests/fixtures/claude_stream.ndjson``
+fixture to verify:
+- output_callback is called with human-readable text fragments
+- ProviderResult.stdout matches the ``result`` event text (not raw NDJSON)
+- No raw JSON leaks through to the callback
+- Streaming CLI flags are added to the subprocess args when output_callback is provided
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.providers.base import ProviderResult
+from fdsx.providers.claude import ClaudeProvider, _STREAM_FORMAT_FLAGS
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "claude_stream.ndjson"
+
+# Expected values derived from the fixture file
+FIXTURE_RESULT_TEXT = "Hello! Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"
+FIXTURE_TEXT_DELTAS = ["Hello", "! Here are 3 items:\n\n", "1. Apple\n2. Banana\n3. Cherry"]
+
+
+def _load_fixture_lines() -> list[str]:
+    """Return non-empty NDJSON lines from the fixture file."""
+    return [line.rstrip("\n") for line in FIXTURE_PATH.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_run_subprocess_factory(fixture_lines: list[str], exit_code: int = 0) -> MagicMock:
+    """Return a mock for _run_subprocess that replays fixture lines via output_callback."""
+
+    def fake_run_subprocess(**kwargs: object) -> ProviderResult:
+        output_callback = kwargs.get("output_callback")
+        if output_callback is not None:
+            for line in fixture_lines:
+                output_callback(line)  # type: ignore[operator]
+        return ProviderResult(exit_code=exit_code, stdout="<raw ndjson>", stderr="")
+
+    mock = MagicMock(side_effect=fake_run_subprocess)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeStreamingEndToEnd:
+    """End-to-end streaming test using the claude_stream.ndjson fixture."""
+
+    def setup_method(self) -> None:
+        self.fixture_lines = _load_fixture_lines()
+        self.provider = ClaudeProvider()
+
+    def test_fixture_file_exists(self) -> None:
+        """Sanity check: the fixture file must exist and be non-empty."""
+        assert FIXTURE_PATH.exists(), f"Fixture not found: {FIXTURE_PATH}"
+        assert len(self.fixture_lines) > 0
+
+    def test_stdout_comes_from_result_event(self) -> None:
+        """ProviderResult.stdout must match the result event text, not raw NDJSON."""
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+
+        assert result.stdout == FIXTURE_RESULT_TEXT
+
+    def test_output_callback_receives_text_fragments(self) -> None:
+        """output_callback must be called with human-readable text fragments."""
+        received: list[str] = []
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+
+        # Must have received each text_delta fragment
+        for fragment in FIXTURE_TEXT_DELTAS:
+            assert fragment in received, f"Expected fragment not received: {fragment!r}"
+
+    def test_no_raw_json_leaks_to_callback(self) -> None:
+        """output_callback must not receive any raw JSON NDJSON lines."""
+        received: list[str] = []
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+
+        for item in received:
+            assert not item.strip().startswith("{"), (
+                f"Raw JSON leaked to output_callback: {item!r}"
+            )
+
+    def test_streaming_flags_added_to_args(self) -> None:
+        """_run_subprocess must be called with stream-json CLI flags."""
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+
+        mock_run.assert_called_once()
+        called_args: list[str] = mock_run.call_args.kwargs["args"]
+        for flag in _STREAM_FORMAT_FLAGS:
+            assert flag in called_args, f"Expected streaming flag not in args: {flag!r}"
+
+    def test_no_streaming_flags_without_callback(self) -> None:
+        """Without output_callback, _run_subprocess must NOT receive stream-json flags."""
+        fake_result = ProviderResult(exit_code=0, stdout="plain response", stderr="")
+        with patch("fdsx.providers.claude._run_subprocess", return_value=fake_result) as mock_run:
+            result = self.provider.execute("Say hello")
+
+        mock_run.assert_called_once()
+        called_args: list[str] = mock_run.call_args.kwargs["args"]
+        for flag in _STREAM_FORMAT_FLAGS:
+            assert flag not in called_args, f"Unexpected streaming flag found in args: {flag!r}"
+        assert result.stdout == "plain response"
+
+    def test_exit_code_preserved(self) -> None:
+        """ProviderResult.exit_code must be propagated from _run_subprocess."""
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines, exit_code=0)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello", output_callback=lambda _: None)
+
+        assert result.exit_code == 0
+
+    def test_fallback_stdout_when_result_event_absent(self) -> None:
+        """When no result event in stream, stdout falls back to concatenated text_delta."""
+        # Only feed text_delta lines (no result event)
+        delta_only_lines = [
+            line for line in self.fixture_lines
+            if '"type":"content_block_delta"' in line or '"type": "content_block_delta"' in line
+        ]
+        mock_run = _fake_run_subprocess_factory(delta_only_lines)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello", output_callback=lambda _: None)
+
+        expected_fallback = "".join(FIXTURE_TEXT_DELTAS)
+        assert result.stdout == expected_fallback
+
+    def test_malformed_lines_do_not_crash(self) -> None:
+        """Malformed NDJSON lines interspersed in the stream do not raise exceptions."""
+        mixed_lines = ["not valid json", self.fixture_lines[-1], "{{broken"]
+        mock_run = _fake_run_subprocess_factory(mixed_lines)
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello", output_callback=lambda _: None)
+
+        # result event was in the last fixture line, so stdout should be correct
+        assert result.stdout == FIXTURE_RESULT_TEXT
+        assert result.exit_code == 0

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 
 
@@ -45,11 +44,10 @@ class TestCLIE2E:
             text=True,
         )
         assert result.returncode == 0
-
-        output = json.loads(result.stdout)
-        assert "plan" in output
-        assert "implementation" in output
-        assert "review" in output
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
 
     def test_run_with_input(self):
         result = subprocess.run(
@@ -64,14 +62,13 @@ class TestCLIE2E:
             text=True,
         )
         assert result.returncode == 0
-
-        output = json.loads(result.stdout)
-        assert "plan" in output
-        assert "implementation" in output
-        assert "review" in output
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
 
     def test_run_with_input_uses_value(self):
-        """R2-F4: --input value must be consumed and appear in the output."""
+        """R2-F4: --input value must be consumed; workflow completes successfully."""
         result = subprocess.run(
             get_fdsx_command()
             + [
@@ -84,9 +81,10 @@ class TestCLIE2E:
             text=True,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        output = json.loads(result.stdout)
-        assert "greeting" in output
-        assert "world" in output["greeting"]
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
 
     def test_run_with_invalid_flow_returns_exit_code_2(self):
         result = subprocess.run(

--- a/tests/integration/test_cli_e2e_phase2.py
+++ b/tests/integration/test_cli_e2e_phase2.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 
 
@@ -35,10 +34,10 @@ class TestCLIE2EPhase2:
             text=True,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        output = json.loads(result.stdout)
-        assert "reviews" in output
-        assert output["decision"] == "APPROVED"
-        assert "approved_result" in output
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
 
     def test_extraction_flow_yaml_validates(self):
         """Test extraction_flow.yaml validates successfully."""
@@ -65,10 +64,10 @@ class TestCLIE2EPhase2:
             text=True,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        output = json.loads(result.stdout)
-        assert "decision" in output
-        assert output["decision"] == "APPROVED"
-        assert "raw_output" in output
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
 
     def test_loop_flow_yaml_validates(self):
         """Test loop_flow.yaml validates successfully."""
@@ -95,12 +94,9 @@ class TestCLIE2EPhase2:
             text=True,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        output = json.loads(result.stdout)
-        # Partial results from loop iterations must be present
-        assert "plan_output" in output
-        assert "impl_output" in output
-        assert "review_output" in output
-        # The flow should NOT reach the "done" state since review always rejects
-        assert "final_result" not in output
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
         # Verify loop completion message on stderr
         assert "Loop completed" in result.stderr
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr

--- a/tests/integration/test_cli_e2e_phase3.py
+++ b/tests/integration/test_cli_e2e_phase3.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 import tempfile
 from pathlib import Path
@@ -26,10 +25,10 @@ class TestCLIE2EPhase3:
             timeout=30,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
-        output = json.loads(result.stdout)
-        assert "plan_output" in output
-        assert "approval_decision" in output
-        assert output["approval_decision"] == "approve"
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
 
     def test_resume_interrupted_flow(self):
         """Test fdsx resume --thread-id with previously interrupted flow."""
@@ -67,9 +66,10 @@ class TestCLIE2EPhase3:
                 timeout=30,
             )
             assert resume_result.returncode == 0, f"stderr: {resume_result.stderr}"
-            output = json.loads(resume_result.stdout)
-            assert "approval_decision" in output
-            assert output["approval_decision"] == "approve"
+            # FR-1.3: No JSON on stdout
+            assert resume_result.stdout == ""
+            # FR-1.1: Completion message on stderr
+            assert "completed successfully" in resume_result.stderr
 
     def test_resume_nonexistent_thread(self):
         """Test fdsx resume --thread-id with non-existent thread returns exit code 2."""

--- a/tests/integration/test_cli_e2e_phase3.py
+++ b/tests/integration/test_cli_e2e_phase3.py
@@ -165,6 +165,7 @@ class TestCLIE2EPhase3:
             flow_path = Path(tmp_dir) / "flow.yaml"
             flow_path.write_text(
                 "name: Prompt File Validate Test\n"
+                "description: Test prompt file validation\n"
                 "start_at: task1\n"
                 "version: '1.0'\n"
                 "\n"
@@ -196,6 +197,7 @@ class TestCLIE2EPhase3:
             flow_path = Path(tmp_dir) / "flow.yaml"
             flow_path.write_text(
                 "name: Missing Prompt File Test\n"
+                "description: Test missing prompt file\n"
                 "start_at: task1\n"
                 "version: '1.0'\n"
                 "\n"

--- a/tests/integration/test_cli_e2e_phase4.py
+++ b/tests/integration/test_cli_e2e_phase4.py
@@ -85,12 +85,12 @@ class TestBatchCLIE2E:
         )
         assert "mutually exclusive" in result.stderr.lower()
 
-    def test_batch_missing_task_splitter(self):
-        """Test --tasks with flow missing task_splitter → exit code 2."""
+    def test_batch_missing_description(self):
+        """Test --tasks with flow missing description → exit code 2 with actionable error."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            flow_path = Path(tmpdir) / "no_splitter_flow.yaml"
+            flow_path = Path(tmpdir) / "no_description_flow.yaml"
             flow_path.write_text(
-                "name: No Splitter Flow\n"
+                "name: No Description Flow\n"
                 "start_at: task1\n"
                 "version: '1.0'\n"
                 "\n"
@@ -124,4 +124,4 @@ class TestBatchCLIE2E:
             assert result.returncode == 2, (
                 f"Expected exit code 2, got {result.returncode}. stderr: {result.stderr}"
             )
-            assert "task_splitter" in result.stderr.lower()
+            assert "description" in result.stderr.lower()

--- a/tests/integration/test_cli_e2e_phase4.py
+++ b/tests/integration/test_cli_e2e_phase4.py
@@ -1,6 +1,5 @@
 """End-to-end CLI tests for Phase 4 batch task scenarios."""
 
-import json
 import subprocess
 import sys
 import tempfile
@@ -23,7 +22,7 @@ class TestBatchCLIE2E:
     """End-to-end CLI tests for batch task execution (T070)."""
 
     def test_batch_full_execution_with_approval(self):
-        """Test fdsx run --tasks via CLI: approve → all tasks execute → exit 0 + JSON."""
+        """Test fdsx run --tasks via CLI: approve → all tasks execute → exit 0, no JSON."""
         runner = CliRunner()
         flow_path = str(Path("tests/fixtures/batch_flow.yaml").resolve())
         tasks_path = str(Path("tests/fixtures/sample_tasks.md").resolve())
@@ -51,14 +50,8 @@ class TestBatchCLIE2E:
         assert result.exit_code == 0, (
             f"output: {result.output}\nexception: {result.exception}"
         )
-        json_text = result.output.split("\n\n")[0]
-        output = json.loads(json_text)
-        assert isinstance(output, list)
-        assert len(output) == 3
-        for item in output:
-            assert item["status"] == "completed"
-            assert "thread_id" in item
-            assert item["error"] is None
+        # FR-1.3: No JSON on stdout
+        assert result.output == "" or not result.output.startswith("[")
 
     def test_input_tasks_mutual_exclusion(self):
         """Test --input and --tasks together → exit code 2, mutual exclusion error."""

--- a/tests/integration/test_codex_streaming.py
+++ b/tests/integration/test_codex_streaming.py
@@ -1,0 +1,176 @@
+"""Integration test for Codex provider streaming end-to-end.
+
+Uses a mocked subprocess that replays the ``tests/fixtures/codex_stream.jsonl``
+fixture to verify:
+- output_callback is called with human-readable content fragments
+- ProviderResult.stdout matches concatenated agent_message texts (not raw JSONL)
+- No raw JSON leaks through to the callback
+- Streaming CLI flag (--json) is added to subprocess args when output_callback provided
+- Without output_callback, --json flag is absent
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fdsx.providers.base import ProviderResult
+from fdsx.providers.codex import CodexProvider, _STREAM_FORMAT_FLAGS
+
+# ---------------------------------------------------------------------------
+# Fixture loading
+# ---------------------------------------------------------------------------
+
+FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "codex_stream.jsonl"
+
+# Expected values derived from the fixture file (two agent_message events joined with "\n")
+FIXTURE_RESULT_TEXT = "Hello! \nHere are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"
+FIXTURE_AGENT_MESSAGE_TEXTS = ["Hello! ", "Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"]
+
+
+def _load_fixture_lines() -> list[str]:
+    """Return non-empty JSONL lines from the fixture file."""
+    return [line.rstrip("\n") for line in FIXTURE_PATH.read_text().splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_run_subprocess_factory(fixture_lines: list[str], exit_code: int = 0) -> MagicMock:
+    """Return a mock for _run_subprocess that replays fixture lines via output_callback."""
+
+    def fake_run_subprocess(**kwargs: object) -> ProviderResult:
+        output_callback = kwargs.get("output_callback")
+        if output_callback is not None:
+            for line in fixture_lines:
+                output_callback(line)  # type: ignore[operator]
+        return ProviderResult(exit_code=exit_code, stdout="<raw jsonl>", stderr="")
+
+    mock = MagicMock(side_effect=fake_run_subprocess)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCodexStreamingEndToEnd:
+    """End-to-end streaming test using the codex_stream.jsonl fixture."""
+
+    def setup_method(self) -> None:
+        self.fixture_lines = _load_fixture_lines()
+        self.provider = CodexProvider()
+
+    def test_fixture_file_exists(self) -> None:
+        """Sanity check: the fixture file must exist and be non-empty."""
+        assert FIXTURE_PATH.exists(), f"Fixture not found: {FIXTURE_PATH}"
+        assert len(self.fixture_lines) > 0
+
+    def test_stdout_comes_from_agent_message_concatenation(self) -> None:
+        """ProviderResult.stdout must match concatenated agent_message texts, not raw JSONL."""
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+
+        assert result.stdout == FIXTURE_RESULT_TEXT
+
+    def test_output_callback_receives_agent_message_texts(self) -> None:
+        """output_callback must be called with each agent_message text."""
+        received: list[str] = []
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+
+        for text in FIXTURE_AGENT_MESSAGE_TEXTS:
+            assert text in received, f"Expected agent_message text not received: {text!r}"
+
+    def test_output_callback_receives_tool_events(self) -> None:
+        """output_callback must be called for command_execution, file_change, mcp_tool_call."""
+        received: list[str] = []
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+
+        assert "[tool: echo hello]" in received
+        assert "[tool: file_change]" in received
+        assert "[tool: web_search]" in received
+
+    def test_output_callback_receives_thinking(self) -> None:
+        """output_callback must be called with [thinking] prefix for reasoning items."""
+        received: list[str] = []
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+
+        assert "[thinking] I need to say hello in a friendly way." in received
+
+    def test_no_raw_json_leaks_to_callback(self) -> None:
+        """output_callback must not receive any raw JSON JSONL lines."""
+        received: list[str] = []
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+
+        for item in received:
+            assert not item.strip().startswith("{"), (
+                f"Raw JSON leaked to output_callback: {item!r}"
+            )
+
+    def test_streaming_flag_added_to_args(self) -> None:
+        """_run_subprocess must be called with all _STREAM_FORMAT_FLAGS when output_callback is provided."""
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+
+        mock_run.assert_called_once()
+        called_args: list[str] = mock_run.call_args.kwargs["args"]
+        for flag in _STREAM_FORMAT_FLAGS:
+            assert flag in called_args, f"Expected {flag!r} in args: {called_args}"
+
+    def test_no_streaming_flag_without_callback(self) -> None:
+        """Without output_callback, _run_subprocess must NOT receive any _STREAM_FORMAT_FLAGS."""
+        fake_result = ProviderResult(exit_code=0, stdout="plain response", stderr="")
+        with patch("fdsx.providers.codex._run_subprocess", return_value=fake_result) as mock_run:
+            result = self.provider.execute("Say hello")
+
+        mock_run.assert_called_once()
+        called_args: list[str] = mock_run.call_args.kwargs["args"]
+        for flag in _STREAM_FORMAT_FLAGS:
+            assert flag not in called_args, f"Unexpected {flag!r} found in args: {called_args}"
+        assert result.stdout == "plain response"
+
+    def test_exit_code_preserved(self) -> None:
+        """ProviderResult.exit_code must be propagated from _run_subprocess."""
+        mock_run = _fake_run_subprocess_factory(self.fixture_lines, exit_code=0)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello", output_callback=lambda _: None)
+
+        assert result.exit_code == 0
+
+    def test_malformed_lines_do_not_crash(self) -> None:
+        """Malformed JSONL lines interspersed in the stream do not raise exceptions."""
+        # Use last fixture line (a completed agent_message) plus malformed lines
+        last_line = self.fixture_lines[-1]
+        mixed_lines = ["not valid json", last_line, "{{broken"]
+        mock_run = _fake_run_subprocess_factory(mixed_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello", output_callback=lambda _: None)
+
+        # Last fixture line is the second agent_message completed event
+        assert result.stdout == "Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"
+        assert result.exit_code == 0
+
+    def test_fallback_stdout_when_no_agent_message(self) -> None:
+        """When no agent_message completed events, stdout comes from raw _run_subprocess result."""
+        # Feed only non-agent_message lines
+        non_message_lines = [
+            line for line in self.fixture_lines
+            if '"agent_message"' not in line
+        ]
+        mock_run = _fake_run_subprocess_factory(non_message_lines)
+        with patch("fdsx.providers.codex._run_subprocess", mock_run):
+            result = self.provider.execute("Say hello", output_callback=lambda _: None)
+
+        # No agent_message events → get_result() returns None → fall back to raw result
+        assert result.stdout == "<raw jsonl>"

--- a/tests/integration/test_e2e_phase6.py
+++ b/tests/integration/test_e2e_phase6.py
@@ -289,7 +289,7 @@ class TestFullPipelineE2E:
 
         run_count = [0]
 
-        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
             run_count[0] += 1
             task_desc = ""
             if inputs:
@@ -320,7 +320,7 @@ class TestFullPipelineE2E:
 
         run_count_after_resume = [0]
 
-        def mock_run_flow_resume(flow_path, inputs, thread_id, base_dir):
+        def mock_run_flow_resume(flow_path, inputs, thread_id, base_dir, **kwargs):
             run_count_after_resume[0] += 1
             return {"result": "ok"}
 
@@ -466,7 +466,7 @@ class TestFullPipelineE2E:
 
         run_count = [0]
 
-        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
             run_count[0] += 1
             if inputs and "E2E Task 2" in inputs.get("task", ""):
                 raise RuntimeError("Simulated error on Task 2")
@@ -523,7 +523,7 @@ class TestFullPipelineE2E:
 
         run_count_rerun = [0]
 
-        def mock_run_flow_rerun(flow_path, inputs, thread_id, base_dir):
+        def mock_run_flow_rerun(flow_path, inputs, thread_id, base_dir, **kwargs):
             run_count_rerun[0] += 1
             return {"result": "ok"}
 

--- a/tests/integration/test_e2e_phase6.py
+++ b/tests/integration/test_e2e_phase6.py
@@ -236,10 +236,10 @@ class TestEdgeCases:
 
 
 class TestFullPipelineE2E:
-    """T43: End-to-end full pipeline test.
+    """T43: End-to-end full pipeline test (T029).
 
     Tests the complete lifecycle:
-    1. Split task content into groups via mock LLM
+    1. Split task content into groups via mock LLM (with spinner)
     2. Simulate user editing a task file
     3. Run tasks_dir with 2nd task failing
     4. Verify partial state: first=completed, second=failed
@@ -396,9 +396,175 @@ class TestFullPipelineE2E:
                     f"Entry '{entry.description}' should be completed"
                 )
 
+    def test_full_pipeline_split_auto_select_cui_persist_skip_error_resume(
+        self, tmp_path
+    ):
+        """T029: Full pipeline: split (with spinner) → auto-select → CUI confirm → persist → re-run (skip) → error → resume command.
+
+        This tests the complete integration of all Phase 1-6 features:
+        - Split creates task files with mock LLM
+        - Run auto-selects workflows (spinner shown)
+        - CUI confirms assignments
+        - Workflow field is persisted in YAML
+        - Re-run skips auto-selection (workflow already set)
+        - Error triggers resume command display
+        """
+        import yaml
+
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / TASKS_DIR
+        tasks_dir.mkdir(parents=True)
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "E2E Task 1"}, {"description": "E2E Task 2"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            result_groups = split_tasks_to_groups(
+                "E2E test tasks",
+                task_splitter,
+            )
+
+        created_files = write_task_files(result_groups, tasks_dir)
+        assert len(created_files) == 1
+
+        task_file = load_task_file(created_files[0])
+        assert len(task_file.entries) == 2
+        assert task_file.entries[0].workflow is None
+        assert task_file.entries[1].workflow is None
+
+        resolve_count = [0]
+
+        def mock_resolve(**kwargs):
+            resolve_count[0] += 1
+            return workflows_dir / "test.yaml"
+
+        run_count = [0]
+
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            run_count[0] += 1
+            if inputs and "E2E Task 2" in inputs.get("task", ""):
+                raise RuntimeError("Simulated error on Task 2")
+            return {"result": "ok"}
+
+        auto_select_spinners: list[str] = []
+
+        class _SpinnerCapture:
+            def __init__(self, message: str = ""):
+                self._message = message
+
+            def __enter__(self):
+                auto_select_spinners.append(f"start:{self._message}")
+                return self
+
+            def __exit__(self, *args):
+                auto_select_spinners.append("stop")
+
+            def update(self, msg):
+                auto_select_spinners.append(f"update:{msg}")
+
+        with patch("fdsx.core.engine.Spinner", side_effect=_SpinnerCapture):
+            with patch(
+                "fdsx.core.engine.resolve_workflow_for_task", side_effect=mock_resolve
+            ):
+                with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                    with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                        with patch("fdsx.core.engine.input", side_effect=["n"]):
+                            results = engine.run_tasks_dir(
+                                None,
+                                tasks_dir,
+                                base_dir=project_root / ".fdsx",
+                                auto_workflow=True,
+                            )
+
+        assert resolve_count[0] == 2, "Both tasks should be auto-selected"
+        assert run_count[0] == 2, "Both tasks should be attempted"
+
+        updated_task_file = load_task_file(created_files[0])
+        assert updated_task_file.entries[0].workflow == "test.yaml"
+        assert updated_task_file.entries[1].workflow == "test.yaml"
+        assert updated_task_file.entries[0].status == "completed"
+        assert updated_task_file.entries[1].status == "failed"
+
+        assert any("Auto-selecting" in msg for msg in auto_select_spinners), (
+            "Spinner should show auto-selection progress"
+        )
+
+        resolve_count_after_persist = [0]
+
+        def mock_resolve_persist(**kwargs):
+            resolve_count_after_persist[0] += 1
+            return workflows_dir / "test.yaml"
+
+        run_count_rerun = [0]
+
+        def mock_run_flow_rerun(flow_path, inputs, thread_id, base_dir):
+            run_count_rerun[0] += 1
+            return {"result": "ok"}
+
+        with patch("fdsx.core.engine.Spinner", side_effect=_SpinnerCapture):
+            with patch(
+                "fdsx.core.engine.resolve_workflow_for_task",
+                side_effect=mock_resolve_persist,
+            ):
+                with patch(
+                    "fdsx.core.engine.run_flow", side_effect=mock_run_flow_rerun
+                ):
+                    with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                        with patch("fdsx.core.engine.input", side_effect=["n"]):
+                            results2 = engine.run_tasks_dir(
+                                None,
+                                tasks_dir,
+                                base_dir=project_root / ".fdsx",
+                                auto_workflow=True,
+                            )
+
+        assert resolve_count_after_persist[0] == 0, (
+            "Workflow already set; auto-selection should be skipped after persistence"
+        )
+        assert run_count_rerun[0] == 1, (
+            "Only Task 2 (failed) should be retried on re-run"
+        )
+
+        for r in results2:
+            if r["entry_description"] == "E2E Task 1":
+                assert r["category"] == "skipped"
+            elif r["entry_description"] == "E2E Task 2":
+                assert r["category"] == "retried"
+                assert r["status"] == "completed"
+
+        final_task_file = load_task_file(created_files[0])
+        assert final_task_file.entries[0].status == "completed"
+        assert final_task_file.entries[1].status == "completed"
+
 
 class TestHelpText:
-    """Verify help text is descriptive (T41)."""
+    """Verify help text is descriptive (T41/T27)."""
 
     def test_run_command_help_includes_batch_modes(self):
         """Verify run command help mentions batch and tasks-dir modes."""
@@ -426,6 +592,41 @@ class TestHelpText:
         assert result.exit_code == 0
         assert "persistent" in result.stdout
         assert "resume support" in result.stdout
+
+    def test_run_help_mentions_spinner_and_cui(self):
+        """Verify run command help mentions spinner, CUI, and non-TTY behavior (T027)."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "spinner" in result.stdout.lower()
+        assert "confirmation" in result.stdout.lower()
+        assert (
+            "non-tty" in result.stdout.lower()
+            or "noninteractive" in result.stdout.lower()
+        )
+
+    def test_run_help_mentions_auto_workflow_and_cui(self):
+        """Verify --auto-workflow and --confirm-workflow mention CUI behavior (T027)."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        help_lower = result.stdout.lower()
+        assert "skip" in help_lower and "confirmation" in help_lower
+        assert "interactive" in help_lower or "workflow" in help_lower
+
+    def test_split_help_mentions_spinner(self):
+        """Verify split command help mentions spinner and non-TTY fallback (T027)."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["split", "--help"])
+
+        assert result.exit_code == 0
+        assert "spinner" in result.stdout.lower() or "animated" in result.stdout.lower()
+        assert (
+            "non-tty" in result.stdout.lower()
+            or "noninteractive" in result.stdout.lower()
+        )
 
 
 class TestSecuritySanitization:

--- a/tests/integration/test_e2e_phase6.py
+++ b/tests/integration/test_e2e_phase6.py
@@ -1,0 +1,476 @@
+"""Integration tests for Phase 6: Polish, Backward Compatibility & E2E.
+
+Tests:
+- T39: Backward compatibility for --tasks flag
+- T40: Clear error messages for invalid task files
+- T42: Edge cases (empty dir, all completed, single task file, invalid YAML)
+- T43: End-to-end full pipeline (split → edit → run → crash → resume → complete)
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+from fdsx.core import engine
+from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.config import FdsxConfig, TaskSplitterConfig
+from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
+
+
+class TestBackwardCompat:
+    """T39: Verify --tasks (in-memory batch) reads task_splitter from config, not flow."""
+
+    def test_tasks_flag_reads_config_not_flow(self):
+        """Verify run_batch calls load_config() and uses config.task_splitter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflow_path = Path(tmpdir) / "flow.yaml"
+            workflow_path.write_text(
+                yaml.dump(
+                    {
+                        "name": "Test Flow",
+                        "description": "A test flow",
+                        "start_at": "step1",
+                        "version": "1.0",
+                        "states": {
+                            "step1": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo test",
+                                "result_path": "$.result",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            tasks_file = Path(tmpdir) / "tasks.txt"
+            tasks_file.write_text("Task 1\nTask 2\n")
+
+            config_loaded = []
+
+            def mock_load_config(*args, **kwargs):
+                config_loaded.append(True)
+                return FdsxConfig(
+                    task_splitter=TaskSplitterConfig(
+                        provider="claude", model="claude-sonnet-4-6"
+                    )
+                )
+
+            mock_provider = MagicMock()
+            mock_provider.execute.return_value = MagicMock(
+                exit_code=0,
+                stdout='[{"description": "Task 1"}, {"description": "Task 2"}]',
+                stderr="",
+            )
+
+            with patch("fdsx.core.engine.load_config", mock_load_config):
+                with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                    with patch("fdsx.core.engine.display_task_list", return_value=True):
+                        with patch(
+                            "fdsx.core.engine.run_flow", return_value={"result": "ok"}
+                        ):
+                            engine.run_batch(workflow_path, tasks_file)
+
+            assert len(config_loaded) > 0, "load_config should have been called"
+            assert "task_splitter" not in workflow_path.read_text().lower(), (
+                "task_splitter should not be in flow YAML"
+            )
+
+
+class TestErrorMessages:
+    """T40: Clear error messages for various failure scenarios."""
+
+    def test_invalid_yaml_task_file_via_cli(self, tmp_path):
+        """Invalid YAML in task file should produce a clear error via CLI."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-bad.yaml").write_text(": [broken yaml\n")
+
+        workflow_path = Path("tests/fixtures/simple_flow.yaml")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                str(workflow_path),
+                "--tasks-dir",
+                str(tasks_dir),
+                "--auto-workflow",
+            ],
+        )
+
+        assert result.exit_code == 2, f"Expected exit code 2, got {result.exit_code}"
+        assert "001-bad.yaml" in result.stderr or "invalid" in result.stderr.lower(), (
+            f"Error should mention the invalid file: {result.stderr}"
+        )
+
+    def test_invalid_yaml_task_file_via_api(self, tmp_path):
+        """Invalid YAML in task file should produce a clear error via API."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-bad.yaml").write_text(": [broken yaml\n")
+
+        workflow_path = Path("tests/fixtures/simple_flow.yaml")
+
+        with pytest.raises(engine.FlowValidationError) as exc_info:
+            engine.run_tasks_dir(workflow_path, tasks_dir, auto_workflow=True)
+
+        assert (
+            "001-bad.yaml" in str(exc_info.value)
+            or "invalid" in str(exc_info.value).lower()
+        ), f"Error should mention the invalid file: {exc_info.value}"
+
+
+class TestEdgeCases:
+    """T42: Edge case handling."""
+
+    def test_empty_tasks_dir_error_via_cli(self, tmp_path):
+        """Empty tasks directory should produce a clear error via CLI."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+
+        workflow_path = Path("tests/fixtures/simple_flow.yaml")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                str(workflow_path),
+                "--tasks-dir",
+                str(tasks_dir),
+                "--auto-workflow",
+            ],
+        )
+
+        assert result.exit_code == 2, f"Expected exit code 2, got {result.exit_code}"
+        assert (
+            "no .yaml" in result.stderr.lower() or "empty" in result.stderr.lower()
+        ), f"Error should mention no YAML files: {result.stderr}"
+
+    def test_all_tasks_completed_multi_file_noop(self, tmp_path):
+        """Multiple files with all entries completed should result in no run_flow calls."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+        tf1 = TaskFile(
+            entries=[
+                TaskEntry(description="task 1", status="completed"),
+                TaskEntry(description="task 2", status="completed"),
+            ]
+        )
+        save_task_file(tasks_dir / "001-file1.yaml", tf1)
+
+        tf2 = TaskFile(
+            entries=[
+                TaskEntry(description="task 3", status="completed"),
+                TaskEntry(description="task 4", status="completed"),
+            ]
+        )
+        save_task_file(tasks_dir / "002-file2.yaml", tf2)
+
+        with patch(
+            "fdsx.core.engine.run_flow", return_value={"result": "ok"}
+        ) as mock_run:
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                results = engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+        mock_run.assert_not_called()
+        assert len(results) == 4
+        for r in results:
+            assert r["category"] == "skipped"
+            assert r["status"] == "completed"
+
+    def test_single_task_file_single_entry(self, tmp_path):
+        """One file with one entry should execute correctly."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+        tf = TaskFile(entries=[TaskEntry(description="single task")])
+        save_task_file(tasks_dir / "001-single.yaml", tf)
+
+        with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                results = engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+        assert len(results) == 1
+        assert results[0]["status"] == "completed"
+        assert results[0]["category"] == "new"
+
+        loaded = load_task_file(tasks_dir / "001-single.yaml")
+        assert loaded.entries[0].status == "completed"
+
+    def test_mix_valid_and_invalid_yaml_files(self, tmp_path):
+        """Mix of valid and invalid YAML files should error clearly."""
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+
+        (tasks_dir / "001-valid.yaml").write_text("description: valid task\n")
+        (tasks_dir / "002-invalid.yaml").write_text(": [broken yaml\n")
+        (tasks_dir / "003-also-valid.yaml").write_text("description: another valid\n")
+
+        workflow_path = Path("tests/fixtures/simple_flow.yaml")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                str(workflow_path),
+                "--tasks-dir",
+                str(tasks_dir),
+                "--auto-workflow",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "002-invalid.yaml" in result.stderr or "invalid" in result.stderr.lower()
+
+
+class TestFullPipelineE2E:
+    """T43: End-to-end full pipeline test.
+
+    Tests the complete lifecycle:
+    1. Split task content into groups via mock LLM
+    2. Simulate user editing a task file
+    3. Run tasks_dir with 2nd task failing
+    4. Verify partial state: first=completed, second=failed
+    5. Resume: run again, verify first skipped, second retried
+    6. Verify final state: all completed
+    """
+
+    def test_split_edit_run_crash_resume_complete(self, tmp_path):
+        """Full lifecycle: split → edit → run (crash) → resume → complete."""
+        tasks_dir = tmp_path / TASKS_DIR
+        tasks_dir.mkdir(parents=True)
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Implement feature A"}, {"description": "Implement feature B"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            result_groups = split_tasks_to_groups(
+                "Implement features A and B",
+                task_splitter,
+            )
+
+        assert len(result_groups) == 1
+        assert len(result_groups[0]) == 2
+
+        created_files = write_task_files(result_groups, tasks_dir)
+        assert len(created_files) == 1
+
+        task_file_path = created_files[0]
+        assert task_file_path.exists()
+
+        task_file = load_task_file(task_file_path)
+        assert len(task_file.entries) == 2
+        assert task_file.entries[0].description == "Implement feature A"
+        assert task_file.entries[1].description == "Implement feature B"
+
+        task_file.entries[1].description = "Implement feature B (edited)"
+        save_task_file(task_file_path, task_file)
+        edited = load_task_file(task_file_path)
+        assert edited.entries[1].description == "Implement feature B (edited)"
+
+        run_count = [0]
+
+        def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            run_count[0] += 1
+            task_desc = ""
+            if inputs:
+                task_desc = inputs.get("task", "")
+            if task_desc and "feature B" in task_desc:
+                raise RuntimeError("Simulated crash during feature B")
+            return {"result": "ok"}
+
+        with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                with patch("fdsx.core.engine.input", side_effect=["n"]):
+                    results1 = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
+
+        assert len(results1) == 2
+        assert run_count[0] == 2, "Both entries should have been attempted"
+
+        task_file_after_run1 = load_task_file(task_file_path)
+        assert task_file_after_run1.entries[0].status == "completed"
+        assert task_file_after_run1.entries[0].description == "Implement feature A"
+        assert task_file_after_run1.entries[1].status == "failed"
+        assert (
+            task_file_after_run1.entries[1].description
+            == "Implement feature B (edited)"
+        )
+        assert "Simulated crash" in (task_file_after_run1.entries[1].error or "")
+
+        run_count_after_resume = [0]
+
+        def mock_run_flow_resume(flow_path, inputs, thread_id, base_dir):
+            run_count_after_resume[0] += 1
+            return {"result": "ok"}
+
+        with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow_resume):
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                results2 = engine.run_tasks_dir(
+                    flow_path, tasks_dir, auto_workflow=True
+                )
+
+        assert len(results2) == 2
+        assert run_count_after_resume[0] == 1, (
+            "Only the failed entry should have been retried"
+        )
+
+        for r in results2:
+            if r["entry_description"] == "Implement feature A":
+                assert r["category"] == "skipped"
+                assert r["status"] == "completed"
+            elif r["entry_description"] == "Implement feature B (edited)":
+                assert r["category"] == "retried"
+                assert r["status"] == "completed"
+
+        task_file_final = load_task_file(task_file_path)
+        assert task_file_final.entries[0].status == "completed"
+        assert task_file_final.entries[0].description == "Implement feature A"
+        assert task_file_final.entries[1].status == "completed"
+        assert task_file_final.entries[1].description == "Implement feature B (edited)"
+
+    def test_e2e_split_helpers_then_run_via_cli(self, tmp_path):
+        """End-to-end: split helpers create files, then run command executes them via CLI."""
+        tasks_dir = tmp_path / TASKS_DIR
+        tasks_dir.mkdir(parents=True)
+        flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "CLI test task 1"}, {"description": "CLI test task 2"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            result_groups = split_tasks_to_groups(
+                "CLI test tasks",
+                task_splitter,
+            )
+        created_files = write_task_files(result_groups, tasks_dir)
+
+        with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app,
+                    [
+                        "run",
+                        str(flow_path),
+                        "--tasks-dir",
+                        str(tasks_dir),
+                        "--auto-workflow",
+                    ],
+                )
+
+        assert result.exit_code == 0, (
+            f"Expected exit code 0, got {result.exit_code}: {result.stderr}"
+        )
+
+        for f in created_files:
+            loaded = load_task_file(f)
+            for entry in loaded.entries:
+                assert entry.status == "completed", (
+                    f"Entry '{entry.description}' should be completed"
+                )
+
+
+class TestHelpText:
+    """Verify help text is descriptive (T41)."""
+
+    def test_run_command_help_includes_batch_modes(self):
+        """Verify run command help mentions batch and tasks-dir modes."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "in-memory batch" in result.stdout
+        assert "persistent batch" in result.stdout
+
+    def test_tasks_option_help_is_descriptive(self):
+        """Verify --tasks option help is descriptive."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "in-memory splitting and" in result.stdout
+        assert "execution" in result.stdout
+
+    def test_tasks_dir_option_help_mentions_resume(self):
+        """Verify --tasks-dir option help mentions resume capability."""
+        runner = CliRunner()
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        assert "persistent" in result.stdout
+        assert "resume support" in result.stdout
+
+
+class TestSecuritySanitization:
+    """Regression: ANSI injection via crafted filenames must be stripped from CLI output."""
+
+    def test_validation_error_ansi_stripped_from_cli_output(self, tmp_path):
+        """Regression: FlowValidationError containing ANSI escape sequences must not leak
+        to the terminal.  A crafted .yaml filename with embedded escape bytes was the
+        reported attack vector (security finding – unsanitized validation errors).
+        """
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        # Create a YAML file with broken content so load_tasks_dir raises FlowValidationError
+        (tasks_dir / "001-bad.yaml").write_text(": [broken yaml\n")
+
+        workflow_path = Path("tests/fixtures/simple_flow.yaml")
+
+        runner = CliRunner()
+
+        # Patch load_tasks_dir to raise a FlowValidationError whose message contains
+        # ANSI escape sequences (simulating a crafted filename being embedded in the error).
+        ansi_payload = "\x1b[31mINJECTED\x1b[0m"
+        with patch(
+            "fdsx.cli.main.engine.run_tasks_dir",
+            side_effect=engine.FlowValidationError(
+                f"Invalid file {ansi_payload} caused error"
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "run",
+                    str(workflow_path),
+                    "--tasks-dir",
+                    str(tasks_dir),
+                    "--auto-workflow",
+                ],
+            )
+
+        assert result.exit_code == 2, f"Expected exit code 2, got {result.exit_code}"
+        # ANSI escape byte must NOT appear in output
+        assert "\x1b" not in result.output, (
+            f"ANSI escape sequence leaked to terminal output: {result.output!r}"
+        )
+        # The visible error text should still be present (stripped of escape codes)
+        assert "INJECTED" in result.output, (
+            f"Visible error content was lost: {result.output!r}"
+        )

--- a/tests/integration/test_e2e_scenarios.py
+++ b/tests/integration/test_e2e_scenarios.py
@@ -92,7 +92,8 @@ class TestScenario1LinearFlow:
 
     @staticmethod
     def _read_run_log(base_dir: Path, thread_id: str) -> dict:
-        log_path = base_dir / "runs" / f"{thread_id}.json"
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+        log_path = base_dir / RUNS_DIR_NAME / thread_id / RUN_FILENAME
         assert log_path.exists(), f"Run log not found at {log_path}"
         with open(log_path, "r") as f:
             return json.load(f)
@@ -273,7 +274,7 @@ class TestScenario4CheckpointResume:
                         base_dir=base_dir,
                     )
 
-            initial_log = TestScenario1LinearFlow._read_run_log(Path(tmpdir), thread_id)
+            initial_log = TestScenario1LinearFlow._read_run_log(base_dir, thread_id)
             initial_started_at = initial_log["started_at"]
 
             engine.resume_flow(
@@ -282,7 +283,7 @@ class TestScenario4CheckpointResume:
                 flow_path,
             )
 
-            resumed_log = TestScenario1LinearFlow._read_run_log(Path(tmpdir), thread_id)
+            resumed_log = TestScenario1LinearFlow._read_run_log(base_dir, thread_id)
             resumed_state_names = [s["name"] for s in resumed_log["states"]]
             resumed_started_at = resumed_log["started_at"]
 
@@ -315,7 +316,7 @@ class TestScenario4CheckpointResume:
                 base_dir=base_dir,
             )
 
-            run_log = TestScenario1LinearFlow._read_run_log(Path(tmpdir), thread_id)
+            run_log = TestScenario1LinearFlow._read_run_log(base_dir, thread_id)
 
             assert run_log["thread_id"] == thread_id
             assert "started_at" in run_log

--- a/tests/integration/test_extraction_flow.py
+++ b/tests/integration/test_extraction_flow.py
@@ -64,6 +64,7 @@ class TestParallelBranchExtraction:
         """Regression test: parallel branch extraction failure should be marked as error with exit_code 1."""
         flow = Flow(
             name="Parallel Extraction Failure Test",
+            description="Test flow for parallel branch extraction failure testing",
             start_at="parallel_state",
             states={
                 "parallel_state": ParallelState(

--- a/tests/integration/test_hook_streaming_interaction.py
+++ b/tests/integration/test_hook_streaming_interaction.py
@@ -1,0 +1,608 @@
+"""Integration tests for T026: Hook + Streaming Interaction.
+
+Verifies that hooks fire correctly around states that produce streaming output.
+
+Key interactions to test:
+- on_start hook fires before the task node (before streaming begins)
+- on_complete hook fires after the task node (after streaming ends)
+- StreamLogger log files are created correctly alongside hook execution
+- Hook data files (input.json/output.json) are created correctly
+- Order of operations: on_start → streaming → on_complete
+- Both streaming output AND hook files coexist correctly
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.core.compiler import compile_flow, _wrap_with_hooks
+from fdsx.core.hooks import INPUT_FILENAME, OUTPUT_FILENAME, HOOKS_DIR_NAME
+from fdsx.logging.recorder import RUNS_DIR_NAME, LOGS_DIR_NAME
+from fdsx.logging.stream_logger import LOG_FILE_SUFFIX, StreamLogger
+from fdsx.models.flow import HookEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_recorder(thread_id: str = "test-thread", flow_name: str = "TestFlow") -> MagicMock:
+    recorder = MagicMock()
+    recorder.thread_id = thread_id
+    recorder.flow_name = flow_name
+    return recorder
+
+
+def _make_hook(command: str, on_failure: str = "warn") -> HookEntry:
+    return HookEntry(command=command, on_failure=on_failure)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# T026: Hook + Streaming interaction tests
+# ---------------------------------------------------------------------------
+
+
+class TestHookFiringOrderWithStreaming:
+    """Verify hooks fire in correct order relative to streaming output."""
+
+    def test_on_start_fires_before_node_output(self, tmp_path: Path) -> None:
+        """on_start hook fires before the task node produces any streaming output.
+
+        Execution order must be: on_start hook → streaming → on_complete hook.
+        """
+        execution_order: list[str] = []
+
+        def streaming_node(state_dict: dict) -> dict:
+            """Simulates a node that produces streaming output."""
+            execution_order.append("node_started")
+            # Simulate streaming output that would be generated inside node
+            execution_order.append("node_streaming")
+            execution_order.append("node_completed")
+            return {**state_dict, "result": "streamed output"}
+
+        on_start = [_make_hook("echo on_start")]
+        on_complete = [_make_hook("echo on_complete")]
+        recorder = _make_recorder(thread_id="hook-stream-tid")
+
+        wrapped = _wrap_with_hooks(
+            streaming_node,
+            "StreamingState",
+            on_start,
+            on_complete,
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "data.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                mock_exec.side_effect = lambda hooks, **kw: execution_order.append(
+                    f"hook_{kw['status']}"
+                )
+                wrapped({"input": "value"})
+
+        # on_start fires before node executes
+        assert execution_order.index("hook_starting") < execution_order.index("node_started"), (
+            "on_start hook must fire before node execution starts"
+        )
+        # node executes before on_complete fires
+        assert execution_order.index("node_completed") < execution_order.index("hook_completed"), (
+            "on_complete hook must fire after node execution completes"
+        )
+
+    def test_streaming_log_file_and_hook_data_files_coexist(self, tmp_path: Path) -> None:
+        """StreamLogger log files and hook data JSON files exist in the correct directories.
+
+        - Log files: .fdsx/runs/<thread-id>/logs/<state-name>.log
+        - Hook files: .fdsx/runs/<thread-id>/hooks/<state-name>/input.json, output.json
+        """
+        thread_id = "coexist-tid"
+        runs_dir = tmp_path / RUNS_DIR_NAME
+        log_dir = runs_dir / thread_id / LOGS_DIR_NAME
+        fdsx_base_dir = tmp_path
+
+        # Create a real StreamLogger (not mocked) to verify log file creation
+        stream_logger = StreamLogger("CoexistState", log_dir)
+
+        # Simulate what the task node does: stream output then close
+        stream_logger.on_stdout("streaming line one")
+        stream_logger.on_stderr("streaming error line")
+        stream_logger.close()
+
+        # Verify log file was created
+        log_file = log_dir / f"CoexistState{LOG_FILE_SUFFIX}"
+        assert log_file.exists(), f"Log file not created at {log_file}"
+        content = log_file.read_text()
+        assert "streaming line one" in content
+        assert "streaming error line" in content
+
+        # Now also write hook data files (simulating what _wrap_with_hooks does)
+        from fdsx.core.hooks import write_hook_data
+
+        input_path = write_hook_data(
+            {"input": "data"},
+            state_name="CoexistState",
+            filename=INPUT_FILENAME,
+            thread_id=thread_id,
+            base_dir=fdsx_base_dir,
+        )
+        output_path = write_hook_data(
+            {"result": "streamed output"},
+            state_name="CoexistState",
+            filename=OUTPUT_FILENAME,
+            thread_id=thread_id,
+            base_dir=fdsx_base_dir,
+        )
+
+        # Both log file and hook data files should coexist
+        assert log_file.exists()
+        assert input_path.exists()
+        assert output_path.exists()
+
+        # Verify hook data files are named correctly
+        assert input_path.name == INPUT_FILENAME
+        assert output_path.name == OUTPUT_FILENAME
+
+        # Verify they are in the hooks subdirectory for the state
+        assert input_path.parent.name == "CoexistState"
+        assert input_path.parent.parent.name == HOOKS_DIR_NAME
+        assert input_path.parent.parent.parent.name == thread_id
+
+    def test_hook_fires_correctly_with_streaming_task_state(self, tmp_path: Path) -> None:
+        """Full integration: hooks fire around a system provider task that produces output.
+
+        Uses compile_flow with a real system provider task so that:
+        - StreamLogger is instantiated inside the task node
+        - Hooks are wired by _wrap_with_hooks
+        - on_start fires before the system command runs
+        - on_complete fires after the system command completes
+        """
+        flow_yaml = """
+name: Hook Streaming Integration
+description: Test hooks + streaming interaction
+start_at: produce_output
+states:
+  produce_output:
+    type: task
+    provider: system
+    command: "echo streaming output line"
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "echo hook_start"
+      on_complete:
+        - command: "echo hook_complete"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "hook-stream-full-tid"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="Hook Streaming Integration")
+        log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        hook_calls: list[dict] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append({"state_name": state_name, "status": status})
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": thread_id}}
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
+
+        # Both hooks should have fired
+        starting_calls = [c for c in hook_calls if c["status"] == "starting"]
+        completed_calls = [c for c in hook_calls if c["status"] == "completed"]
+
+        assert len(starting_calls) >= 1, "on_start hook should have fired"
+        assert len(completed_calls) >= 1, "on_complete hook should have fired"
+        assert starting_calls[0]["state_name"] == "produce_output"
+        assert completed_calls[0]["state_name"] == "produce_output"
+
+    def test_streaming_output_appears_on_stderr_with_hooks_configured(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """When hooks are configured, streaming output still appears on stderr with [prefix].
+
+        This verifies the hook wrapper does not interfere with streaming output.
+        """
+        flow_yaml = """
+name: Hook + Streaming Terminal
+description: Verify terminal output not affected by hooks
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo hello_from_task"
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "echo hook_start"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "stream-terminal-tid"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="Hook + Streaming Terminal")
+        log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks"):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": thread_id}}
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
+
+        captured = capsys.readouterr()
+        # Streaming output should appear on stderr with [state_name] prefix
+        assert "[step1] hello_from_task" in captured.err, (
+            f"Expected '[step1] hello_from_task' in stderr, got: {captured.err!r}"
+        )
+
+    def test_log_file_created_when_hooks_also_configured(self, tmp_path: Path) -> None:
+        """Per-state log file is created when hooks are also configured.
+
+        This verifies hook execution does not interfere with StreamLogger log file creation.
+        """
+        flow_yaml = """
+name: Log + Hook Coexistence
+description: Log file and hooks together
+start_at: logstep
+states:
+  logstep:
+    type: task
+    provider: system
+    command: "echo logged_output"
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "echo hook_start"
+      on_complete:
+        - command: "echo hook_done"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "log-hook-tid"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="Log + Hook Coexistence")
+        log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks"):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": thread_id}}
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
+
+        # Per-state log file should exist
+        log_file = log_dir / f"logstep{LOG_FILE_SUFFIX}"
+        assert log_file.exists(), f"Log file should exist at {log_file}"
+
+        content = log_file.read_text()
+        assert "logged_output" in content
+
+
+class TestHookInputOutputDataWithStreaming:
+    """Verify hook data files contain correct data when state produces streaming output."""
+
+    def test_input_json_contains_state_before_streaming(self, tmp_path: Path) -> None:
+        """input.json is written with the pre-execution state (before streaming).
+
+        This verifies write_hook_data for input.json captures state BEFORE the
+        task node runs (and before streaming begins).
+        """
+        initial_state = {"setup_value": "initial", "_meta": {}}
+        captured_input_data: list[dict] = []
+
+        def node_fn(state_dict: dict) -> dict:
+            return {**state_dict, "result": "done"}
+
+        hook = _make_hook("echo start")
+        recorder = _make_recorder(thread_id="input-data-tid")
+
+        wrapped = _wrap_with_hooks(
+            node_fn,
+            "DataState",
+            [hook],
+            [],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        def fake_write(data, *, state_name, filename, thread_id, base_dir):
+            if filename == INPUT_FILENAME:
+                captured_input_data.append(dict(data))
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write):
+            with patch("fdsx.core.compiler.execute_hooks"):
+                wrapped(initial_state)
+
+        assert len(captured_input_data) == 1
+        assert captured_input_data[0] == initial_state
+
+    def test_output_json_contains_state_after_streaming(self, tmp_path: Path) -> None:
+        """output.json is written with the post-execution state (after streaming).
+
+        This verifies write_hook_data for output.json captures the result produced
+        by the task node (the state AFTER streaming is complete).
+        """
+        captured_output_data: list[dict] = []
+
+        def node_fn(state_dict: dict) -> dict:
+            # Simulate a node that processes streaming output and returns result
+            return {**state_dict, "result": "streamed_and_processed"}
+
+        hook = _make_hook("echo complete")
+        recorder = _make_recorder(thread_id="output-data-tid")
+
+        wrapped = _wrap_with_hooks(
+            node_fn,
+            "OutputState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        def fake_write(data, *, state_name, filename, thread_id, base_dir):
+            if filename == OUTPUT_FILENAME:
+                captured_output_data.append(dict(data))
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write):
+            with patch("fdsx.core.compiler.execute_hooks"):
+                wrapped({"input": "value"})
+
+        assert len(captured_output_data) == 1
+        assert captured_output_data[0]["result"] == "streamed_and_processed"
+
+
+class TestHookAbortWithStreaming:
+    """Verify abort policy behaves correctly when streaming is also configured."""
+
+    def test_abort_on_start_prevents_streaming(self, tmp_path: Path) -> None:
+        """When on_start hook aborts, the task node (including streaming) does not execute."""
+        from fdsx.core.hooks import HookAbortError
+
+        node_executed = []
+
+        def streaming_node(state_dict: dict) -> dict:
+            node_executed.append(True)
+            # This would be where streaming happens
+            return {**state_dict, "result": "should not reach"}
+
+        hook = _make_hook("abort-script", on_failure="abort")
+        recorder = _make_recorder()
+
+        wrapped = _wrap_with_hooks(
+            streaming_node,
+            "AbortStreamState",
+            [hook],
+            [],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "in.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                mock_exec.side_effect = HookAbortError("abort-script", 1)
+                with pytest.raises(HookAbortError):
+                    wrapped({"input": "x"})
+
+        # Node (and its streaming) should not have executed
+        assert len(node_executed) == 0, (
+            "Node (and streaming) should not execute when on_start aborts"
+        )
+
+    def test_on_complete_fires_with_failed_status_when_task_node_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """on_complete fires with status='failed' when the task node raises.
+
+        This covers the case where a streaming task fails mid-execution.
+        """
+
+        def failing_node(state_dict: dict) -> dict:
+            raise RuntimeError("provider failed")
+
+        hook = _make_hook("echo on_complete")
+        recorder = _make_recorder()
+
+        wrapped = _wrap_with_hooks(
+            failing_node,
+            "FailingStreamState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "out.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                with pytest.raises(RuntimeError, match="provider failed"):
+                    wrapped({"x": 1})
+
+        assert mock_exec.call_count == 1
+        exec_kwargs = mock_exec.call_args[1]
+        assert exec_kwargs["status"] == "failed", (
+            "on_complete should fire with 'failed' status when task node raises"
+        )
+
+
+class TestMultiStateHookStreamingInteraction:
+    """Verify hook+streaming works correctly in a multi-state flow."""
+
+    def test_hooks_fire_for_each_state_independently(self, tmp_path: Path) -> None:
+        """Each state fires hooks independently; streaming is separate per state."""
+        flow_yaml = """
+name: Multi State Hook Stream
+description: Multi-state hook and streaming
+start_at: step1
+hooks:
+  on_start:
+    - command: "echo flow_start"
+  on_complete:
+    - command: "echo flow_complete"
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo step1_output"
+    result_path: $.step1_result
+    next: step2
+  step2:
+    type: task
+    provider: system
+    command: "echo step2_output"
+    result_path: $.step2_result
+    end: true
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "multi-state-hook-tid"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="Multi State Hook Stream")
+        log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        hook_calls: list[dict] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append({"state_name": state_name, "status": status})
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": thread_id}}
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
+
+        # Both states should have hooks fired
+        state_names_that_fired = {c["state_name"] for c in hook_calls}
+        assert "step1" in state_names_that_fired, "step1 hooks should have fired"
+        assert "step2" in state_names_that_fired, "step2 hooks should have fired"
+
+        # Both starting and completed for each state
+        step1_starting = [c for c in hook_calls if c["state_name"] == "step1" and c["status"] == "starting"]
+        step1_completed = [c for c in hook_calls if c["state_name"] == "step1" and c["status"] == "completed"]
+        step2_starting = [c for c in hook_calls if c["state_name"] == "step2" and c["status"] == "starting"]
+        step2_completed = [c for c in hook_calls if c["state_name"] == "step2" and c["status"] == "completed"]
+
+        assert len(step1_starting) == 1, "step1 on_start should fire once"
+        assert len(step1_completed) == 1, "step1 on_complete should fire once"
+        assert len(step2_starting) == 1, "step2 on_start should fire once"
+        assert len(step2_completed) == 1, "step2 on_complete should fire once"
+
+    def test_log_files_created_per_state_with_hooks(self, tmp_path: Path) -> None:
+        """Each state creates its own log file even when hooks are configured at flow level."""
+        flow_yaml = """
+name: Per State Logs With Hooks
+description: Log files per state with flow hooks
+start_at: stateA
+hooks:
+  on_start:
+    - command: "echo flow_hook"
+states:
+  stateA:
+    type: task
+    provider: system
+    command: "echo output_from_A"
+    result_path: $.a_result
+    next: stateB
+  stateB:
+    type: task
+    provider: system
+    command: "echo output_from_B"
+    result_path: $.b_result
+    end: true
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "per-state-log-tid"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="Per State Logs With Hooks")
+        log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks"):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": thread_id}}
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
+
+        # Both state log files should exist
+        log_A = log_dir / f"stateA{LOG_FILE_SUFFIX}"
+        log_B = log_dir / f"stateB{LOG_FILE_SUFFIX}"
+        assert log_A.exists(), f"Log file for stateA should exist at {log_A}"
+        assert log_B.exists(), f"Log file for stateB should exist at {log_B}"
+
+        # Content should be from respective states
+        assert "output_from_A" in log_A.read_text()
+        assert "output_from_B" in log_B.read_text()

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -1,0 +1,971 @@
+"""Integration tests for Phase 8: Hooks System Wiring (T022-T023).
+
+Tests:
+- _wrap_with_hooks() wraps a node with on_start/on_complete hooks
+- Hooks fire correctly for TaskState, ChoiceState, PassState, ParallelState, WaitState
+- Hook levels merge in correct order: global → flow → state
+- Abort-policy hook failure halts the node execution
+- Warn-policy hook failure continues execution
+- ParallelState hooks wrap dispatch/collector, not branch executor
+- WaitState on_start fires in notify node, on_complete fires in interrupt node
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from fdsx.core.compiler import _wrap_with_hooks
+from fdsx.core.hooks import INPUT_FILENAME, OUTPUT_FILENAME, RUNS_DIR_NAME, HOOKS_DIR_NAME
+from fdsx.models.flow import HookConfig, HookEntry
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_recorder(thread_id: str = "test-thread", flow_name: str = "TestFlow") -> MagicMock:
+    recorder = MagicMock()
+    recorder.thread_id = thread_id
+    recorder.flow_name = flow_name
+    return recorder
+
+
+def _make_hook(command: str, on_failure: str = "warn") -> HookEntry:
+    return HookEntry(command=command, on_failure=on_failure)  # type: ignore[arg-type]
+
+
+def _simple_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+    """A simple node that adds a marker to the state."""
+    return {**state_dict, "executed": True}
+
+
+# ---------------------------------------------------------------------------
+# T022: _wrap_with_hooks() unit-level integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestWrapWithHooksNoOp:
+    """When both hook lists are empty, _wrap_with_hooks returns the original function."""
+
+    def test_returns_original_fn_when_no_hooks(self) -> None:
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "MyState",
+            [],
+            [],
+            recorder=None,
+            fdsx_base_dir=None,
+        )
+        assert wrapped is _simple_node
+
+    def test_no_subprocess_calls_when_no_hooks(self, tmp_path: Path) -> None:
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "MyState",
+            [],
+            [],
+            recorder=_make_recorder(),
+            fdsx_base_dir=tmp_path,
+        )
+        with patch("subprocess.run") as mock_run:
+            result = wrapped({"key": "value"})
+        mock_run.assert_not_called()
+        assert result["executed"] is True
+
+
+class TestWrapWithHooksOnStart:
+    """on_start hooks fire before node execution with status='starting'."""
+
+    def test_on_start_hook_fires_before_node(self, tmp_path: Path) -> None:
+        execution_order: list[str] = []
+
+        def tracking_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            execution_order.append("node")
+            return {**state_dict, "executed": True}
+
+        hook = _make_hook("echo start")
+        on_start = [hook]
+
+        recorder = _make_recorder(thread_id="tid-001")
+        wrapped = _wrap_with_hooks(
+            tracking_node,
+            "State1",
+            on_start,
+            [],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+            with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+                mock_write.return_value = tmp_path / "input.json"
+                result = wrapped({"x": 1})
+
+        assert result["executed"] is True
+        # execute_hooks called once (on_start)
+        assert mock_exec.call_count == 1
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["status"] == "starting"
+        assert call_kwargs["state_name"] == "State1"
+        assert call_kwargs["thread_id"] == "tid-001"
+        assert call_kwargs["flow_name"] == "TestFlow"
+
+    def test_input_json_written_before_on_start(self, tmp_path: Path) -> None:
+        hook = _make_hook("echo start")
+        recorder = _make_recorder(thread_id="tid-input")
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "StateX",
+            [hook],
+            [],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        call_order: list[str] = []
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.side_effect = lambda *a, **kw: (
+                call_order.append(f"write:{kw.get('filename', '')}"),
+                tmp_path / kw.get("filename", "out.json"),
+            )[-1]
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                mock_exec.side_effect = lambda *a, **kw: call_order.append("exec_hook")
+                wrapped({"y": 2})
+
+        assert call_order[0] == f"write:{INPUT_FILENAME}"
+        assert call_order[1] == "exec_hook"
+
+
+class TestWrapWithHooksOnComplete:
+    """on_complete hooks fire after node execution with status='completed'."""
+
+    def test_on_complete_hook_fires_after_node(self, tmp_path: Path) -> None:
+        hook = _make_hook("echo complete")
+        recorder = _make_recorder(thread_id="tid-002")
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "State2",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+            with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+                mock_write.return_value = tmp_path / "out.json"
+                result = wrapped({"a": 1})
+
+        assert result["executed"] is True
+        assert mock_exec.call_count == 1
+        call_kwargs = mock_exec.call_args[1]
+        assert call_kwargs["status"] == "completed"
+        assert call_kwargs["state_name"] == "State2"
+
+    def test_output_json_written_before_on_complete(self, tmp_path: Path) -> None:
+        hook = _make_hook("echo done")
+        recorder = _make_recorder(thread_id="tid-output")
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "StateY",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        call_order: list[str] = []
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.side_effect = lambda *a, **kw: (
+                call_order.append(f"write:{kw.get('filename', '')}"),
+                tmp_path / kw.get("filename", "out.json"),
+            )[-1]
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                mock_exec.side_effect = lambda *a, **kw: call_order.append("exec_hook")
+                wrapped({"z": 3})
+
+        assert call_order[0] == f"write:{INPUT_FILENAME}"
+        assert call_order[1] == f"write:{OUTPUT_FILENAME}"
+        assert call_order[2] == "exec_hook"
+
+
+class TestWrapWithHooksBothEvents:
+    """When both hook lists are non-empty, both fire in correct order."""
+
+    def test_start_fires_before_node_complete_fires_after(self, tmp_path: Path) -> None:
+        execution_order: list[str] = []
+
+        def tracking_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            execution_order.append("node")
+            return {**state_dict, "done": True}
+
+        on_start = [_make_hook("start-hook")]
+        on_complete = [_make_hook("complete-hook")]
+        recorder = _make_recorder()
+
+        wrapped = _wrap_with_hooks(
+            tracking_node,
+            "MyState",
+            on_start,
+            on_complete,
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+            with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+                mock_write.return_value = tmp_path / "x.json"
+                wrapped({"input": "value"})
+
+        # execute_hooks called twice: once for on_start, once for on_complete
+        assert mock_exec.call_count == 2
+        first_call = mock_exec.call_args_list[0]
+        second_call = mock_exec.call_args_list[1]
+        assert first_call[1]["status"] == "starting"
+        assert second_call[1]["status"] == "completed"
+
+
+class TestWrapWithHooksDataFiles:
+    """Hook data files are written with correct state_name, thread_id, and filenames."""
+
+    def test_input_json_uses_correct_params(self, tmp_path: Path) -> None:
+        hook = _make_hook("echo x")
+        recorder = _make_recorder(thread_id="my-thread", flow_name="MyFlow")
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "DataState",
+            [hook],
+            [],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "in.json"
+            with patch("fdsx.core.compiler.execute_hooks"):
+                wrapped({"val": 42})
+
+        # First call = input.json
+        first_call = mock_write.call_args_list[0]
+        assert first_call[1]["state_name"] == "DataState"
+        assert first_call[1]["filename"] == INPUT_FILENAME
+        assert first_call[1]["thread_id"] == "my-thread"
+        assert first_call[1]["base_dir"] == tmp_path
+
+    def test_output_json_uses_node_result(self, tmp_path: Path) -> None:
+        hook = _make_hook("echo y")
+        recorder = _make_recorder(thread_id="my-thread")
+
+        def my_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            return {"result": "node_output"}
+
+        wrapped = _wrap_with_hooks(
+            my_node,
+            "ResultState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "out.json"
+            with patch("fdsx.core.compiler.execute_hooks"):
+                wrapped({"in": "data"})
+
+        # Second call = output.json, data = node result
+        second_call = mock_write.call_args_list[1]
+        assert second_call[0][0] == {"result": "node_output"}  # positional arg
+        assert second_call[1]["filename"] == OUTPUT_FILENAME
+
+
+class TestWrapWithHooksAbortBehavior:
+    """Abort-policy hook failure raises HookAbortError which halts the node."""
+
+    def test_abort_on_start_prevents_node_execution(self, tmp_path: Path) -> None:
+        from fdsx.core.hooks import HookAbortError
+
+        executed = []
+
+        def tracking_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            executed.append(True)
+            return state_dict
+
+        hook = _make_hook("fail-script", on_failure="abort")
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            tracking_node,
+            "AbortState",
+            [hook],
+            [],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "in.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                mock_exec.side_effect = HookAbortError("fail-script", 1)
+                with pytest.raises(HookAbortError):
+                    wrapped({"x": 1})
+
+        assert len(executed) == 0, "Node should not execute after abort"
+
+    def test_abort_on_complete_raises_after_node(self, tmp_path: Path) -> None:
+        from fdsx.core.hooks import HookAbortError
+
+        executed = []
+
+        def tracking_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            executed.append(True)
+            return {**state_dict, "done": True}
+
+        hook = _make_hook("fail-after", on_failure="abort")
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            tracking_node,
+            "AbortAfterState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "out.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                mock_exec.side_effect = HookAbortError("fail-after", 2)
+                with pytest.raises(HookAbortError):
+                    wrapped({"x": 1})
+
+        assert len(executed) == 1, "Node should have executed before abort"
+
+
+class TestWrapWithHooksNodeFailure:
+    """on_complete hooks fire with status='failed' when the node raises, then the error re-raises."""
+
+    def test_on_complete_fires_with_failed_status_when_node_raises(self, tmp_path: Path) -> None:
+        """on_complete hooks fire with status='failed' when node raises RuntimeError."""
+
+        def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("node exploded")
+
+        hook = _make_hook("echo on_complete")
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            failing_node,
+            "FailState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "out.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                with pytest.raises(RuntimeError, match="node exploded"):
+                    wrapped({"x": 1})
+
+        assert mock_exec.call_count == 1
+        exec_kwargs = mock_exec.call_args[1]
+        assert exec_kwargs["status"] == "failed"
+
+    def test_node_error_is_reraised_after_on_complete_hooks(self, tmp_path: Path) -> None:
+        """The original exception is re-raised after on_complete hooks run."""
+        original_error = ValueError("original error")
+
+        def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            raise original_error
+
+        hook = _make_hook("echo on_complete")
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            failing_node,
+            "ReraiseState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "out.json"
+            with patch("fdsx.core.compiler.execute_hooks"):
+                with pytest.raises(ValueError) as exc_info:
+                    wrapped({})
+
+        assert exc_info.value is original_error
+
+    def test_output_json_written_with_input_state_on_failure(self, tmp_path: Path) -> None:
+        """When node fails, output.json is written with the input state_dict (fallback)."""
+
+        def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+        hook = _make_hook("echo h")
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            failing_node,
+            "FallbackState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        write_data_calls: list[dict] = []
+
+        def fake_write(data, *, state_name, filename, thread_id, base_dir):
+            write_data_calls.append({"data": data, "filename": filename})
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write):
+            with patch("fdsx.core.compiler.execute_hooks"):
+                with pytest.raises(RuntimeError):
+                    wrapped({"original": "state"})
+
+        output_write = next(c for c in write_data_calls if c["filename"] == OUTPUT_FILENAME)
+        assert output_write["data"] == {"original": "state"}, (
+            "output.json should contain the input state_dict as fallback on failure"
+        )
+
+    def test_both_on_start_and_on_complete_fire_with_correct_statuses_on_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """on_start fires with 'starting', on_complete fires with 'failed' when node raises."""
+
+        def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("fail")
+
+        on_start = [_make_hook("echo start")]
+        on_complete = [_make_hook("echo complete")]
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            failing_node,
+            "BothHooksFailState",
+            on_start,
+            on_complete,
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "x.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                with pytest.raises(RuntimeError):
+                    wrapped({"k": "v"})
+
+        assert mock_exec.call_count == 2
+        start_call = mock_exec.call_args_list[0]
+        complete_call = mock_exec.call_args_list[1]
+        assert start_call[1]["status"] == "starting"
+        assert complete_call[1]["status"] == "failed"
+
+
+class TestWrapWithHooksRecorderFallback:
+    """When recorder is None, thread_id and flow_name fall back to empty strings."""
+
+    def test_no_recorder_uses_empty_strings(self, tmp_path: Path) -> None:
+        hook = _make_hook("echo hook")
+        wrapped = _wrap_with_hooks(
+            _simple_node,
+            "NullRecorderState",
+            [hook],
+            [],
+            recorder=None,
+            fdsx_base_dir=tmp_path,
+        )
+
+        with patch("fdsx.core.compiler.write_hook_data") as mock_write:
+            mock_write.return_value = tmp_path / "in.json"
+            with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+                wrapped({"k": "v"})
+
+        write_kwargs = mock_write.call_args_list[0][1]
+        assert write_kwargs["thread_id"] == ""
+
+        exec_kwargs = mock_exec.call_args[1]
+        assert exec_kwargs["thread_id"] == ""
+        assert exec_kwargs["flow_name"] == ""
+
+
+# ---------------------------------------------------------------------------
+# T023: compile_flow integration tests — hooks wired for all node types
+# ---------------------------------------------------------------------------
+
+
+class TestCompileFlowHooksWiring:
+    """Verify compile_flow applies _wrap_with_hooks for all node types."""
+
+    def _make_simple_flow_yaml(self, hooks_yaml: str = "") -> str:
+        return f"""
+name: Hook Test Flow
+description: Test hooks wiring
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo hello"
+    result_path: $.result
+    end: true
+{hooks_yaml}
+"""
+
+    def test_task_state_hooks_fire_via_compile_flow(self, tmp_path: Path) -> None:
+        """on_start and on_complete hooks fire for TaskState via compile_flow."""
+        import yaml
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+        from fdsx.core.config import FdsxConfig
+        from fdsx.models.flow import HookConfig, HookEntry
+
+        flow_yaml = """
+name: Task Hook Flow
+description: Task with hooks
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "echo on_start"
+      on_complete:
+        - command: "echo on_complete"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        recorder = _make_recorder(thread_id="hooks-tid", flow_name="Task Hook Flow")
+        log_dir = tmp_path / ".fdsx" / "runs" / "hooks-tid" / "logs"
+
+        hook_calls: list[dict] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append({
+                "state_name": state_name,
+                "status": status,
+                "count": len(hooks),
+            })
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(
+                    flow,
+                    recorder=recorder,
+                    log_dir=log_dir,
+                )
+                # Run the graph
+                config_dict = {"configurable": {"thread_id": "hooks-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        starting_calls = [c for c in hook_calls if c["status"] == "starting"]
+        completed_calls = [c for c in hook_calls if c["status"] == "completed"]
+        assert len(starting_calls) >= 1, "on_start hooks should have fired"
+        assert len(completed_calls) >= 1, "on_complete hooks should have fired"
+        assert starting_calls[0]["state_name"] == "step1"
+        assert completed_calls[0]["state_name"] == "step1"
+
+    def test_flow_level_hooks_fire_for_all_states(self, tmp_path: Path) -> None:
+        """Flow-level hooks fire for all states in the flow."""
+        flow_yaml = """
+name: Flow Hook Test
+description: Flow-level hooks
+start_at: step1
+hooks:
+  on_start:
+    - command: "echo flow_start"
+  on_complete:
+    - command: "echo flow_complete"
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        recorder = _make_recorder(thread_id="flow-hook-tid", flow_name="Flow Hook Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / "flow-hook-tid" / "logs"
+
+        hook_calls: list[dict] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append({"status": status, "count": len(hooks)})
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": "flow-hook-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        assert any(c["status"] == "starting" for c in hook_calls), "on_start should fire"
+        assert any(c["status"] == "completed" for c in hook_calls), "on_complete should fire"
+
+    def test_config_level_hooks_merge_with_flow_and_state(self, tmp_path: Path) -> None:
+        """Config-level hooks are included via collect_hooks merge."""
+        flow_yaml = """
+name: Config Hook Test
+description: Config-level hooks
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+        from fdsx.core.config import FdsxConfig
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None
+
+        # Config with global hook
+        fdsx_config = FdsxConfig(
+            hooks=HookConfig(on_start=[HookEntry(command="echo global_start")])
+        )
+
+        recorder = _make_recorder(thread_id="config-hook-tid", flow_name="Config Hook Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / "config-hook-tid" / "logs"
+
+        hook_calls: list[list] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append([h.command for h in hooks])
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, config=fdsx_config, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": "config-hook-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        # Config-level hook should appear in the on_start call
+        all_commands = [cmd for call_cmds in hook_calls for cmd in call_cmds]
+        assert "echo global_start" in all_commands, (
+            f"Config-level hook not found in hook calls: {hook_calls}"
+        )
+
+    def test_hook_merge_order_global_flow_state(self, tmp_path: Path) -> None:
+        """Hooks merge in order: global (config) → flow → state."""
+        flow_yaml = """
+name: Merge Order Test
+description: Hook merge order
+start_at: step1
+hooks:
+  on_start:
+    - command: "flow-hook"
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "state-hook"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+        from fdsx.core.config import FdsxConfig
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None
+
+        fdsx_config = FdsxConfig(
+            hooks=HookConfig(on_start=[HookEntry(command="global-hook")])
+        )
+
+        recorder = _make_recorder(thread_id="merge-tid", flow_name="Merge Order Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / "merge-tid" / "logs"
+
+        captured_hooks: list[list[str]] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            if status == "starting":
+                captured_hooks.append([h.command for h in hooks])
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, config=fdsx_config, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": "merge-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        assert len(captured_hooks) == 1
+        cmds = captured_hooks[0]
+        assert cmds == ["global-hook", "flow-hook", "state-hook"], (
+            f"Expected global→flow→state order, got: {cmds}"
+        )
+
+    def test_no_hooks_configured_no_subprocess_calls(self, tmp_path: Path) -> None:
+        """When no hooks are configured at any level, no execute_hooks calls are made."""
+        flow_yaml = """
+name: No Hook Flow
+description: No hooks
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None
+
+        recorder = _make_recorder(thread_id="no-hook-tid")
+        log_dir = tmp_path / ".fdsx" / "runs" / "no-hook-tid" / "logs"
+
+        with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
+            compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+            config_dict = {"configurable": {"thread_id": "no-hook-tid"}}
+            list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        mock_exec.assert_not_called()
+
+    def test_pass_state_hooks_fire(self, tmp_path: Path) -> None:
+        """Hooks fire for PassState nodes."""
+        flow_yaml = """
+name: Pass Hook Flow
+description: PassState with hooks
+start_at: passme
+states:
+  passme:
+    type: pass
+    end: true
+    hooks:
+      on_start:
+        - command: "echo pass_start"
+      on_complete:
+        - command: "echo pass_done"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        recorder = _make_recorder(thread_id="pass-tid")
+        log_dir = tmp_path / ".fdsx" / "runs" / "pass-tid" / "logs"
+
+        hook_calls: list[dict] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append({"state_name": state_name, "status": status})
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": "pass-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        assert any(c["status"] == "starting" and c["state_name"] == "passme" for c in hook_calls)
+        assert any(c["status"] == "completed" and c["state_name"] == "passme" for c in hook_calls)
+
+    def test_parallel_state_hooks_wrap_dispatch_and_collector(self, tmp_path: Path) -> None:
+        """ParallelState: on_start fires in dispatch, on_complete fires in collector."""
+        flow_yaml = """
+name: Parallel Hook Flow
+description: ParallelState with hooks
+start_at: par
+states:
+  par:
+    type: parallel
+    result_path: $.results
+    end: true
+    hooks:
+      on_start:
+        - command: "echo par_start"
+      on_complete:
+        - command: "echo par_done"
+    branches:
+      - provider: system
+        command: "echo branch1"
+        retry: 0
+      - provider: system
+        command: "echo branch2"
+        retry: 0
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        recorder = _make_recorder(thread_id="par-tid")
+        log_dir = tmp_path / ".fdsx" / "runs" / "par-tid" / "logs"
+
+        hook_calls: list[dict] = []
+
+        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+            hook_calls.append({"state_name": state_name, "status": status, "count": len(hooks)})
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
+            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": "par-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        starting_calls = [c for c in hook_calls if c["status"] == "starting"]
+        completed_calls = [c for c in hook_calls if c["status"] == "completed"]
+
+        # on_start fires once (in dispatch node), on_complete fires once (in collector)
+        assert len(starting_calls) == 1
+        assert len(completed_calls) == 1
+        assert starting_calls[0]["state_name"] == "par"
+        assert completed_calls[0]["state_name"] == "par"
+
+    def test_fdsx_base_dir_derived_from_log_dir(self, tmp_path: Path) -> None:
+        """fdsx_base_dir is correctly derived as log_dir.parent.parent.parent."""
+        flow_yaml = """
+name: Base Dir Test
+description: Test base dir derivation
+start_at: s1
+states:
+  s1:
+    type: task
+    provider: system
+    command: "echo x"
+    result_path: $.r
+    end: true
+    hooks:
+      on_start:
+        - command: "echo h"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None
+
+        fdsx_root = tmp_path / ".fdsx"
+        log_dir = fdsx_root / "runs" / "test-tid" / "logs"
+        recorder = _make_recorder(thread_id="test-tid")
+
+        write_calls: list[dict] = []
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            write_calls.append({"base_dir": base_dir})
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch("fdsx.core.compiler.execute_hooks"):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+                config_dict = {"configurable": {"thread_id": "test-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        assert len(write_calls) > 0
+        assert write_calls[0]["base_dir"] == fdsx_root, (
+            f"Expected base_dir={fdsx_root}, got {write_calls[0]['base_dir']}"
+        )
+
+    def test_log_dir_none_passes_none_as_base_dir(self, tmp_path: Path) -> None:
+        """When log_dir is None, fdsx_base_dir is None (write_hook_data uses CWD default)."""
+        flow_yaml = """
+name: None Log Dir Test
+description: No log dir
+start_at: s1
+states:
+  s1:
+    type: task
+    provider: system
+    command: "echo x"
+    result_path: $.r
+    end: true
+    hooks:
+      on_start:
+        - command: "echo h"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        from fdsx.core.loader import load_flow
+        from fdsx.core.compiler import compile_flow
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None
+
+        recorder = _make_recorder(thread_id="none-logdir-tid")
+        write_calls: list[dict] = []
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            write_calls.append({"base_dir": base_dir})
+            return tmp_path / filename
+
+        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch("fdsx.core.compiler.execute_hooks"):
+                compiled = compile_flow(flow, recorder=recorder, log_dir=None)
+                config_dict = {"configurable": {"thread_id": "none-logdir-tid"}}
+                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+
+        assert len(write_calls) > 0
+        assert write_calls[0]["base_dir"] is None

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -12,15 +12,16 @@ Tests:
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from fdsx.core.compiler import _wrap_with_hooks
-from fdsx.core.hooks import INPUT_FILENAME, OUTPUT_FILENAME, RUNS_DIR_NAME, HOOKS_DIR_NAME
+from fdsx.core.compiler import _wrap_with_hooks, compile_flow
+from fdsx.core.config import FdsxConfig
+from fdsx.core.hooks import INPUT_FILENAME, OUTPUT_FILENAME
+from fdsx.core.loader import load_flow
 from fdsx.models.flow import HookConfig, HookEntry
 
 
@@ -506,29 +507,8 @@ class TestWrapWithHooksRecorderFallback:
 class TestCompileFlowHooksWiring:
     """Verify compile_flow applies _wrap_with_hooks for all node types."""
 
-    def _make_simple_flow_yaml(self, hooks_yaml: str = "") -> str:
-        return f"""
-name: Hook Test Flow
-description: Test hooks wiring
-start_at: step1
-states:
-  step1:
-    type: task
-    provider: system
-    command: "echo hello"
-    result_path: $.result
-    end: true
-{hooks_yaml}
-"""
-
     def test_task_state_hooks_fire_via_compile_flow(self, tmp_path: Path) -> None:
         """on_start and on_complete hooks fire for TaskState via compile_flow."""
-        import yaml
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-        from fdsx.core.config import FdsxConfig
-        from fdsx.models.flow import HookConfig, HookEntry
-
         flow_yaml = """
 name: Task Hook Flow
 description: Task with hooks
@@ -549,7 +529,6 @@ states:
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
 
-        from fdsx.core.loader import load_flow
         flow, errors = load_flow(flow_path)
         assert flow is not None, f"Load errors: {errors}"
 
@@ -608,9 +587,6 @@ states:
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
 
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-
         flow, errors = load_flow(flow_path)
         assert flow is not None, f"Load errors: {errors}"
 
@@ -650,10 +626,6 @@ states:
 """
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
-
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-        from fdsx.core.config import FdsxConfig
 
         flow, errors = load_flow(flow_path)
         assert flow is not None
@@ -709,10 +681,6 @@ states:
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
 
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-        from fdsx.core.config import FdsxConfig
-
         flow, errors = load_flow(flow_path)
         assert flow is not None
 
@@ -761,9 +729,6 @@ states:
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
 
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-
         flow, errors = load_flow(flow_path)
         assert flow is not None
 
@@ -795,9 +760,6 @@ states:
 """
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
-
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
 
         flow, errors = load_flow(flow_path)
         assert flow is not None, f"Load errors: {errors}"
@@ -849,9 +811,6 @@ states:
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
 
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-
         flow, errors = load_flow(flow_path)
         assert flow is not None, f"Load errors: {errors}"
 
@@ -901,9 +860,6 @@ states:
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
 
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
-
         flow, errors = load_flow(flow_path)
         assert flow is not None
 
@@ -947,9 +903,6 @@ states:
 """
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
-
-        from fdsx.core.loader import load_flow
-        from fdsx.core.compiler import compile_flow
 
         flow, errors = load_flow(flow_path)
         assert flow is not None

--- a/tests/integration/test_large_command.py
+++ b/tests/integration/test_large_command.py
@@ -1,0 +1,77 @@
+"""Integration tests for large command ARG_MAX stdin fallback (T003).
+
+Tests that SystemProvider handles commands exceeding 128KB correctly by
+automatically piping via stdin, simulating real workflow conditions where
+variable interpolation inflates command size.
+"""
+
+from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD
+from fdsx.providers.system import SystemProvider
+
+
+class TestLargeCommandIntegration:
+    """Integration tests for large command execution via SystemProvider."""
+
+    def test_system_provider_executes_large_command(self):
+        """SystemProvider.execute() succeeds with a command exceeding 128KB."""
+        provider = SystemProvider()
+
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        large_cmd = f"_large_var={padding}; echo 'workflow_complete'"
+
+        assert len(large_cmd.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
+
+        result = provider.execute(prompt=large_cmd)
+
+        assert result.exit_code == 0
+        assert result.stdout == "workflow_complete"
+
+    def test_system_provider_large_command_via_command_param(self):
+        """SystemProvider.execute(command=...) also handles large commands correctly."""
+        provider = SystemProvider()
+
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        large_cmd = f"_data={padding}; echo 'command_param_ok'"
+
+        result = provider.execute(prompt="ignored", command=large_cmd)
+
+        assert result.exit_code == 0
+        assert result.stdout == "command_param_ok"
+
+    def test_large_command_with_pipeline_simulating_variable_interpolation(self):
+        """Simulates variable interpolation inflating a command beyond 128KB.
+
+        In real workflows, a large state value (e.g., aggregated parallel review
+        outputs) gets substituted into the next task's command template.  This test
+        verifies the system provider handles such inflated commands end-to-end.
+        """
+        provider = SystemProvider()
+
+        # Simulate a large state value being interpolated into the command.
+        large_value = "review_output_line\n" * 7000  # ~130KB+ when embedded
+        # Embed the large value as a heredoc-style variable, then process it
+        large_cmd = f"large_state='{large_value}'; echo \"$large_state\" | wc -l | tr -d ' '"
+
+        if len(large_cmd.encode("utf-8")) < ARG_MAX_STDIN_THRESHOLD:
+            # If the constructed command doesn't hit the threshold, pad it
+            padding = "x" * (ARG_MAX_STDIN_THRESHOLD - len(large_cmd.encode("utf-8")))
+            large_cmd = f"_pad={padding}; {large_cmd}"
+
+        assert len(large_cmd.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
+
+        result = provider.execute(prompt=large_cmd)
+
+        assert result.exit_code == 0
+        # Output should be a number (line count) — confirming shell executed correctly
+        assert result.stdout.strip().isdigit()
+
+    def test_large_command_exit_code_propagated(self):
+        """Non-zero exit codes from large commands are correctly propagated."""
+        provider = SystemProvider()
+
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        large_cmd = f"_pad={padding}; exit 7"
+
+        result = provider.execute(prompt=large_cmd)
+
+        assert result.exit_code == 7

--- a/tests/integration/test_parallel_flow.py
+++ b/tests/integration/test_parallel_flow.py
@@ -63,6 +63,7 @@ class TestParallelMinSuccess:
 
         flow = Flow(
             name="Parallel All Fail",
+            description="Test flow for min_success failure",
             start_at="parallel_state",
             states={
                 "parallel_state": ParallelState(

--- a/tests/integration/test_parallel_flow.py
+++ b/tests/integration/test_parallel_flow.py
@@ -4,6 +4,7 @@ import pytest
 
 from fdsx.core.engine import run_flow
 from fdsx.core.loader import load_flow
+from fdsx.logging.recorder import LOGS_DIR_NAME, RUNS_DIR_NAME
 
 
 class TestParallelFlow:
@@ -98,3 +99,117 @@ class TestParallelMinSuccess:
 
         with pytest.raises(RuntimeError, match="only .* branches succeeded"):
             compiled.graph.invoke({})
+
+
+class TestParallelBranchLabeling:
+    """T012: Verify parallel branch StreamLogger labeling (FR-2.2, FR-2.3, FR-2.4)."""
+
+    def test_parallel_branches_use_state_name_label(self, tmp_path, capsys):
+        """Each branch's terminal output is labeled with the parallel state name.
+
+        FR-2.2: prefix is '[state_name]', no branch index suffix.
+        FR-2.3: output from all branches is labeled with the same state name.
+        """
+        base_dir = tmp_path / ".fdsx"
+        run_flow(
+            flow_path=Path("tests/fixtures/parallel_review.yaml"),
+            base_dir=base_dir,
+        )
+
+        captured = capsys.readouterr()
+        # verify no branch-index suffixed labels appear
+        for line in captured.err.splitlines():
+            if line.startswith("["):
+                label_end = line.find("]")
+                label = line[1:label_end]
+                # Labels must not contain numeric suffixes like "review_parallel-0"
+                assert not label.endswith(("-0", "-1", "-2")), (
+                    f"Branch index suffix found in label: {label!r}"
+                )
+
+    def test_parallel_log_files_created_per_state(self, tmp_path):
+        """Each parallel state produces a log file named after the state (FR-2.4).
+
+        Verifies that .fdsx/runs/<thread_id>/logs/<state_name>.log is created.
+        No branch index suffix in the filename.
+        """
+        from fdsx.models.flow import Branch, Flow, ParallelState
+
+        flow = Flow(
+            name="Log File Test",
+            description="Parallel log file test",
+            start_at="review_parallel",
+            states={
+                "review_parallel": ParallelState(
+                    type="parallel",
+                    branches=[
+                        Branch(provider="system", command="echo alpha", retry=0),
+                        Branch(provider="system", command="echo beta", retry=0),
+                    ],
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        from fdsx.core.compiler import compile_flow
+
+        base_dir = tmp_path / ".fdsx"
+        thread_id = "test-parallel-log"
+        log_dir = base_dir / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        from fdsx.logging.recorder import RunRecorder
+
+        recorder = RunRecorder(thread_id=thread_id, flow_name="Log File Test")
+        compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+        compiled.graph.invoke({})
+
+        # Log file for the parallel state should exist
+        log_file = log_dir / "review_parallel.log"
+        assert log_file.exists(), f"Expected log file at {log_file}"
+
+        content = log_file.read_text(encoding="utf-8")
+        # Both branches' output should be in the same log file
+        assert "alpha" in content
+        assert "beta" in content
+
+        # No branch-index-suffixed log files should exist
+        assert not (log_dir / "review_parallel-0.log").exists()
+        assert not (log_dir / "review_parallel-1.log").exists()
+
+    def test_no_log_file_for_empty_output_branch(self, tmp_path):
+        """No log file is created when a branch produces no output (FR-2.6)."""
+        from fdsx.models.flow import Branch, Flow, ParallelState
+
+        flow = Flow(
+            name="Empty Log Test",
+            description="Branch with no output",
+            start_at="parallel_state",
+            states={
+                "parallel_state": ParallelState(
+                    type="parallel",
+                    branches=[
+                        Branch(provider="system", command="true", retry=0),
+                    ],
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        from fdsx.core.compiler import compile_flow
+
+        base_dir = tmp_path / ".fdsx"
+        thread_id = "test-empty-log"
+        log_dir = base_dir / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
+
+        from fdsx.logging.recorder import RunRecorder
+
+        recorder = RunRecorder(thread_id=thread_id, flow_name="Empty Log Test")
+        compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+        compiled.graph.invoke({})
+
+        log_file = log_dir / "parallel_state.log"
+        assert not log_file.exists(), (
+            f"Log file should not exist for state with no output: {log_file}"
+        )

--- a/tests/integration/test_provider_options.py
+++ b/tests/integration/test_provider_options.py
@@ -1,0 +1,347 @@
+"""Integration tests for end-to-end provider options wiring (T019).
+
+Tests verify that provider options flow correctly through:
+  get_provider → provider.execute (CLI flags)
+  config + workflow + task merge → compile_flow → provider.execute
+"""
+
+from unittest.mock import patch
+
+from fdsx.core.compiler import _merge_provider_options, compile_flow
+from fdsx.core.config import FdsxConfig, ProviderConfigs
+from fdsx.models.flow import Branch, Flow, ParallelState, TaskState
+from fdsx.providers.base import ProviderResult, get_provider
+from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
+from fdsx.providers.codex import CodexOptions, CodexProvider
+from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
+from fdsx.providers.system import SystemProvider
+
+
+# ---------------------------------------------------------------------------
+# Helper: fake ProviderResult for mocking _run_subprocess
+# ---------------------------------------------------------------------------
+
+FAKE_SUCCESS = ProviderResult(exit_code=0, stdout="ok", stderr="")
+
+
+def _make_single_task_flow(
+    provider: str = "claude",
+    model: str = "claude-sonnet",
+    task_provider_options: dict | None = None,
+    flow_providers: dict | None = None,
+) -> Flow:
+    """Build a minimal single-task flow."""
+    return Flow(
+        name="test",
+        description="Test flow",
+        start_at="step1",
+        states={
+            "step1": TaskState(
+                type="task",
+                provider=provider,
+                model=model,
+                prompt_template="do the thing",
+                result_path="$.result",
+                end=True,
+                provider_options=task_provider_options,
+            )
+        },
+        providers=flow_providers,
+    )
+
+
+def _make_parallel_flow(
+    branches: list[dict],
+) -> Flow:
+    """Build a minimal parallel-state flow."""
+    branch_objects = [Branch(**b) for b in branches]
+    return Flow(
+        name="test",
+        description="Test parallel flow",
+        start_at="parallel_step",
+        states={
+            "parallel_step": ParallelState(
+                type="parallel",
+                branches=branch_objects,
+                result_path="$.results",
+                end=True,
+            )
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# T019-1: claude with permission_mode passed to CLI
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeWithPermissionMode:
+    """Verify permission_mode is forwarded to the Claude CLI invocation."""
+
+    def test_claude_provider_appends_permission_mode_flag(self):
+        """ClaudeProvider.execute() appends --permission-mode to CLI args."""
+        options = ClaudeOptions(permission_mode="bypassPermissions")
+        provider = ClaudeProvider(options)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+            provider.execute(prompt="hello", model="claude-sonnet")
+
+        assert len(captured_args) == 1
+        args = captured_args[0]
+        assert "--permission-mode" in args
+        assert "bypassPermissions" in args
+        assert args[args.index("--permission-mode") + 1] == "bypassPermissions"
+
+    def test_claude_provider_no_options_no_extra_flags(self):
+        """ClaudeProvider with default options adds no extra flags to CLI args."""
+        provider = ClaudeProvider()
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+            provider.execute(prompt="hello", model="claude-sonnet")
+
+        args = captured_args[0]
+        assert "--permission-mode" not in args
+        assert "--dangerously-skip-permissions" not in args
+
+    def test_claude_dangerously_skip_permissions_flag(self):
+        """dangerously_skip_permissions=True appends the flag."""
+        options = ClaudeOptions(dangerously_skip_permissions=True)
+        provider = ClaudeProvider(options)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+            provider.execute(prompt="hello")
+
+        assert "--dangerously-skip-permissions" in captured_args[0]
+
+
+# ---------------------------------------------------------------------------
+# T019-2: config + workflow merge flows to execute()
+# ---------------------------------------------------------------------------
+
+
+class TestConfigWorkflowMerge:
+    """Verify config + workflow-level merge is reflected in provider CLI args."""
+
+    def test_config_options_applied_when_no_workflow_override(self):
+        """Config-level permission_mode is used when workflow doesn't override."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                claude=ClaudeOptions(permission_mode="acceptEdits"),
+            )
+        )
+        flow = _make_single_task_flow()
+        merged = _merge_provider_options(config, flow, "claude", None)
+
+        assert merged is not None
+        provider = get_provider("claude", merged)
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options.permission_mode == "acceptEdits"
+
+    def test_workflow_options_override_config(self):
+        """Workflow-level options override config-level for the same key."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                claude=ClaudeOptions(permission_mode="acceptEdits"),
+            )
+        )
+        flow = _make_single_task_flow(
+            flow_providers={"claude": {"permission_mode": "bypassPermissions"}}
+        )
+        merged = _merge_provider_options(config, flow, "claude", None)
+
+        assert merged is not None
+        provider = get_provider("claude", merged)
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options.permission_mode == "bypassPermissions"
+
+    def test_config_default_values_do_not_override_workflow(self):
+        """Config default booleans (False) do not suppress workflow-level True."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                claude=ClaudeOptions(permission_mode="acceptEdits"),
+                # dangerously_skip_permissions defaults to False
+            )
+        )
+        flow = _make_single_task_flow(
+            flow_providers={"claude": {"dangerously_skip_permissions": True}}
+        )
+        merged = _merge_provider_options(config, flow, "claude", None)
+
+        assert merged is not None
+        # permission_mode from config, dangerously_skip from workflow
+        assert merged.get("permission_mode") == "acceptEdits"
+        assert merged.get("dangerously_skip_permissions") is True
+
+
+# ---------------------------------------------------------------------------
+# T019-3: Task-level override
+# ---------------------------------------------------------------------------
+
+
+class TestTaskLevelOverride:
+    """Task-level provider_options overrides all higher levels."""
+
+    def test_task_override_wins_over_config_and_workflow(self):
+        """Task provider_options wins over config and workflow settings."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                claude=ClaudeOptions(permission_mode="acceptEdits"),
+            )
+        )
+        flow = _make_single_task_flow(
+            flow_providers={"claude": {"permission_mode": "plan"}},
+            task_provider_options={"permission_mode": "bypassPermissions"},
+        )
+        merged = _merge_provider_options(config, flow, "claude", flow.states["step1"].provider_options)  # type: ignore[union-attr]
+
+        assert merged is not None
+        assert merged["permission_mode"] == "bypassPermissions"
+
+    def test_task_override_applied_in_get_provider(self):
+        """get_provider respects task-level options passed directly."""
+        provider = get_provider("claude", {"permission_mode": "dontAsk"})
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options.permission_mode == "dontAsk"
+
+
+# ---------------------------------------------------------------------------
+# T019-4: Unchanged workflows without options
+# ---------------------------------------------------------------------------
+
+
+class TestUnchangedWorkflowsWithoutOptions:
+    """Workflows without any provider options continue to work normally."""
+
+    def test_merge_returns_none_for_flow_without_options(self):
+        """Flow with no providers/provider_options yields None merge result."""
+        config = FdsxConfig()  # no providers
+        flow = _make_single_task_flow()
+
+        merged = _merge_provider_options(config, flow, "claude", None)
+
+        assert merged is None
+
+    def test_get_provider_with_none_options_returns_default_provider(self):
+        """get_provider with None options returns provider with default options."""
+        provider = get_provider("claude", None)
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options == ClaudeOptions()
+
+    def test_system_provider_unaffected_by_options(self):
+        """System provider always ignores options."""
+        provider = get_provider("system", {"irrelevant": "value"})
+        assert isinstance(provider, SystemProvider)
+        # SystemProvider has no .options attribute — it should work fine
+        result = provider.execute(prompt="echo hello", command="echo hello")
+        assert result.exit_code == 0
+
+    def test_compile_flow_without_config_works(self):
+        """compile_flow without config still builds a valid CompiledGraph."""
+        flow = Flow(
+            name="test",
+            description="System test flow",
+            start_at="step1",
+            states={
+                "step1": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo done",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        compiled = compile_flow(flow)
+        assert compiled is not None
+        assert compiled.entry_point == "step1"
+
+
+# ---------------------------------------------------------------------------
+# T019-5: Parallel branches with mixed providers
+# ---------------------------------------------------------------------------
+
+
+class TestParallelBranchesWithMixedProviders:
+    """Parallel branches using different providers each get correct options."""
+
+    def test_codex_provider_appends_sandbox_flag(self):
+        """CodexProvider.execute() appends --sandbox to CLI args."""
+        options = CodexOptions(sandbox="workspace-write")
+        provider = CodexProvider(options)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch("fdsx.providers.codex._run_subprocess", side_effect=fake_run_subprocess):
+            provider.execute(prompt="do work", model="codex-mini")
+
+        args = captured_args[0]
+        assert "--sandbox" in args
+        assert "workspace-write" in args
+
+    def test_opencode_provider_flags_applied(self):
+        """OpenCodeProvider.execute() appends any to_cli_flags() output."""
+        options = OpenCodeOptions()  # currently no flags
+        provider = OpenCodeProvider(options)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch("fdsx.providers.opencode._run_subprocess", side_effect=fake_run_subprocess):
+            provider.execute(prompt="do work", model="opencode-model")
+
+        # Prompt must still be the last arg
+        args = captured_args[0]
+        assert args[-1] == "do work"
+
+    def test_get_provider_codex_with_approval_policy(self):
+        """get_provider('codex', options) returns CodexProvider with correct options."""
+        provider = get_provider("codex", {"approval_policy": "never"})
+        assert isinstance(provider, CodexProvider)
+        assert provider.options.approval_policy == "never"
+        assert "--approval-policy" in provider.options.to_cli_flags()
+
+    def test_merge_for_different_providers_are_independent(self):
+        """Merging options for claude does not affect codex and vice versa."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                claude=ClaudeOptions(permission_mode="acceptEdits"),
+                codex=CodexOptions(sandbox="read-only"),
+            )
+        )
+        flow = _make_single_task_flow()
+
+        claude_result = _merge_provider_options(config, flow, "claude", None)
+        codex_result = _merge_provider_options(config, flow, "codex", None)
+
+        assert claude_result is not None
+        assert claude_result.get("permission_mode") == "acceptEdits"
+        assert "sandbox" not in claude_result
+
+        assert codex_result is not None
+        assert codex_result.get("sandbox") == "read-only"
+        assert "permission_mode" not in codex_result

--- a/tests/integration/test_quiet_mode.py
+++ b/tests/integration/test_quiet_mode.py
@@ -1,0 +1,93 @@
+"""Integration tests for quiet mode end-to-end (T019, FR-5.1, FR-5.4).
+
+Tests verify:
+- --quiet suppresses stderr streaming output from providers
+- Log files are still written with --quiet
+- Completion summary still appears with --quiet
+"""
+
+import shutil
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+
+
+class TestQuietModeE2E:
+    """End-to-end integration tests for --quiet flag (FR-5.1, FR-5.4)."""
+
+    def test_quiet_suppresses_state_streaming_output(self):
+        """--quiet suppresses [state_name] prefixed lines on stderr."""
+        runner = CliRunner()
+        flow_path = str(Path("tests/fixtures/simple_flow.yaml").resolve())
+
+        result = runner.invoke(app, ["run", flow_path, "--quiet"])
+
+        assert result.exit_code == 0, (
+            f"Expected exit 0, got {result.exit_code}. output: {result.output}"
+        )
+        # Streaming lines with [state_name] prefix should be absent
+        assert "[plan]" not in result.output
+        assert "[implement]" not in result.output
+        assert "[review]" not in result.output
+
+    def test_quiet_completion_summary_still_printed(self):
+        """--quiet does not suppress the completion summary."""
+        runner = CliRunner()
+        flow_path = str(Path("tests/fixtures/simple_flow.yaml").resolve())
+
+        result = runner.invoke(app, ["run", flow_path, "--quiet"])
+
+        assert result.exit_code == 0, (
+            f"Expected exit 0, got {result.exit_code}. output: {result.output}"
+        )
+        # Completion summary should still appear (from display_completion_summary)
+        assert "completed successfully" in result.output
+
+    def test_non_quiet_produces_streaming_output(self):
+        """Without --quiet, streaming output is produced (baseline)."""
+        runner = CliRunner()
+        flow_path = str(Path("tests/fixtures/simple_flow.yaml").resolve())
+
+        result = runner.invoke(app, ["run", flow_path])
+
+        assert result.exit_code == 0, (
+            f"Expected exit 0, got {result.exit_code}. output: {result.output}"
+        )
+        # At least one streaming line should be present without --quiet
+        assert (
+            "[plan]" in result.output
+            or "[implement]" in result.output
+            or "[review]" in result.output
+        )
+
+    def test_quiet_log_files_still_written(self, tmp_path, monkeypatch):
+        """--quiet still writes per-state log files (FR-5.3)."""
+        monkeypatch.chdir(tmp_path)
+
+        src_fixture = Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
+        flow_file = tmp_path / "simple_flow.yaml"
+        shutil.copy(src_fixture, flow_file)
+
+        runner = CliRunner()
+        thread_id = "test-quiet-log-files"
+
+        result = runner.invoke(
+            app,
+            ["run", str(flow_file), "--thread-id", thread_id, "--quiet"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected exit 0, got {result.exit_code}. output: {result.output}"
+        )
+
+        # Verify log files were created despite --quiet
+        log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
+        log_files = list(log_dir.glob("*.log"))
+        assert len(log_files) > 0, f"Expected log files in {log_dir}, found none"
+
+        # Verify at least one log file has content
+        any_content = any(f.stat().st_size > 0 for f in log_files)
+        assert any_content, "All log files are empty"

--- a/tests/integration/test_result_file.py
+++ b/tests/integration/test_result_file.py
@@ -1,0 +1,171 @@
+"""Integration tests for result_file variable passing (T018, T019).
+
+T018: End-to-end tests with system provider verifying result_file creates files
+      and stores absolute paths in state variables.
+T019: Regression test verifying that flows without result_file do not create
+      the data/ directory.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from fdsx.core import engine
+from fdsx.core.variables import RESULT_FILE_DATA_DIR
+from fdsx.logging.recorder import RUNS_DIR_NAME
+
+
+class TestTaskResultFileIntegration:
+    """T018: Task state result_file end-to-end integration test."""
+
+    def test_task_result_file_creates_md_and_stores_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two-state workflow: echo → cat (downstream file read).
+
+        Asserts:
+        - File exists at <run_dir>/data/output_ref.md
+        - File content equals the echo output
+        - result["output_ref"] is the absolute path to that file
+        - Downstream state reads file contents via the stored path
+        """
+        monkeypatch.chdir(tmp_path)
+
+        flow_yaml = tmp_path / "task_result_file_flow.yaml"
+        flow_yaml.write_text(
+            "name: Task Result File Flow\n"
+            "description: Test result_file on task state\n"
+            "start_at: echo_state\n"
+            "states:\n"
+            "  echo_state:\n"
+            "    type: task\n"
+            "    provider: system\n"
+            "    command: \"echo 'Hello World'\"\n"
+            "    result_path: $.raw_output\n"
+            "    result_file: $.output_ref\n"
+            "    next: consume_state\n"
+            "  consume_state:\n"
+            "    type: task\n"
+            "    provider: system\n"
+            "    command: \"cat {output_ref}\"\n"
+            "    result_path: $.final\n"
+            "    end: true\n",
+            encoding="utf-8",
+        )
+
+        thread_id = "test-task-result-file"
+        result = engine.run_flow(flow_yaml, thread_id=thread_id, base_dir=tmp_path)
+
+        run_dir = tmp_path / RUNS_DIR_NAME / thread_id
+        expected_file = run_dir / RESULT_FILE_DATA_DIR / "output_ref.md"
+
+        assert "output_ref" in result, f"result_file variable missing from result: {result}"
+        assert Path(result["output_ref"]).is_absolute(), (
+            f"output_ref should be absolute path, got: {result['output_ref']}"
+        )
+        assert expected_file.exists(), f"Expected file not found: {expected_file}"
+
+        content = expected_file.read_text(encoding="utf-8")
+        assert "Hello World" in content, (
+            f"File content mismatch. Expected 'Hello World', got: {content!r}"
+        )
+        assert result["output_ref"] == str(expected_file.resolve()), (
+            f"output_ref path mismatch: {result['output_ref']} != {expected_file.resolve()}"
+        )
+        assert "final" in result, f"Downstream state result missing: {result}"
+        assert "Hello World" in result["final"], (
+            f"Downstream state should read file contents, got: {result['final']!r}"
+        )
+
+
+class TestParallelResultFileIntegration:
+    """T018: Parallel state result_file end-to-end integration test."""
+
+    def test_parallel_result_file_creates_json_and_stores_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parallel state with two branches and result_file.
+
+        Asserts:
+        - File exists at <run_dir>/data/reviews_ref.json
+        - File contains valid JSON (list of branch results)
+        - result["reviews_ref"] is the absolute path to that file
+        """
+        monkeypatch.chdir(tmp_path)
+
+        flow_yaml = tmp_path / "parallel_result_file_flow.yaml"
+        flow_yaml.write_text(
+            "name: Parallel Result File Flow\n"
+            "description: Test result_file on parallel state\n"
+            "start_at: review_parallel\n"
+            "states:\n"
+            "  review_parallel:\n"
+            "    type: parallel\n"
+            "    branches:\n"
+            "      - provider: system\n"
+            "        command: \"echo 'Branch 1 review'\"\n"
+            "        retry: 0\n"
+            "      - provider: system\n"
+            "        command: \"echo 'Branch 2 review'\"\n"
+            "        retry: 0\n"
+            "    result_path: $.reviews\n"
+            "    result_file: $.reviews_ref\n"
+            "    end: true\n",
+            encoding="utf-8",
+        )
+
+        thread_id = "test-parallel-result-file"
+        result = engine.run_flow(flow_yaml, thread_id=thread_id, base_dir=tmp_path)
+
+        run_dir = tmp_path / RUNS_DIR_NAME / thread_id
+        expected_file = run_dir / RESULT_FILE_DATA_DIR / "reviews_ref.json"
+
+        assert "reviews_ref" in result, (
+            f"result_file variable missing from result: {result}"
+        )
+        assert Path(result["reviews_ref"]).is_absolute(), (
+            f"reviews_ref should be absolute path, got: {result['reviews_ref']}"
+        )
+        assert expected_file.exists(), f"Expected JSON file not found: {expected_file}"
+
+        content = expected_file.read_text(encoding="utf-8")
+        parsed = json.loads(content)
+        assert isinstance(parsed, list), (
+            f"Expected JSON list in {expected_file}, got: {type(parsed)}"
+        )
+        assert len(parsed) == 2, (
+            f"Expected 2 branch results, got: {len(parsed)}"
+        )
+        for entry in parsed:
+            assert "output" in entry, f"Missing 'output' key in branch result: {entry}"
+            assert "exit_code" in entry, f"Missing 'exit_code' key in branch result: {entry}"
+        assert result["reviews_ref"] == str(expected_file.resolve()), (
+            f"reviews_ref path mismatch: {result['reviews_ref']} != {expected_file.resolve()}"
+        )
+
+
+class TestResultFileRegression:
+    """T019: Regression test — no data/ directory when result_file is not used."""
+
+    def test_no_data_dir_without_result_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Run simple_flow.yaml (no result_file) and verify data/ dir is not created."""
+        repo_root = Path.cwd()
+        monkeypatch.chdir(tmp_path)
+        path = repo_root / "tests" / "fixtures" / "simple_flow.yaml"
+
+        thread_id = "test-no-result-file"
+        result = engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
+
+        run_dir = tmp_path / RUNS_DIR_NAME / thread_id
+        data_dir = run_dir / RESULT_FILE_DATA_DIR
+
+        assert not data_dir.exists(), (
+            f"data/ directory should not be created when result_file is not used, "
+            f"but found: {data_dir}"
+        )
+        assert "plan" in result, f"Expected 'plan' in result: {result}"
+        assert "implementation" in result, f"Expected 'implementation' in result: {result}"
+        assert "review" in result, f"Expected 'review' in result: {result}"

--- a/tests/integration/test_resume_interrupt.py
+++ b/tests/integration/test_resume_interrupt.py
@@ -1,0 +1,276 @@
+import yaml
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.cli.main import app
+from fdsx.core import engine
+from fdsx.core.config import FdsxConfig
+from fdsx.models.task import TaskEntry, TaskFile, save_task_file
+
+
+class TestResumeCommandOnError:
+    """Integration tests for resume command display on errors."""
+
+    def test_runtime_error_displays_resume_command(self, tmp_path, monkeypatch):
+        """RuntimeError from engine displays resume command with correct thread_id."""
+        monkeypatch.chdir(tmp_path)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        workflow_path = tmp_path / "test.yaml"
+        workflow_path.write_text(workflow_yaml)
+
+        mock_run_flow = MagicMock(side_effect=RuntimeError("Test error"))
+
+        with patch("fdsx.core.engine.run_flow", mock_run_flow):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(app, ["run", str(workflow_path)])
+
+        assert result.exit_code == 1
+        assert "Error: Test error" in result.stderr
+        assert "fdsx resume --thread-id" in result.stderr
+        assert "To resume this flow, run:" in result.stderr
+
+    def test_exception_displays_resume_command(self, tmp_path, monkeypatch):
+        """Generic Exception from engine displays resume command."""
+        monkeypatch.chdir(tmp_path)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        workflow_path = tmp_path / "test.yaml"
+        workflow_path.write_text(workflow_yaml)
+
+        mock_run_flow = MagicMock(side_effect=ValueError("Test value error"))
+
+        with patch("fdsx.core.engine.run_flow", mock_run_flow):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(app, ["run", str(workflow_path)])
+
+        assert result.exit_code == 1
+        assert "Error: Test value error" in result.stderr
+        assert "fdsx resume --thread-id" in result.stderr
+
+
+class TestResumeCommandOnKeyboardInterrupt:
+    """Integration tests for resume command display on KeyboardInterrupt."""
+
+    def test_keyboard_interrupt_displays_resume_command(self, tmp_path, monkeypatch):
+        """KeyboardInterrupt from engine displays resume command."""
+        monkeypatch.chdir(tmp_path)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        workflow_path = tmp_path / "test.yaml"
+        workflow_path.write_text(workflow_yaml)
+
+        mock_run_flow = MagicMock(side_effect=KeyboardInterrupt())
+
+        with patch("fdsx.core.engine.run_flow", mock_run_flow):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(app, ["run", str(workflow_path)])
+
+        assert result.exit_code == 130
+        assert "fdsx resume --thread-id" in result.stderr
+        assert "To resume this flow, run:" in result.stderr
+
+    def test_keyboard_interrupt_in_tasks_dir_mode(self, tmp_path, monkeypatch):
+        """KeyboardInterrupt in tasks-dir mode displays run command, not resume."""
+        monkeypatch.chdir(tmp_path)
+
+        workflows_dir = tmp_path / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(tasks_dir / "001-task.yaml", tf)
+
+        mock_run_tasks_dir = MagicMock(side_effect=KeyboardInterrupt())
+
+        with patch("fdsx.core.engine.run_tasks_dir", mock_run_tasks_dir):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(app, ["run", "--tasks-dir", str(tasks_dir)])
+
+        assert result.exit_code == 130
+        assert "fdsx run --tasks-dir" in result.stderr
+        assert "To continue processing, run:" in result.stderr
+
+
+class TestResumeCommandTasksDirMode:
+    """Integration tests for resume command in tasks-dir mode (shows run command)."""
+
+    def test_runtime_error_in_tasks_dir_displays_run_command(
+        self, tmp_path, monkeypatch
+    ):
+        """RuntimeError in tasks-dir mode displays fdsx run --tasks-dir."""
+        monkeypatch.chdir(tmp_path)
+
+        workflows_dir = tmp_path / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(tasks_dir / "001-task.yaml", tf)
+
+        mock_run_tasks_dir = MagicMock(side_effect=RuntimeError("Tasks dir error"))
+
+        with patch("fdsx.core.engine.run_tasks_dir", mock_run_tasks_dir):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(app, ["run", "--tasks-dir", str(tasks_dir)])
+
+        assert result.exit_code == 1
+        assert "Error: Tasks dir error" in result.stderr
+        assert f"fdsx run --tasks-dir {tasks_dir}" in result.stderr
+        assert "To continue processing, run:" in result.stderr
+
+    def test_tasks_dir_command_shows_correct_path(self, tmp_path, monkeypatch):
+        """The displayed run command contains the correct tasks-dir path."""
+        monkeypatch.chdir(tmp_path)
+
+        workflows_dir = tmp_path / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "my-tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test")])
+        save_task_file(tasks_dir / "001-task.yaml", tf)
+
+        mock_run_tasks_dir = MagicMock(side_effect=RuntimeError("Error"))
+
+        with patch("fdsx.core.engine.run_tasks_dir", mock_run_tasks_dir):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(app, ["run", "--tasks-dir", str(tasks_dir)])
+
+        assert result.exit_code == 1
+        assert f"--tasks-dir {tasks_dir}" in result.stderr
+
+
+class TestResumeCommandWithThreadId:
+    """Integration tests for resume command with explicit thread_id."""
+
+    def test_explicit_thread_id_in_resume_command(self, tmp_path, monkeypatch):
+        """When --thread-id is provided, it appears in the resume command."""
+        monkeypatch.chdir(tmp_path)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        workflow_path = tmp_path / "test.yaml"
+        workflow_path.write_text(workflow_yaml)
+
+        mock_run_flow = MagicMock(side_effect=RuntimeError("Test error"))
+
+        with patch("fdsx.core.engine.run_flow", mock_run_flow):
+            runner = __import__("typer.testing", fromlist=["CliRunner"]).CliRunner()
+            result = runner.invoke(
+                app, ["run", "--thread-id", "my-custom-thread", str(workflow_path)]
+            )
+
+        assert result.exit_code == 1
+        assert "--thread-id my-custom-thread" in result.stderr
+        assert "fdsx resume --thread-id my-custom-thread" in result.stderr

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import yaml
 
-from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.batch import COMPLETED_SUBDIR, TASKS_DIR, split_tasks_to_groups, write_task_files
 from fdsx.core.config import FdsxConfig, TaskSplitterConfig
 from fdsx.models.task import TaskEntry
 
@@ -330,3 +330,176 @@ class TestSplitCliIntegration:
         assert isinstance(paths, list)
         assert len(paths) == 1
         assert "Created 1 task file" in result.stderr
+
+    # T001: Split succeeds when only completed/ dir exists (no pending tasks)
+    def test_split_command_succeeds_with_only_completed_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """Split without --force succeeds when tasks dir contains only completed/ subdir."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        (completed_dir / "001-old-task.yaml").write_text("description: Old task\nstatus: done")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("New feature")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "New feature"}]]',
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        import json as _json
+        paths = _json.loads(result.stdout)
+        assert len(paths) == 1
+
+    # T001: Completed/ dir and its contents are preserved after a normal split
+    def test_split_command_preserves_completed_dir_on_normal_split(
+        self, tmp_path, monkeypatch
+    ):
+        """Split preserves completed/ directory and its contents when no pending tasks exist."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        completed_file = completed_dir / "001-old-task.yaml"
+        completed_file.write_text("description: Old task\nstatus: done")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("New feature")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "New feature"}]]',
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert completed_dir.exists()
+        assert completed_file.exists()
+        assert completed_file.read_text() == "description: Old task\nstatus: done"
+
+    # T001: Task numbering continues from the highest index in completed/
+    def test_split_command_numbering_continues_from_completed(
+        self, tmp_path, monkeypatch
+    ):
+        """New task files are numbered starting after the highest index in completed/."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        (completed_dir / "001-first.yaml").write_text("description: First\nstatus: done")
+        (completed_dir / "002-second.yaml").write_text("description: Second\nstatus: done")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Third task")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Third task"}]]',
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert (tasks_dir / "003-third-task.yaml").exists()
+
+    # T001: Split without --force still fails when a pending .yaml exists outside completed/
+    def test_split_command_still_blocks_with_pending_yaml(
+        self, tmp_path, monkeypatch
+    ):
+        """Split without --force fails when a pending .yaml file exists directly in tasks dir."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        (completed_dir / "001-done.yaml").write_text("description: Done\nstatus: done")
+        # Pending task directly in tasks dir — should block split
+        (tasks_dir / "002-pending.yaml").write_text("description: Pending\nstatus: pending")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("New feature")
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            runner = CliRunner()
+            result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+
+        assert result.exit_code == 2
+        assert "not empty" in result.stderr
+
+    # T003: --force removes pending .yaml files but preserves completed/ dir
+    def test_split_command_force_preserves_completed_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """--force clears pending .yaml files but preserves completed/ and its contents."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir(parents=True, exist_ok=True)
+        completed_file = completed_dir / "001-done.yaml"
+        completed_file.write_text("description: Done\nstatus: done")
+        pending_file = tasks_dir / "002-pending.yaml"
+        pending_file.write_text("description: Pending\nstatus: pending")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("New feature")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "New feature"}]]',
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app, ["split", str(task_file), "--force"], catch_exceptions=False
+                )
+
+        assert result.exit_code == 0
+        assert not pending_file.exists()
+        assert completed_dir.exists()
+        assert completed_file.exists()
+        assert completed_file.read_text() == "description: Done\nstatus: done"

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -1,0 +1,332 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.config import FdsxConfig, TaskSplitterConfig
+from fdsx.models.task import TaskEntry
+
+
+class TestSplitIntegration:
+    def test_split_end_to_end_with_mock_provider(self):
+        """End-to-end test: split task content via mock provider and write files."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Implement feature A"}, {"description": "Implement feature B"}], [{"description": "Write tests for feature A"}], [{"description": "Write tests for feature B"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            result_groups = split_tasks_to_groups(
+                "Implement features A and B",
+                task_splitter,
+            )
+
+        assert len(result_groups) == 3
+        assert len(result_groups[0]) == 2
+        assert len(result_groups[1]) == 1
+        assert len(result_groups[2]) == 1
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / TASKS_DIR
+            created_files = write_task_files(result_groups, tasks_dir)
+
+            assert len(created_files) == 3
+            assert (tasks_dir / "001-implement-feature-a.yaml").exists()
+            assert (tasks_dir / "002-write-tests-for-feature-a.yaml").exists()
+            assert (tasks_dir / "003-write-tests-for-feature-b.yaml").exists()
+
+            for f in created_files:
+                assert f.exists()
+                assert f.stat().st_mode & 0o777 == 0o600
+
+            content = (tasks_dir / "001-implement-feature-a.yaml").read_text()
+            data = yaml.safe_load(content)
+            assert len(data["tasks"]) == 2
+            assert data["tasks"][0]["description"] == "Implement feature A"
+
+    def test_split_with_empty_result(self):
+        """Test handling of empty result from provider."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="[]",
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups("some content", task_splitter)
+
+        assert groups == []
+
+    def test_split_with_single_task(self):
+        """Test handling of single task result."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Single task"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups("single task", task_splitter)
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert groups[0][0].description == "Single task"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / TASKS_DIR
+            created_files = write_task_files(groups, tasks_dir)
+
+            assert len(created_files) == 1
+            content = (tasks_dir / "001-single-task.yaml").read_text()
+            data = yaml.safe_load(content)
+            assert "description" in data
+            assert data["description"] == "Single task"
+
+    def test_split_writes_yaml_with_task_status(self):
+        """Verify that written YAML files contain correct status field."""
+        groups = [
+            [TaskEntry(description="Task with default status")],
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / TASKS_DIR
+            write_task_files(groups, tasks_dir)
+
+            content = (tasks_dir / "001-task-with-default-status.yaml").read_text()
+            data = yaml.safe_load(content)
+
+            assert "status" in data
+            assert data["status"] == "pending"
+
+
+class TestSplitCliIntegration:
+    def test_split_command_missing_task_splitter_config_uses_defaults(
+        self, tmp_path, monkeypatch
+    ):
+        """Test split command falls back to built-in defaults when task_splitter is not configured."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Task 1\nTask 2")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task 1"}], [{"description": "Task 2"}]]',
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        # Config has no task_splitter — should fall back to built-in TaskSplitterConfig()
+        with patch(
+            "fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=None)
+        ):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(app, ["split", str(task_file)])
+
+        assert result.exit_code == 0
+        import json as _json
+
+        paths = _json.loads(result.stdout)
+        assert isinstance(paths, list)
+        assert len(paths) == 2
+        assert "Created 2 task file" in result.stderr
+
+    def test_split_command_missing_task_file(self, tmp_path):
+        """Test split command fails when task file doesn't exist."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["split", str(tmp_path / "nonexistent.md")])
+
+            assert result.exit_code == 2
+            assert "not found" in result.stderr
+
+    def test_split_command_non_empty_dir_without_force(self, tmp_path, monkeypatch):
+        """Test split command fails when tasks dir is non-empty and --force is not used."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        existing_file = tasks_dir / "existing.yaml"
+        existing_file.write_text("existing: true")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Task 1")
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
+            runner = CliRunner()
+            result = runner.invoke(
+                app, ["split", str(task_file)], catch_exceptions=False
+            )
+
+            assert result.exit_code == 2
+            assert "not empty" in result.stderr
+
+    def test_split_command_with_force_flag(self, tmp_path, monkeypatch):
+        """Test split command clears existing dir with --force flag."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        existing_file = tasks_dir / "existing.yaml"
+        existing_file.write_text("existing: true")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Task 1")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task 1"}]]',
+            stderr="",
+        )
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app, ["split", str(task_file), "--force"], catch_exceptions=False
+                )
+
+        assert result.exit_code == 0
+        assert not existing_file.exists()
+
+    def test_split_command_force_refuses_symlinked_tasks_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """Test --force refuses to delete tasks directory when it is a symlink."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        real_dir = tmp_path / "real_tasks"
+        real_dir.mkdir()
+        tasks_parent = tmp_path / ".fdsx"
+        tasks_parent.mkdir()
+        symlink_dir = tasks_parent / "tasks"
+        symlink_dir.symlink_to(real_dir)
+
+        # Place a file in the symlinked dir so the non-empty check triggers
+        (symlink_dir / "existing.yaml").write_text("existing: true")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Task 1")
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                app, ["split", str(task_file), "--force"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 2
+        assert "symlink" in result.stderr
+
+    def test_split_command_force_preserves_non_yaml_files(self, tmp_path, monkeypatch):
+        """Test --force only deletes .yaml files, preserving other files."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        tasks_dir = tmp_path / TASKS_DIR
+        tasks_dir.mkdir(parents=True, exist_ok=True)
+        (tasks_dir / "existing.yaml").write_text("old: true")
+        (tasks_dir / "notes.txt").write_text("user notes")
+        (tasks_dir / "readme.md").write_text("# Notes")
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Task 1")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task 1"}]]',
+            stderr="",
+        )
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app, ["split", str(task_file), "--force"], catch_exceptions=False
+                )
+
+        assert result.exit_code == 0
+        assert not (tasks_dir / "existing.yaml").exists()
+        assert (tasks_dir / "notes.txt").exists()
+        assert (tasks_dir / "readme.md").exists()
+
+    def test_split_command_success(self, tmp_path, monkeypatch):
+        """Test successful split command execution."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Implement feature A\nImplement feature B")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Implement feature A"}, {"description": "Implement feature B"}]]',
+            stderr="",
+        )
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app, ["split", str(task_file)], catch_exceptions=False
+                )
+
+        assert result.exit_code == 0
+        import json as _json
+
+        paths = _json.loads(result.stdout)
+        assert isinstance(paths, list)
+        assert len(paths) == 1
+        assert "Created 1 task file" in result.stderr

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -463,6 +463,49 @@ class TestSplitCliIntegration:
         assert result.exit_code == 2
         assert "not empty" in result.stderr
 
+    # T006: Prompt produces feature-level tasks with numbered sub-steps
+    def test_split_produces_feature_level_tasks(self):
+        """Verify split accepts feature-level task descriptions with numbered sub-steps."""
+        import json as _json
+
+        mock_provider = MagicMock()
+        feature_level_description = (
+            "Implement authentication feature\n"
+            "1. Create auth/models.py with User model\n"
+            "2. Add login and logout endpoints in auth/routes.py\n"
+            "3. Write unit tests for auth module"
+        )
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout=_json.dumps([[{"description": feature_level_description}]]),
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups(
+                "Add user authentication with login/logout endpoints",
+                task_splitter,
+            )
+
+        # Feature-level split produces fewer groups than micro-task split would
+        assert len(groups) == 1
+        # Single feature-level task covers multiple steps
+        assert len(groups[0]) == 1
+        # Task description contains numbered sub-steps
+        description = groups[0][0].description
+        assert "1." in description
+        assert "2." in description
+        assert "3." in description
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / TASKS_DIR
+            created_files = write_task_files(groups, tasks_dir)
+
+            # Produces fewer files than micro-task split (1 vs many)
+            assert len(created_files) == 1
+
     # T003: --force removes pending .yaml files but preserves completed/ dir
     def test_split_command_force_preserves_completed_dir(
         self, tmp_path, monkeypatch

--- a/tests/integration/test_split_spinner.py
+++ b/tests/integration/test_split_spinner.py
@@ -1,0 +1,282 @@
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from fdsx.cli.main import app
+from fdsx.core import engine
+from fdsx.core.config import FdsxConfig, TaskSplitterConfig
+from fdsx.models.task import TaskEntry, TaskFile, save_task_file
+
+
+class _MockSpinner:
+    """Test double for Spinner that records start and update calls."""
+
+    _started_messages: list[str] = []
+    _update_messages: list[str] = []
+
+    def __init__(self, message: str = ""):
+        self._message = message
+
+    def __enter__(self) -> "_MockSpinner":
+        _MockSpinner._started_messages.append(self._message)
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def update(self, message: str) -> None:
+        _MockSpinner._update_messages.append(message)
+
+    @classmethod
+    def reset(cls) -> None:
+        cls._started_messages = []
+        cls._update_messages = []
+
+
+class TestSplitSpinner:
+    """Tests for spinner during fdsx split command."""
+
+    def test_split_spinner_messages(self, tmp_path, monkeypatch):
+        """Spinner messages appear during split: splitting + writing + completion."""
+        from typer.testing import CliRunner
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Task 1\nTask 2\nTask 3")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task 1"}], [{"description": "Task 2"}], [{"description": "Task 3"}]]',
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(app, ["split", str(task_file)])
+
+        assert result.exit_code == 0, f"stderr: {result.stderr}"
+        assert "Splitting tasks..." in result.stderr
+        assert "Writing 3 task file(s)..." in result.stderr
+
+    def test_split_empty_result_no_spinner_crash(self, tmp_path, monkeypatch):
+        """Empty result from provider — spinner stops cleanly without crash."""
+        from typer.testing import CliRunner
+
+        task_file = tmp_path / "tasks.md"
+        task_file.write_text("Nothing to split")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="[]",
+            stderr="",
+        )
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(app, ["split", str(task_file)])
+
+        assert result.exit_code == 0
+        assert "No tasks were generated" in result.stderr
+
+
+class TestAutoSelectionSpinner:
+    """Tests for spinner during workflow auto-selection in run_tasks_dir."""
+
+    def test_auto_selection_progress_messages(self, tmp_path):
+        """Spinner shows progress during auto-selection of workflows."""
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        for i in range(3):
+            tf = TaskFile(entries=[TaskEntry(description=f"task {i}")])
+            save_task_file(tasks_dir / f"{i:03d}-task.yaml", tf)
+
+        resolve_count = [0]
+
+        def mock_resolve(**kwargs):
+            resolve_count[0] += 1
+            return workflows_dir / "test.yaml"
+
+        with patch(
+            "fdsx.core.engine.resolve_workflow_for_task", side_effect=mock_resolve
+        ):
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(
+                        None,
+                        tasks_dir,
+                        base_dir=project_root / ".fdsx",
+                        auto_workflow=True,
+                    )
+
+        assert resolve_count[0] == 3
+
+    def test_auto_selection_spinner_message_count(self, tmp_path):
+        """Spinner update called with correct per-entry progress."""
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        for i in range(2):
+            tf = TaskFile(entries=[TaskEntry(description=f"task {i}")])
+            save_task_file(tasks_dir / f"{i:03d}-task.yaml", tf)
+
+        _MockSpinner.reset()
+
+        with patch("fdsx.core.engine.Spinner", side_effect=_MockSpinner):
+            with patch(
+                "fdsx.core.engine.resolve_workflow_for_task",
+                return_value=workflows_dir / "test.yaml",
+            ):
+                with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                    with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                        engine.run_tasks_dir(
+                            None,
+                            tasks_dir,
+                            base_dir=project_root / ".fdsx",
+                            auto_workflow=True,
+                        )
+
+        assert len(_MockSpinner._update_messages) == 2
+        assert (
+            "Auto-selecting workflows for 2 tasks..."
+            in _MockSpinner._update_messages[0]
+        )
+        assert "(1/2)" in _MockSpinner._update_messages[0]
+        assert "(2/2)" in _MockSpinner._update_messages[1]
+
+    def test_no_spinner_when_all_entries_have_workflow(self, tmp_path):
+        """No spinner when all entries already have workflow field set."""
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        (workflows_dir / "test.yaml").write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(
+            entries=[TaskEntry(description="task with workflow", workflow="test.yaml")]
+        )
+        save_task_file(tasks_dir / "001-task.yaml", tf)
+
+        _MockSpinner.reset()
+
+        with patch("fdsx.core.engine.Spinner", side_effect=_MockSpinner):
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(
+                        None,
+                        tasks_dir,
+                        base_dir=project_root / ".fdsx",
+                        auto_workflow=True,
+                    )
+
+        assert len(_MockSpinner._started_messages) == 0
+
+    def test_no_spinner_when_workflow_path_provided(self, tmp_path):
+        """No spinner when workflow_path argument is provided to run_tasks_dir."""
+        project_root = tmp_path
+        workflow_path = project_root / "batch_flow.yaml"
+        workflow_yaml = yaml.dump(
+            {
+                "name": "Test",
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+        workflow_path.write_text(workflow_yaml)
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="task without workflow")])
+        save_task_file(tasks_dir / "001-task.yaml", tf)
+
+        _MockSpinner.reset()
+
+        with patch("fdsx.core.engine.Spinner", side_effect=_MockSpinner):
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(
+                        workflow_path,
+                        tasks_dir,
+                        base_dir=project_root / ".fdsx",
+                        auto_workflow=True,
+                    )
+
+        assert len(_MockSpinner._started_messages) == 0

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -642,10 +642,9 @@ class TestTasksDirCli:
 
 
 class TestBatchEditFlow:
-    """Regression tests for FR-6.3 batch edit flow (Finding 1).
+    """Regression tests for the interactive workflow confirmation CUI (T013-T020).
 
-    When the user rejects the batch workflow assignments, the engine must allow
-    per-entry keep/change instead of aborting immediately.
+    Tests the new CUI flow: confirm ('c') proceeds, cancel ('q') aborts.
     """
 
     def _make_workflow_yaml(self, name: str, description: str) -> str:
@@ -668,8 +667,8 @@ class TestBatchEditFlow:
             }
         )
 
-    def test_reject_then_keep_all_proceeds(self, tmp_path):
-        """Reject batch, then keep all entries — execution should proceed."""
+    def test_confirm_proceeds(self, tmp_path):
+        """CUI confirm ('c') — execution proceeds."""
         project_root = tmp_path
         workflows_dir = project_root / ".fdsx" / "workflows"
         workflows_dir.mkdir(parents=True)
@@ -682,18 +681,15 @@ class TestBatchEditFlow:
         tf = TaskFile(entries=[TaskEntry(description="plan this feature")])
         save_task_file(tasks_dir / "001-test.yaml", tf)
 
-        mock_provider = MagicMock()
-        mock_provider.execute.return_value = MagicMock(
-            exit_code=0, stdout="plan.yaml", stderr=""
-        )
+        wf_path = workflows_dir / "plan.yaml"
+        mock_assignments = {(0, 0): wf_path}
 
-        # inputs to engine: "n" = reject batch, "k" = keep entry
-        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+        with patch("fdsx.core.selector.get_provider", return_value=MagicMock()):
             with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
                     with patch(
-                        "fdsx.core.engine.input",
-                        side_effect=["n", "k"],
+                        "fdsx.display.terminal.confirm_workflow_assignments_interactive",
+                        return_value=mock_assignments,
                     ):
                         results = engine.run_tasks_dir(
                             None,
@@ -704,16 +700,13 @@ class TestBatchEditFlow:
 
         assert len([r for r in results if r["category"] == "new"]) == 1
 
-    def test_reject_then_cancel_during_edit_aborts(self, tmp_path):
-        """Reject batch, then cancel during pick_workflow_manually — aborts."""
+    def test_cancel_aborts(self, tmp_path):
+        """CUI cancel ('q') — execution aborts with empty results."""
         project_root = tmp_path
         workflows_dir = project_root / ".fdsx" / "workflows"
         workflows_dir.mkdir(parents=True)
         (workflows_dir / "plan.yaml").write_text(
             self._make_workflow_yaml("Plan", "Planning workflow")
-        )
-        (workflows_dir / "impl.yaml").write_text(
-            self._make_workflow_yaml("Impl", "Implementation workflow")
         )
 
         tasks_dir = tmp_path / "tasks"
@@ -721,30 +714,23 @@ class TestBatchEditFlow:
         tf = TaskFile(entries=[TaskEntry(description="do something")])
         save_task_file(tasks_dir / "001-test.yaml", tf)
 
-        mock_provider = MagicMock()
-        mock_provider.execute.return_value = MagicMock(
-            exit_code=0, stdout="plan.yaml", stderr=""
-        )
+        with patch("fdsx.core.selector.get_provider", return_value=MagicMock()):
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                with patch(
+                    "fdsx.display.terminal.confirm_workflow_assignments_interactive",
+                    return_value=None,
+                ):
+                    results = engine.run_tasks_dir(
+                        None,
+                        tasks_dir,
+                        base_dir=project_root / ".fdsx",
+                        auto_workflow=False,
+                    )
 
-        # engine inputs: "n" = reject batch, "c" = change
-        # selector inputs: "c" = cancel during pick
-        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
-                with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    with patch("fdsx.core.engine.input", side_effect=["n", "c"]):
-                        with patch("fdsx.core.selector.input", return_value="c"):
-                            results = engine.run_tasks_dir(
-                                None,
-                                tasks_dir,
-                                base_dir=project_root / ".fdsx",
-                                auto_workflow=False,
-                            )
-
-        # Cancelled during edit → empty results (aborted)
         assert results == []
 
-    def test_approve_batch_skips_edit_flow(self, tmp_path):
-        """Approve batch on first prompt — no per-entry prompts are called."""
+    def test_auto_workflow_skips_cui(self, tmp_path):
+        """auto_workflow=True skips the CUI entirely."""
         project_root = tmp_path
         workflows_dir = project_root / ".fdsx" / "workflows"
         workflows_dir.mkdir(parents=True)
@@ -757,21 +743,18 @@ class TestBatchEditFlow:
         tf = TaskFile(entries=[TaskEntry(description="plan this feature")])
         save_task_file(tasks_dir / "001-test.yaml", tf)
 
-        mock_provider = MagicMock()
-        mock_provider.execute.return_value = MagicMock(
-            exit_code=0, stdout="plan.yaml", stderr=""
-        )
-
-        # Only "y" for batch approve — no keep/change prompts follow
-        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+        with patch("fdsx.core.selector.get_provider", return_value=MagicMock()):
             with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    with patch("fdsx.core.engine.input", side_effect=["y"]):
+                    with patch(
+                        "fdsx.display.terminal.confirm_workflow_assignments_interactive"
+                    ) as mock_cui:
                         results = engine.run_tasks_dir(
                             None,
                             tasks_dir,
                             base_dir=project_root / ".fdsx",
-                            auto_workflow=False,
+                            auto_workflow=True,
                         )
 
+        mock_cui.assert_not_called()
         assert len([r for r in results if r["category"] == "new"]) == 1

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -212,7 +212,7 @@ class TestRunTasksDir:
 
             run_count = [0]
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 run_count[0] += 1
                 return {"result": "ok"}
 
@@ -303,7 +303,7 @@ class TestRunTasksDir:
 
             call_count = [0]
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 call_count[0] += 1
                 return {"result": "ok"}
 
@@ -336,7 +336,7 @@ class TestRunTasksDir:
 
             call_count = [0]
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 call_count[0] += 1
                 if call_count[0] == 1:
                     raise RuntimeError("Task 1 failed")
@@ -372,7 +372,7 @@ class TestRunTasksDir:
 
             call_count = [0]
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 call_count[0] += 1
                 if call_count[0] == 1:
                     raise RuntimeError("Task 1 failed")
@@ -459,7 +459,7 @@ class TestRunTasksDir:
             )
             save_task_file(tasks_dir / "001-test.yaml", tf)
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 raise RuntimeError("Failed again")
 
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
@@ -485,7 +485,7 @@ class TestRunTasksDir:
             )
             save_task_file(tasks_dir / "001-test.yaml", tf)
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 raise RuntimeError("Task failed")
 
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
@@ -695,7 +695,7 @@ class TestMoveToCompletedOnRunTasksDir:
 
             call_count = [0]
 
-            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 call_count[0] += 1
                 if call_count[0] == 1:
                     raise RuntimeError("first fails")
@@ -897,3 +897,41 @@ class TestBatchEditFlow:
 
         mock_cui.assert_not_called()
         assert len([r for r in results if r["category"] == "new"]) == 1
+
+
+class TestRunTasksDirQuietFlagPropagation:
+    def test_run_tasks_dir_passes_quiet_true_to_run_flow(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow") as mock_run_flow:
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True, quiet=True
+                    )
+
+            assert mock_run_flow.called
+            for call_args in mock_run_flow.call_args_list:
+                assert call_args.kwargs.get("quiet") is True
+
+    def test_run_tasks_dir_passes_quiet_false_by_default(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow") as mock_run_flow:
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
+
+            assert mock_run_flow.called
+            for call_args in mock_run_flow.call_args_list:
+                assert call_args.kwargs.get("quiet") is False

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -1,0 +1,601 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+from fdsx.core import engine
+from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
+
+
+class TestTasksDirLoader:
+    def test_load_tasks_dir_returns_sorted_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            (tasks_dir / "b-task.yaml").write_text("description: b task\n")
+            (tasks_dir / "a-task.yaml").write_text("description: a task\n")
+            (tasks_dir / "c-task.yaml").write_text("description: c task\n")
+
+            files = engine.load_tasks_dir(tasks_dir)
+
+            assert len(files) == 3
+            names = [f.name for f, _ in files]
+            assert names == ["a-task.yaml", "b-task.yaml", "c-task.yaml"]
+
+    def test_load_tasks_dir_empty_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            with pytest.raises(ValueError, match="No .yaml files"):
+                engine.load_tasks_dir(tasks_dir)
+
+    def test_load_tasks_dir_nonexistent_dir(self):
+        with pytest.raises(FileNotFoundError):
+            engine.load_tasks_dir(Path("/nonexistent/path"))
+
+    def test_load_tasks_dir_parses_task_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            task_file = tasks_dir / "001-test.yaml"
+            task_file.write_text("description: Test task\n")
+
+            files = engine.load_tasks_dir(tasks_dir)
+
+            assert len(files) == 1
+            file_path, parsed = files[0]
+            assert file_path == task_file
+            assert len(parsed.entries) == 1
+            assert parsed.entries[0].description == "Test task"
+
+    def test_load_tasks_dir_rejects_symlinked_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_dir = Path(tmpdir) / "real"
+            real_dir.mkdir()
+            (real_dir / "001-task.yaml").write_text("description: task\n")
+
+            symlink_dir = Path(tmpdir) / "link"
+            symlink_dir.symlink_to(real_dir)
+
+            with pytest.raises(ValueError, match="must not be a symlink"):
+                engine.load_tasks_dir(symlink_dir)
+
+    def test_load_tasks_dir_rejects_symlinked_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            real_file = tasks_dir / "001-real.yaml"
+            real_file.write_text("description: real task\n")
+
+            symlink_file = tasks_dir / "002-link.yaml"
+            symlink_file.symlink_to(real_file)
+
+            with pytest.raises(ValueError, match="must be a regular file"):
+                engine.load_tasks_dir(tasks_dir)
+
+
+class TestFilterActionableEntries:
+    def test_skips_completed(self):
+        task_file = TaskFile(
+            entries=[
+                TaskEntry(description="task1", status="completed"),
+                TaskEntry(description="task2", status="pending"),
+            ]
+        )
+        result = engine._filter_actionable_entries(task_file)
+        assert len(result) == 1
+        assert result[0][1].description == "task2"
+
+    def test_includes_failed(self):
+        task_file = TaskFile(
+            entries=[
+                TaskEntry(description="task1", status="failed"),
+            ]
+        )
+        result = engine._filter_actionable_entries(task_file)
+        assert len(result) == 1
+        assert result[0][1].description == "task1"
+
+    def test_includes_running(self):
+        task_file = TaskFile(
+            entries=[
+                TaskEntry(description="task1", status="running"),
+            ]
+        )
+        result = engine._filter_actionable_entries(task_file)
+        assert len(result) == 1
+        assert result[0][1].description == "task1"
+
+    def test_skips_all_completed(self):
+        task_file = TaskFile(
+            entries=[
+                TaskEntry(description="task1", status="completed"),
+                TaskEntry(description="task2", status="completed"),
+            ]
+        )
+        result = engine._filter_actionable_entries(task_file)
+        assert len(result) == 0
+
+
+class TestUpdateTaskStatus:
+    def test_updates_and_persists_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            task_file = TaskFile(
+                entries=[
+                    TaskEntry(description="test task", status="pending"),
+                ]
+            )
+            file_path = tasks_dir / "task.yaml"
+            save_task_file(file_path, task_file)
+
+            engine._update_task_status(
+                file_path, task_file, 0, "running", thread_id="test-thread-123"
+            )
+
+            loaded = load_task_file(file_path)
+            assert loaded.entries[0].status == "running"
+            assert loaded.entries[0].thread_id == "test-thread-123"
+
+            engine._update_task_status(
+                file_path, task_file, 0, "completed", thread_id="test-thread-123"
+            )
+
+            loaded = load_task_file(file_path)
+            assert loaded.entries[0].status == "completed"
+
+    def test_updates_error_field(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            task_file = TaskFile(
+                entries=[
+                    TaskEntry(description="test task", status="pending"),
+                ]
+            )
+            file_path = tasks_dir / "task.yaml"
+            save_task_file(file_path, task_file)
+
+            engine._update_task_status(
+                file_path, task_file, 0, "failed", error="Something went wrong"
+            )
+
+            loaded = load_task_file(file_path)
+            assert loaded.entries[0].status == "failed"
+            assert loaded.entries[0].error == "Something went wrong"
+
+
+class TestRunTasksDir:
+    def test_full_run_all_pending(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf1 = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf1)
+
+            tf2 = TaskFile(entries=[TaskEntry(description="task B")])
+            save_task_file(tasks_dir / "002-b.yaml", tf2)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert len(results) == 2
+            for r in results:
+                assert r["status"] == "completed"
+                assert r["category"] == "new"
+
+            loaded_a = load_task_file(tasks_dir / "001-a.yaml")
+            assert loaded_a.entries[0].status == "completed"
+
+            loaded_b = load_task_file(tasks_dir / "002-b.yaml")
+            assert loaded_b.entries[0].status == "completed"
+
+    def test_skips_completed_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(
+                        description="task already done",
+                        status="completed",
+                        thread_id="old-thread",
+                    ),
+                    TaskEntry(description="task to run", status="pending"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            run_count = [0]
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                run_count[0] += 1
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert run_count[0] == 1
+            skipped = [r for r in results if r["category"] == "skipped"]
+            assert len(skipped) == 1
+            assert skipped[0]["entry_description"] == "task already done"
+            executed = [r for r in results if r["category"] == "new"]
+            assert len(executed) == 1
+            assert executed[0]["entry_description"] == "task to run"
+
+    def test_retries_failed_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(
+                        description="failed task",
+                        status="failed",
+                        error="previous error",
+                    ),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert len(results) == 1
+            assert results[0]["status"] == "completed"
+            assert results[0]["category"] == "retried"
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].status == "completed"
+            assert loaded.entries[0].error is None
+
+    def test_retries_running_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(
+                        description="interrupted task",
+                        status="running",
+                        thread_id="old-thread",
+                    ),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert len(results) == 1
+            assert results[0]["status"] == "completed"
+            assert results[0]["category"] == "retried"
+
+    def test_multi_task_file_per_entry_tracking(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="task 1"),
+                    TaskEntry(description="task 2"),
+                    TaskEntry(description="task 3"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-multi.yaml", tf)
+
+            call_count = [0]
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                call_count[0] += 1
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert call_count[0] == 3
+            assert len(results) == 3
+
+            loaded = load_task_file(tasks_dir / "001-multi.yaml")
+            for entry in loaded.entries:
+                assert entry.status == "completed"
+
+    def test_continues_after_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="task 1"),
+                    TaskEntry(description="task 2"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            call_count = [0]
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise RuntimeError("Task 1 failed")
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["y", "y"]):
+                        results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert len(results) == 2
+            assert results[0]["status"] == "failed"
+            assert results[1]["status"] == "completed"
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].status == "failed"
+            assert loaded.entries[1].status == "completed"
+
+    def test_stops_on_user_n(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="task 1"),
+                    TaskEntry(description="task 2"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            call_count = [0]
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise RuntimeError("Task 1 failed")
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["n"]):
+                        results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert len(results) == 1
+            assert results[0]["status"] == "failed"
+
+    def test_skips_file_when_all_completed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="done", status="completed"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-done.yaml", tf)
+
+            with patch(
+                "fdsx.core.engine.run_flow", return_value={"result": "ok"}
+            ) as mock_run:
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            mock_run.assert_not_called()
+            assert len(results) == 1
+            assert results[0]["entry_index"] == 0
+            assert results[0]["entry_description"] == "done"
+            assert results[0]["category"] == "skipped"
+
+    def test_all_completed_multi_entry_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="task 1", status="completed"),
+                    TaskEntry(description="task 2", status="completed"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-done.yaml", tf)
+
+            with patch(
+                "fdsx.core.engine.run_flow", return_value={"result": "ok"}
+            ) as mock_run:
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            mock_run.assert_not_called()
+            assert len(results) == 2
+            for r in results:
+                assert r["category"] == "skipped"
+                assert r["status"] == "completed"
+            assert results[0]["entry_index"] == 0
+            assert results[1]["entry_index"] == 1
+
+    def test_retried_task_that_fails_again(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(
+                        description="will fail again",
+                        status="failed",
+                        error="previous error",
+                    ),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                raise RuntimeError("Failed again")
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["n"]):
+                        results = engine.run_tasks_dir(flow_path, tasks_dir)
+
+            assert len(results) == 1
+            assert results[0]["status"] == "failed"
+            assert results[0]["category"] == "retried"
+
+    def test_thread_id_preserved_after_failure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="task 1"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                raise RuntimeError("Task failed")
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["n"]):
+                        engine.run_tasks_dir(flow_path, tasks_dir)
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].thread_id is not None
+
+
+class TestDisplayTasksDirSummary:
+    def test_displays_summary_to_stderr(self, capsys):
+        from fdsx.core.batch import display_tasks_dir_summary
+
+        results = [
+            {
+                "file_index": 0,
+                "file_name": "001-a.yaml",
+                "entry_index": 0,
+                "entry_description": "task a",
+                "thread_id": "thread-1",
+                "status": "completed",
+                "error": None,
+                "category": "new",
+            },
+            {
+                "file_index": 0,
+                "file_name": "001-a.yaml",
+                "entry_index": 1,
+                "entry_description": "task b",
+                "thread_id": "thread-2",
+                "status": "failed",
+                "error": "oops",
+                "category": "new",
+            },
+            {
+                "file_index": 1,
+                "file_name": "002-b.yaml",
+                "entry_index": 0,
+                "entry_description": "skipped task",
+                "thread_id": "thread-3",
+                "status": "completed",
+                "error": None,
+                "category": "skipped",
+            },
+        ]
+
+        display_tasks_dir_summary(results)
+
+        captured = capsys.readouterr()
+        assert "TASKS-DIR EXECUTION SUMMARY" in captured.err
+        assert "Total: 3" in captured.err
+        assert "Skipped: 1" in captured.err
+        assert "New: 2" in captured.err
+        assert "Failed: 1" in captured.err
+        assert "Completed:" not in captured.err
+
+
+class TestTasksDirCli:
+    def test_run_tasks_dir_cli_success(self, tmp_path):
+        project_root = Path(__file__).resolve().parent.parent.parent
+        workflow_path = project_root / "tests/fixtures/batch_flow.yaml"
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="cli task")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+            with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app,
+                    [
+                        "run",
+                        str(workflow_path),
+                        "--tasks-dir",
+                        str(tasks_dir),
+                    ],
+                )
+
+        assert result.exit_code == 0, (
+            f"exit_code={result.exit_code}, stderr={result.stderr}"
+        )
+
+    def test_run_tasks_dir_mutual_exclusion(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-test.yaml").write_text("description: dummy\n")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "workflow.yaml",
+                "--tasks-dir",
+                str(tasks_dir),
+                "--input",
+                "foo=bar",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.stderr.lower()
+
+    def test_run_tasks_dir_requires_workflow(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-test.yaml").write_text("description: dummy\n")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["run", "--tasks-dir", str(tasks_dir)],
+        )
+        assert result.exit_code == 2
+        assert "required" in result.stderr.lower()
+
+    def test_run_tasks_dir_rejects_symlink_dir(self, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        save_task_file(
+            real_dir / "001-test.yaml", TaskFile(entries=[TaskEntry(description="t")])
+        )
+
+        symlink_dir = tmp_path / "link"
+        symlink_dir.symlink_to(real_dir)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["run", "tests/fixtures/batch_flow.yaml", "--tasks-dir", str(symlink_dir)],
+        )
+        assert result.exit_code == 2
+        assert "symlink" in result.stderr.lower()

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -186,10 +186,11 @@ class TestRunTasksDir:
                 assert r["status"] == "completed"
                 assert r["category"] == "new"
 
-            loaded_a = load_task_file(tasks_dir / "001-a.yaml")
+            # Files are moved to completed/ once all entries finish
+            loaded_a = load_task_file(tasks_dir / "completed" / "001-a.yaml")
             assert loaded_a.entries[0].status == "completed"
 
-            loaded_b = load_task_file(tasks_dir / "002-b.yaml")
+            loaded_b = load_task_file(tasks_dir / "completed" / "002-b.yaml")
             assert loaded_b.entries[0].status == "completed"
 
     def test_skips_completed_entries(self):
@@ -255,7 +256,8 @@ class TestRunTasksDir:
             assert results[0]["status"] == "completed"
             assert results[0]["category"] == "retried"
 
-            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            # File is moved to completed/ once all entries finish
+            loaded = load_task_file(tasks_dir / "completed" / "001-test.yaml")
             assert loaded.entries[0].status == "completed"
             assert loaded.entries[0].error is None
 
@@ -314,7 +316,8 @@ class TestRunTasksDir:
             assert call_count[0] == 3
             assert len(results) == 3
 
-            loaded = load_task_file(tasks_dir / "001-multi.yaml")
+            # File is moved to completed/ once all entries finish
+            loaded = load_task_file(tasks_dir / "completed" / "001-multi.yaml")
             for entry in loaded.entries:
                 assert entry.status == "completed"
 
@@ -639,6 +642,142 @@ class TestTasksDirCli:
         )
         assert result.exit_code == 2
         assert "mutually exclusive" in result.stderr.lower()
+
+
+class TestMoveToCompletedOnRunTasksDir:
+    """Tests for FR-3: files are moved to completed/ after all entries complete."""
+
+    def test_completed_file_moved_to_completed_subdir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert not (tasks_dir / "001-a.yaml").exists()
+            assert (tasks_dir / "completed" / "001-a.yaml").exists()
+
+    def test_failed_file_stays_in_tasks_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", side_effect=RuntimeError("fail")):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["n"]):
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            # File with failed entry must remain in tasks_dir
+            assert (tasks_dir / "001-a.yaml").exists()
+            assert not (tasks_dir / "completed" / "001-a.yaml").exists()
+
+    def test_partial_completion_file_stays_in_tasks_dir(self):
+        """File with mixed completed/failed entries must not be moved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="task 1"),
+                    TaskEntry(description="task 2"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-mixed.yaml", tf)
+
+            call_count = [0]
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir):
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    raise RuntimeError("first fails")
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["y"]):
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert (tasks_dir / "001-mixed.yaml").exists()
+            assert not (tasks_dir / "completed" / "001-mixed.yaml").exists()
+
+    def test_pre_completed_file_moved_to_completed_subdir(self):
+        """Files that were already fully completed (skipped) should also be moved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[TaskEntry(description="already done", status="completed")]
+            )
+            save_task_file(tasks_dir / "001-done.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow") as mock_run:
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            mock_run.assert_not_called()
+            assert not (tasks_dir / "001-done.yaml").exists()
+            assert (tasks_dir / "completed" / "001-done.yaml").exists()
+
+    def test_move_failure_logs_warning_and_does_not_abort(self, capsys):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.core.engine.move_task_to_completed",
+                        side_effect=OSError("disk full"),
+                    ):
+                        results = engine.run_tasks_dir(
+                            flow_path, tasks_dir, auto_workflow=True
+                        )
+
+            captured = capsys.readouterr()
+            assert "Warning" in captured.err
+            assert "001-a.yaml" in captured.err
+            # Execution should still complete
+            assert len(results) == 1
+            assert results[0]["status"] == "completed"
+
+    def test_collision_logs_warning(self, capsys):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            # Put a file in completed/ to trigger a collision
+            completed_dir = tasks_dir / "completed"
+            completed_dir.mkdir()
+            (completed_dir / "001-a.yaml").write_text("collision\n")
+
+            tf = TaskFile(entries=[TaskEntry(description="task A")])
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
+
+            captured = capsys.readouterr()
+            assert "Warning" in captured.err
+            # Original file not lost on collision
+            assert (tasks_dir / "001-a.yaml").exists()
+            assert len(results) == 1
+            assert results[0]["status"] == "completed"
 
 
 class TestBatchEditFlow:

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
@@ -177,7 +177,9 @@ class TestRunTasksDir:
 
             with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             assert len(results) == 2
             for r in results:
@@ -215,7 +217,9 @@ class TestRunTasksDir:
 
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             assert run_count[0] == 1
             skipped = [r for r in results if r["category"] == "skipped"]
@@ -243,7 +247,9 @@ class TestRunTasksDir:
 
             with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             assert len(results) == 1
             assert results[0]["status"] == "completed"
@@ -271,7 +277,9 @@ class TestRunTasksDir:
 
             with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             assert len(results) == 1
             assert results[0]["status"] == "completed"
@@ -299,7 +307,9 @@ class TestRunTasksDir:
 
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             assert call_count[0] == 3
             assert len(results) == 3
@@ -331,8 +341,10 @@ class TestRunTasksDir:
 
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    with patch("fdsx.core.engine.input", side_effect=["y", "y"]):
-                        results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    with patch("fdsx.core.engine.input", side_effect=["y"]):
+                        results = engine.run_tasks_dir(
+                            flow_path, tasks_dir, auto_workflow=True
+                        )
 
             assert len(results) == 2
             assert results[0]["status"] == "failed"
@@ -366,7 +378,9 @@ class TestRunTasksDir:
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
                     with patch("fdsx.core.engine.input", side_effect=["n"]):
-                        results = engine.run_tasks_dir(flow_path, tasks_dir)
+                        results = engine.run_tasks_dir(
+                            flow_path, tasks_dir, auto_workflow=True
+                        )
 
             assert len(results) == 1
             assert results[0]["status"] == "failed"
@@ -387,7 +401,9 @@ class TestRunTasksDir:
                 "fdsx.core.engine.run_flow", return_value={"result": "ok"}
             ) as mock_run:
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             mock_run.assert_not_called()
             assert len(results) == 1
@@ -412,7 +428,9 @@ class TestRunTasksDir:
                 "fdsx.core.engine.run_flow", return_value={"result": "ok"}
             ) as mock_run:
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    results = engine.run_tasks_dir(flow_path, tasks_dir)
+                    results = engine.run_tasks_dir(
+                        flow_path, tasks_dir, auto_workflow=True
+                    )
 
             mock_run.assert_not_called()
             assert len(results) == 2
@@ -444,7 +462,9 @@ class TestRunTasksDir:
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
                     with patch("fdsx.core.engine.input", side_effect=["n"]):
-                        results = engine.run_tasks_dir(flow_path, tasks_dir)
+                        results = engine.run_tasks_dir(
+                            flow_path, tasks_dir, auto_workflow=True
+                        )
 
             assert len(results) == 1
             assert results[0]["status"] == "failed"
@@ -468,7 +488,7 @@ class TestRunTasksDir:
             with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
                     with patch("fdsx.core.engine.input", side_effect=["n"]):
-                        engine.run_tasks_dir(flow_path, tasks_dir)
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
 
             loaded = load_task_file(tasks_dir / "001-test.yaml")
             assert loaded.entries[0].thread_id is not None
@@ -542,6 +562,7 @@ class TestTasksDirCli:
                         str(workflow_path),
                         "--tasks-dir",
                         str(tasks_dir),
+                        "--auto-workflow",
                     ],
                 )
 
@@ -569,7 +590,7 @@ class TestTasksDirCli:
         assert result.exit_code == 2
         assert "mutually exclusive" in result.stderr.lower()
 
-    def test_run_tasks_dir_requires_workflow(self, tmp_path):
+    def test_run_tasks_dir_without_workflow_requires_auto_workflow(self, tmp_path):
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         (tasks_dir / "001-test.yaml").write_text("description: dummy\n")
@@ -577,10 +598,10 @@ class TestTasksDirCli:
         runner = CliRunner()
         result = runner.invoke(
             app,
-            ["run", "--tasks-dir", str(tasks_dir)],
+            ["run", "--tasks-dir", str(tasks_dir), "--auto-workflow"],
         )
-        assert result.exit_code == 2
-        assert "required" in result.stderr.lower()
+        assert result.exit_code == 1
+        assert "No workflows found" in result.stderr
 
     def test_run_tasks_dir_rejects_symlink_dir(self, tmp_path):
         real_dir = tmp_path / "real"
@@ -599,3 +620,158 @@ class TestTasksDirCli:
         )
         assert result.exit_code == 2
         assert "symlink" in result.stderr.lower()
+
+    def test_auto_and_confirm_workflow_mutually_exclusive(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-test.yaml").write_text("description: dummy\n")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "run",
+                "--tasks-dir",
+                str(tasks_dir),
+                "--auto-workflow",
+                "--confirm-workflow",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "mutually exclusive" in result.stderr.lower()
+
+
+class TestBatchEditFlow:
+    """Regression tests for FR-6.3 batch edit flow (Finding 1).
+
+    When the user rejects the batch workflow assignments, the engine must allow
+    per-entry keep/change instead of aborting immediately.
+    """
+
+    def _make_workflow_yaml(self, name: str, description: str) -> str:
+        import yaml
+
+        return yaml.dump(
+            {
+                "name": name,
+                "description": description,
+                "start_at": "s",
+                "states": {
+                    "s": {
+                        "type": "task",
+                        "provider": "system",
+                        "command": "echo done",
+                        "result_path": "$.result",
+                        "end": True,
+                    }
+                },
+            }
+        )
+
+    def test_reject_then_keep_all_proceeds(self, tmp_path):
+        """Reject batch, then keep all entries — execution should proceed."""
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "plan.yaml").write_text(
+            self._make_workflow_yaml("Plan", "Planning workflow")
+        )
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="plan this feature")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0, stdout="plan.yaml", stderr=""
+        )
+
+        # inputs to engine: "n" = reject batch, "k" = keep entry
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.core.engine.input",
+                        side_effect=["n", "k"],
+                    ):
+                        results = engine.run_tasks_dir(
+                            None,
+                            tasks_dir,
+                            base_dir=project_root / ".fdsx",
+                            auto_workflow=False,
+                        )
+
+        assert len([r for r in results if r["category"] == "new"]) == 1
+
+    def test_reject_then_cancel_during_edit_aborts(self, tmp_path):
+        """Reject batch, then cancel during pick_workflow_manually — aborts."""
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "plan.yaml").write_text(
+            self._make_workflow_yaml("Plan", "Planning workflow")
+        )
+        (workflows_dir / "impl.yaml").write_text(
+            self._make_workflow_yaml("Impl", "Implementation workflow")
+        )
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="do something")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0, stdout="plan.yaml", stderr=""
+        )
+
+        # engine inputs: "n" = reject batch, "c" = change
+        # selector inputs: "c" = cancel during pick
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["n", "c"]):
+                        with patch("fdsx.core.selector.input", return_value="c"):
+                            results = engine.run_tasks_dir(
+                                None,
+                                tasks_dir,
+                                base_dir=project_root / ".fdsx",
+                                auto_workflow=False,
+                            )
+
+        # Cancelled during edit → empty results (aborted)
+        assert results == []
+
+    def test_approve_batch_skips_edit_flow(self, tmp_path):
+        """Approve batch on first prompt — no per-entry prompts are called."""
+        project_root = tmp_path
+        workflows_dir = project_root / ".fdsx" / "workflows"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "plan.yaml").write_text(
+            self._make_workflow_yaml("Plan", "Planning workflow")
+        )
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="plan this feature")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0, stdout="plan.yaml", stderr=""
+        )
+
+        # Only "y" for batch approve — no keep/change prompts follow
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch("fdsx.core.engine.input", side_effect=["y"]):
+                        results = engine.run_tasks_dir(
+                            None,
+                            tasks_dir,
+                            base_dir=project_root / ".fdsx",
+                            auto_workflow=False,
+                        )
+
+        assert len([r for r in results if r["category"] == "new"]) == 1

--- a/tests/integration/test_workflow_persistence.py
+++ b/tests/integration/test_workflow_persistence.py
@@ -1,0 +1,209 @@
+"""Integration tests for workflow assignment persistence (T017, T018)."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.core import engine
+from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
+
+
+class TestWorkflowPersistence:
+    """Tests for workflow persistence to task YAML files."""
+
+    def test_confirm_persists_workflow_to_yaml(self):
+        """Confirming in CUI persists workflow field to task YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="Fix the bug")])
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.display.terminal.is_interactive", return_value=False
+                    ):
+                        results = engine.run_tasks_dir(
+                            flow_path, tasks_dir, auto_workflow=False
+                        )
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].workflow is not None
+            assert results[0]["status"] == "completed"
+
+    def test_cancel_does_not_persist_workflow(self):
+        """Cancelling in CUI does not modify the workflow field in YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="Fix the bug")])
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.display.terminal.is_interactive", return_value=False
+                    ):
+                        with patch(
+                            "fdsx.display.terminal.confirm_workflow_assignments_interactive",
+                            return_value=None,
+                        ):
+                            results = engine.run_tasks_dir(
+                                flow_path, tasks_dir, auto_workflow=False
+                            )
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].workflow is None
+
+    def test_pre_existing_workflow_skips_auto_selection(self):
+        """Tasks with workflow already set skip auto-selection."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[TaskEntry(description="Fix the bug", workflow="review.yaml")]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            resolve_calls = []
+
+            def mock_resolve(
+                task_description, workflows_dir, selector_config, auto_workflow
+            ):
+                resolve_calls.append(
+                    {
+                        "desc": task_description,
+                        "auto": auto_workflow,
+                    }
+                )
+                return workflows_dir / "review.yaml"
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.core.selector.resolve_workflow_for_task",
+                        side_effect=mock_resolve,
+                    ):
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert len(resolve_calls) == 0, (
+                "resolve_workflow_for_task should not be called when "
+                "entry.workflow is already set"
+            )
+
+    def test_rerun_with_persisted_workflow_skips_selector(self):
+        """Re-running after workflow is persisted skips the selector."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[TaskEntry(description="Fix the bug", workflow="review.yaml")]
+            )
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            selector_called = []
+
+            def track_selector(*args, **kwargs):
+                selector_called.append(True)
+                return Path("review.yaml")
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.core.selector.resolve_workflow_for_task",
+                        side_effect=track_selector,
+                    ):
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert len(selector_called) == 0, (
+                "Selector should not be called when workflow is already persisted"
+            )
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].workflow == "review.yaml"
+            assert loaded.entries[0].status == "completed"
+
+    def test_non_tty_auto_confirm_persists_workflow(self):
+        """Non-TTY mode auto-confirms and persists workflow to YAML."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="Fix the bug")])
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.display.terminal.is_interactive", return_value=False
+                    ):
+                        with patch(
+                            "fdsx.display.terminal.confirm_workflow_assignments_interactive"
+                        ) as mock_cui:
+                            mock_cui.return_value = {(0, 0): Path("review.yaml")}
+                            results = engine.run_tasks_dir(
+                                flow_path, tasks_dir, auto_workflow=False
+                            )
+
+            mock_cui.assert_called_once()
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].workflow == "review.yaml"
+
+    def test_workflow_persists_with_correct_filename_format(self):
+        """Persisted workflow is stored as filename only (not full path)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(entries=[TaskEntry(description="Fix the bug")])
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.display.terminal.is_interactive", return_value=False
+                    ):
+                        results = engine.run_tasks_dir(
+                            flow_path, tasks_dir, auto_workflow=False
+                        )
+
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            wf = loaded.entries[0].workflow
+            assert wf is not None
+            assert "/" not in wf
+            assert "\\" not in wf
+            assert wf == Path(wf).name
+
+    def test_multiple_entries_all_persisted(self):
+        """All workflow assignments are persisted for multi-entry files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = Path("tests/fixtures/batch_flow.yaml")
+
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="Task A"),
+                    TaskEntry(description="Task B"),
+                    TaskEntry(description="Task C"),
+                ]
+            )
+            save_task_file(tasks_dir / "001-multi.yaml", tf)
+
+            with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    with patch(
+                        "fdsx.display.terminal.is_interactive", return_value=False
+                    ):
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=False)
+
+            loaded = load_task_file(tasks_dir / "001-multi.yaml")
+            for entry in loaded.entries:
+                assert entry.workflow is not None
+                assert entry.status == "completed"

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -305,6 +305,7 @@ class TestMinSuccessDefault:
 
         flow = Flow(
             name="Min Success Default Test",
+            description="Test flow for min_success default",
             start_at="parallel_state",
             states={
                 "parallel_state": ParallelState(

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -438,6 +438,30 @@ class TestBuildTaskSplitPrompt:
 
         assert "independent tasks" in prompt.lower() or "SEPARATE groups" in prompt
 
+    def test_build_task_split_prompt_contains_feature_level_instruction(self):
+        """Prompt must instruct grouping related work into feature-level tasks."""
+        prompt = _build_task_split_prompt("test content", None, None)
+
+        assert "feature-level" in prompt.lower()
+
+    def test_build_task_split_prompt_contains_substeps_instruction(self):
+        """Prompt must instruct including numbered sub-steps within task descriptions."""
+        prompt = _build_task_split_prompt("test content", None, None)
+
+        assert "sub-step" in prompt.lower() or "numbered" in prompt.lower()
+
+    def test_build_task_split_prompt_contains_anti_examples(self):
+        """Prompt must include anti-examples (BAD) showing micro-tasks to avoid."""
+        prompt = _build_task_split_prompt("test content", None, None)
+
+        assert "BAD" in prompt or "Do NOT" in prompt
+
+    def test_build_task_split_prompt_contains_few_shot_example(self):
+        """Prompt must include a few-shot example showing both BAD and GOOD patterns."""
+        prompt = _build_task_split_prompt("test content", None, None)
+
+        assert "BAD" in prompt and "GOOD" in prompt
+
 
 class TestExtractInputVariables:
     def test_extract_from_task_states_with_prompt_template(self):

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -1,23 +1,67 @@
+import tempfile
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 
 from fdsx.core.batch import (
+    TASKS_DIR,
+    _slugify,
     split_tasks,
+    split_tasks_to_groups,
     display_task_list,
     display_batch_summary,
     _parse_task_list,
+    _parse_structured_tasks,
     _build_task_split_prompt,
     _extract_input_variables,
+    write_task_files,
 )
 from fdsx.core.config import TaskSplitterConfig
 from fdsx.models.flow import Flow, TaskState
+from fdsx.models.task import TaskEntry
 
 
 class TestSplitTasks:
-    def test_split_tasks_parses_numbered_list(self):
+    def test_split_tasks_parses_json_response(self):
         flow = Flow(
             name="Test Flow",
             description="Test flow for split tasks",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        task_splitter = TaskSplitterConfig(
+            provider="claude", model="claude-3-5-sonnet-20241022"
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "First task"}, {"description": "Second task"}], [{"description": "Third task"}]]',
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            tasks = split_tasks("test content", flow, task_splitter)
+
+        assert len(tasks) == 3
+        assert tasks[0] == "First task"
+        assert tasks[1] == "Second task"
+        assert tasks[2] == "Third task"
+
+    def test_split_tasks_fallback_to_numbered_list(self):
+        """If JSON parsing fails, fall back to numbered list parsing."""
+        flow = Flow(
+            name="Test Flow",
+            description="Test flow for fallback",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -110,6 +154,63 @@ class TestSplitTasks:
                 split_tasks("test content", flow, task_splitter)
 
 
+class TestSplitTasksToGroups:
+    def test_split_tasks_to_groups_parses_json(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task A"}, {"description": "Task B"}], [{"description": "Task C"}]]',
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups("test content", task_splitter)
+
+        assert len(groups) == 2
+        assert len(groups[0]) == 2
+        assert len(groups[1]) == 1
+        assert groups[0][0].description == "Task A"
+        assert groups[0][1].description == "Task B"
+        assert groups[1][0].description == "Task C"
+
+    def test_split_tasks_to_groups_with_optional_context(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task 1"}]]',
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups(
+                "test content",
+                task_splitter,
+                state_names=["plan", "implement"],
+                input_vars={"task", "context"},
+            )
+
+        assert len(groups) == 1
+        assert groups[0][0].description == "Task 1"
+
+    def test_split_tasks_to_groups_provider_failure(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=1,
+            stdout="",
+            stderr="Provider error",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with pytest.raises(RuntimeError, match="Task splitter failed"):
+                split_tasks_to_groups("test content", task_splitter)
+
+
 class TestDisplayTaskList:
     def test_display_task_list_approve(self):
         tasks = ["First task", "Second task", "Third task"]
@@ -193,8 +294,124 @@ class TestParseTaskList:
         assert len(tasks) == 2
 
 
+class TestParseStructuredTasks:
+    def test_parse_json_with_code_block(self):
+        response = """```json
+[[{"description": "Task 1"}, {"description": "Task 2"}], [{"description": "Task 3"}]]
+```"""
+        groups = _parse_structured_tasks(response)
+
+        assert len(groups) == 2
+        assert len(groups[0]) == 2
+        assert len(groups[1]) == 1
+        assert groups[0][0].description == "Task 1"
+        assert groups[0][1].description == "Task 2"
+        assert groups[1][0].description == "Task 3"
+
+    def test_parse_json_without_code_block(self):
+        response = '[[{"description": "Task A"}, {"description": "Task B"}]]'
+        groups = _parse_structured_tasks(response)
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 2
+
+    def test_parse_empty_groups(self):
+        response = "[]"
+        groups = _parse_structured_tasks(response)
+
+        assert groups == []
+
+    def test_parse_invalid_json(self):
+        response = "not valid json"
+        with pytest.raises(ValueError, match="Failed to parse JSON"):
+            _parse_structured_tasks(response)
+
+    def test_parse_invalid_format_not_array(self):
+        response = '{"description": "Single task"}'
+        with pytest.raises(ValueError, match="Expected JSON array"):
+            _parse_structured_tasks(response)
+
+    def test_parse_invalid_group_not_array(self):
+        response = '[{"description": "Single task"}]'
+        with pytest.raises(ValueError, match="Group 0 must be an array"):
+            _parse_structured_tasks(response)
+
+    def test_parse_missing_description(self):
+        response = '[[{"name": "Task without description"}]]'
+        with pytest.raises(ValueError, match="missing required 'description'"):
+            _parse_structured_tasks(response)
+
+    def test_parse_task_entries_have_correct_defaults(self):
+        response = '[[{"description": "Test task"}]]'
+        groups = _parse_structured_tasks(response)
+
+        assert len(groups) == 1
+        assert groups[0][0].status == "pending"
+        assert groups[0][0].workflow is None
+        assert groups[0][0].thread_id is None
+        assert groups[0][0].error is None
+
+
+class TestWriteTaskFiles:
+    def test_write_task_files_creates_numbered_files(self):
+        groups = [
+            [TaskEntry(description="Task 1"), TaskEntry(description="Task 2")],
+            [TaskEntry(description="Task 3")],
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks"
+            created = write_task_files(groups, tasks_dir)
+
+            assert len(created) == 2
+            assert (tasks_dir / "001-task-1.yaml").exists()
+            assert (tasks_dir / "002-task-3.yaml").exists()
+
+    def test_write_task_files_skips_empty_groups(self):
+        groups = [
+            [TaskEntry(description="Task 1")],
+            [],
+            [TaskEntry(description="Task 2")],
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks"
+            created = write_task_files(groups, tasks_dir)
+
+            assert len(created) == 2
+            assert (tasks_dir / "001-task-1.yaml").exists()
+            assert not any(f.name.startswith("002-") for f in tasks_dir.iterdir())
+            assert (tasks_dir / "003-task-2.yaml").exists()
+
+    def test_write_task_files_creates_correct_yaml_content(self):
+        groups = [
+            [TaskEntry(description="First task"), TaskEntry(description="Second task")],
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir) / "tasks"
+            write_task_files(groups, tasks_dir)
+
+            content = (tasks_dir / "001-first-task.yaml").read_text()
+            assert "First task" in content
+            assert "Second task" in content
+
+    def test_write_task_files_rejects_symlinked_parent(self, tmp_path):
+        groups = [
+            [TaskEntry(description="Task 1")],
+        ]
+
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link"
+        link_dir.symlink_to(real_dir)
+
+        with pytest.raises(ValueError, match="Refusing to write"):
+            write_task_files(groups, link_dir / "tasks")
+
+
 class TestBuildTaskSplitPrompt:
-    def test_build_prompt(self):
+    def test_build_prompt_with_state_names_and_input_vars(self):
         prompt = _build_task_split_prompt(
             "test content", ["plan", "implement"], {"task"}
         )
@@ -202,6 +419,21 @@ class TestBuildTaskSplitPrompt:
         assert "test content" in prompt
         assert "plan, implement" in prompt
         assert "task" in prompt
+        assert "JSON" in prompt
+        assert "DEPEND on each other sequentially" in prompt
+
+    def test_build_prompt_without_optional_params(self):
+        prompt = _build_task_split_prompt("test content", None, None)
+
+        assert "test content" in prompt
+        assert "any workflow" in prompt
+        assert "task" in prompt
+        assert "DEPEND on each other sequentially" in prompt
+
+    def test_build_prompt_independent_tasks_go_in_separate_groups(self):
+        prompt = _build_task_split_prompt("test content", None, None)
+
+        assert "independent tasks" in prompt.lower() or "SEPARATE groups" in prompt
 
 
 class TestExtractInputVariables:
@@ -343,12 +575,14 @@ class TestSplitTasksWithConfig:
                 )
             },
         )
-        config_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+        config_splitter = TaskSplitterConfig(
+            provider="claude", model="claude-sonnet-4-6"
+        )
 
         mock_provider = MagicMock()
         mock_provider.execute.return_value = MagicMock(
             exit_code=0,
-            stdout="1. Task A\n2. Task B",
+            stdout='[[{"description": "Task A"}, {"description": "Task B"}]]',
             stderr="",
         )
 
@@ -359,3 +593,41 @@ class TestSplitTasksWithConfig:
         # Verify the model from TaskSplitterConfig was forwarded to the provider
         call_kwargs = mock_provider.execute.call_args[1]
         assert call_kwargs["model"] == "claude-sonnet-4-6"
+
+
+class TestTaskConstants:
+    def test_tasks_dir_constant(self):
+        assert TASKS_DIR == ".fdsx/tasks"
+
+
+class TestSlugify:
+    def test_basic_text(self):
+        assert _slugify("Hello World") == "hello-world"
+
+    def test_lowercase_conversion(self):
+        assert _slugify("IMPLEMENT Feature A") == "implement-feature-a"
+
+    def test_special_characters_removed(self):
+        assert _slugify("Task: Fix bug!") == "task-fix-bug"
+
+    def test_multiple_spaces_collapsed(self):
+        assert _slugify("Task   with   spaces") == "task-with-spaces"
+
+    def test_long_text_truncated(self):
+        long_text = "a" * 60
+        result = _slugify(long_text, max_length=40)
+        assert len(result) <= 40
+
+    def test_empty_string_returns_task(self):
+        assert _slugify("") == "task"
+
+    def test_only_special_chars_returns_task(self):
+        assert _slugify("!!!###") == "task"
+
+    def test_hyphens_not_duplicated(self):
+        assert _slugify("task--double") == "task-double"
+
+    def test_leading_trailing_hyphens_stripped(self):
+        result = _slugify("  leading and trailing  ")
+        assert not result.startswith("-")
+        assert not result.endswith("-")

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -5,8 +5,11 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from fdsx.core.batch import (
+    COMPLETED_SUBDIR,
     TASKS_DIR,
+    _scan_max_task_index,
     _slugify,
+    move_task_to_completed,
     split_tasks,
     split_tasks_to_groups,
     display_task_list,
@@ -599,6 +602,9 @@ class TestTaskConstants:
     def test_tasks_dir_constant(self):
         assert TASKS_DIR == ".fdsx/tasks"
 
+    def test_completed_subdir_constant(self):
+        assert COMPLETED_SUBDIR == "completed"
+
 
 class TestSlugify:
     def test_basic_text(self):
@@ -631,3 +637,166 @@ class TestSlugify:
         result = _slugify("  leading and trailing  ")
         assert not result.startswith("-")
         assert not result.endswith("-")
+
+
+class TestScanMaxTaskIndex:
+    def test_returns_zero_for_empty_dir(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        assert _scan_max_task_index(tasks_dir) == 0
+
+    def test_returns_zero_for_nonexistent_dir(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        assert _scan_max_task_index(tasks_dir) == 0
+
+    def test_finds_max_in_tasks_dir(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-a.yaml").write_text("")
+        (tasks_dir / "003-b.yaml").write_text("")
+        (tasks_dir / "002-c.yaml").write_text("")
+        assert _scan_max_task_index(tasks_dir) == 3
+
+    def test_finds_max_in_completed_subdir(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-a.yaml").write_text("")
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir()
+        (completed_dir / "005-old.yaml").write_text("")
+        assert _scan_max_task_index(tasks_dir) == 5
+
+    def test_returns_max_across_both_dirs(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "003-active.yaml").write_text("")
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir()
+        (completed_dir / "007-old.yaml").write_text("")
+        (completed_dir / "002-older.yaml").write_text("")
+        assert _scan_max_task_index(tasks_dir) == 7
+
+    def test_ignores_files_without_numeric_prefix(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "no-prefix.yaml").write_text("")
+        (tasks_dir / "abc-task.yaml").write_text("")
+        assert _scan_max_task_index(tasks_dir) == 0
+
+    def test_ignores_non_yaml_files(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "001-a.txt").write_text("")
+        (tasks_dir / "002-b.json").write_text("")
+        assert _scan_max_task_index(tasks_dir) == 0
+
+
+class TestWriteTaskFilesIndexContinuation:
+    def test_new_files_start_after_existing(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        (tasks_dir / "003-existing.yaml").write_text("")
+
+        groups = [[TaskEntry(description="New task")]]
+        created = write_task_files(groups, tasks_dir)
+
+        assert len(created) == 1
+        assert created[0].name == "004-new-task.yaml"
+
+    def test_new_files_start_after_completed_dir(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir()
+        (completed_dir / "005-done.yaml").write_text("")
+
+        groups = [[TaskEntry(description="Another task")]]
+        created = write_task_files(groups, tasks_dir)
+
+        assert len(created) == 1
+        assert created[0].name == "006-another-task.yaml"
+
+    def test_fresh_dir_starts_from_001(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        groups = [[TaskEntry(description="First task")]]
+        created = write_task_files(groups, tasks_dir)
+
+        assert len(created) == 1
+        assert created[0].name == "001-first-task.yaml"
+
+
+class TestMoveTaskToCompleted:
+    def test_moves_file_to_completed_subdir(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "001-test.yaml"
+        task_file.write_text("description: test\n")
+
+        move_task_to_completed(task_file)
+
+        assert not task_file.exists()
+        assert (tasks_dir / COMPLETED_SUBDIR / "001-test.yaml").exists()
+
+    def test_creates_completed_dir_if_absent(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "001-task.yaml"
+        task_file.write_text("description: task\n")
+
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        assert not completed_dir.exists()
+
+        move_task_to_completed(task_file)
+
+        assert completed_dir.exists()
+        assert completed_dir.is_dir()
+
+    def test_preserves_original_filename(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "042-my-important-task.yaml"
+        task_file.write_text("description: task\n")
+
+        move_task_to_completed(task_file)
+
+        assert (tasks_dir / COMPLETED_SUBDIR / "042-my-important-task.yaml").exists()
+
+    def test_raises_on_collision(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        completed_dir = tasks_dir / COMPLETED_SUBDIR
+        completed_dir.mkdir()
+
+        task_file = tasks_dir / "001-test.yaml"
+        task_file.write_text("description: test\n")
+        (completed_dir / "001-test.yaml").write_text("description: existing\n")
+
+        with pytest.raises(FileExistsError, match="already exists"):
+            move_task_to_completed(task_file)
+
+        # Original file must not be removed on collision
+        assert task_file.exists()
+
+    def test_raises_on_symlinked_ancestor(self, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link"
+        link_dir.symlink_to(real_dir)
+
+        task_file = link_dir / "001-task.yaml"
+        task_file.write_text("description: task\n")
+
+        with pytest.raises(ValueError, match="symlink"):
+            move_task_to_completed(task_file)
+
+    def test_preserves_file_content(self, tmp_path):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        task_file = tasks_dir / "001-content.yaml"
+        content = "entries:\n- description: important content\n  status: completed\n"
+        task_file.write_text(content)
+
+        move_task_to_completed(task_file)
+
+        dest = tasks_dir / COMPLETED_SUBDIR / "001-content.yaml"
+        assert dest.read_text() == content

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -9,13 +9,15 @@ from fdsx.core.batch import (
     _build_task_split_prompt,
     _extract_input_variables,
 )
-from fdsx.models.flow import Flow, TaskState, TaskSplitter
+from fdsx.core.config import TaskSplitterConfig
+from fdsx.models.flow import Flow, TaskState
 
 
 class TestSplitTasks:
     def test_split_tasks_parses_numbered_list(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for split tasks",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -27,7 +29,7 @@ class TestSplitTasks:
                 )
             },
         )
-        task_splitter = TaskSplitter(
+        task_splitter = TaskSplitterConfig(
             provider="claude", model="claude-3-5-sonnet-20241022"
         )
 
@@ -49,6 +51,7 @@ class TestSplitTasks:
     def test_split_tasks_empty_response(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for split tasks empty",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -60,7 +63,7 @@ class TestSplitTasks:
                 )
             },
         )
-        task_splitter = TaskSplitter(
+        task_splitter = TaskSplitterConfig(
             provider="claude", model="claude-3-5-sonnet-20241022"
         )
 
@@ -79,6 +82,7 @@ class TestSplitTasks:
     def test_split_tasks_provider_failure(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for provider failure",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -90,7 +94,7 @@ class TestSplitTasks:
                 )
             },
         )
-        task_splitter = TaskSplitter(
+        task_splitter = TaskSplitterConfig(
             provider="claude", model="claude-3-5-sonnet-20241022"
         )
 
@@ -204,6 +208,7 @@ class TestExtractInputVariables:
     def test_extract_from_task_states_with_prompt_template(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for extract input variables",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -234,6 +239,7 @@ class TestExtractInputVariables:
     def test_extract_returns_task_by_default(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for extract task default",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -255,6 +261,7 @@ class TestExtractInputVariables:
 
         flow = Flow(
             name="Test Flow",
+            description="Test flow for extract parallel branches",
             start_at="review",
             states={
                 "review": ParallelState(
@@ -285,6 +292,7 @@ class TestExtractInputVariables:
     def test_extract_dotted_variable_references(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for dotted variable references",
             start_at="plan",
             states={
                 "plan": TaskState(
@@ -305,12 +313,49 @@ class TestExtractInputVariables:
         assert "issue" in input_vars
 
 
-class TestTaskSplitterValidation:
-    def test_task_splitter_rejects_system_provider(self):
+class TestTaskSplitterConfigValidation:
+    def test_task_splitter_config_rejects_system_provider(self):
         with pytest.raises(ValueError, match="task_splitter provider must be one of"):
-            TaskSplitter(provider="system", model="default")
+            TaskSplitterConfig(provider="system", model="default")
 
-    def test_task_splitter_accepts_valid_llm_providers(self):
+    def test_task_splitter_config_accepts_valid_llm_providers(self):
         for provider in ["claude", "opencode", "codex"]:
-            ts = TaskSplitter(provider=provider, model="test-model")
+            ts = TaskSplitterConfig(provider=provider, model="test-model")
             assert ts.provider == provider
+
+
+class TestSplitTasksWithConfig:
+    """Regression tests: split_tasks accepts TaskSplitterConfig from config (T9 migration)."""
+
+    def test_split_tasks_accepts_task_splitter_config(self):
+        """split_tasks must work with TaskSplitterConfig from load_config()."""
+        flow = Flow(
+            name="Config Test Flow",
+            description="Test that split_tasks accepts TaskSplitterConfig",
+            start_at="plan",
+            states={
+                "plan": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        config_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task A\n2. Task B",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            tasks = split_tasks("test content", flow, config_splitter)
+
+        assert tasks == ["Task A", "Task B"]
+        # Verify the model from TaskSplitterConfig was forwarded to the provider
+        call_kwargs = mock_provider.execute.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-6"

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -129,6 +129,107 @@ class TestCheckpointManager:
         threads = manager.list_threads()
         assert threads == []
 
+    def test_list_threads_includes_run_log_only_threads(self, manager, temp_dir):
+        """T003: list_threads must include threads that have a run log but no checkpoint."""
+        import json
+
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+
+        # Create a run log directory for a thread with no checkpoint
+        runs_dir = manager.base_dir / RUNS_DIR_NAME
+        thread_dir = runs_dir / "run-log-only-thread"
+        thread_dir.mkdir(parents=True, exist_ok=True)
+        run_log = {
+            "thread_id": "run-log-only-thread",
+            "flow_name": "my_flow",
+            "started_at": "2026-03-21T10:00:00+00:00",
+            "status": "completed",
+            "states": [],
+        }
+        run_log_path = thread_dir / RUN_FILENAME
+        run_log_path.write_text(json.dumps(run_log))
+
+        threads = manager.list_threads()
+
+        thread_ids = [t["thread_id"] for t in threads]
+        assert "run-log-only-thread" in thread_ids
+
+        entry = next(t for t in threads if t["thread_id"] == "run-log-only-thread")
+        assert entry["flow_name"] == "my_flow"
+
+    def test_list_threads_no_duplicate_for_run_log_and_checkpoint(self, manager, temp_dir):
+        """T003: a thread present in both DB and run log must appear only once."""
+        import json
+        import sqlite3
+
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+
+        # Add thread to checkpoint DB
+        db_path = manager.checkpoints_dir / "checkpoints.db"
+        conn = sqlite3.connect(str(db_path))
+        cursor = conn.cursor()
+        cursor.execute(
+            """CREATE TABLE IF NOT EXISTS checkpoints (
+                thread_id TEXT PRIMARY KEY, checkpoint BLOB, metadata BLOB
+            )"""
+        )
+        cursor.execute(
+            "INSERT INTO checkpoints (thread_id, checkpoint, metadata) VALUES (?, ?, ?)",
+            ("dual-thread", b"fake", b"fake"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Also create a run log for the same thread
+        runs_dir = manager.base_dir / RUNS_DIR_NAME
+        thread_dir = runs_dir / "dual-thread"
+        thread_dir.mkdir(parents=True, exist_ok=True)
+        run_log = {
+            "thread_id": "dual-thread",
+            "flow_name": "my_flow",
+            "started_at": "2026-03-21T10:00:00+00:00",
+            "status": "completed",
+            "states": [],
+        }
+        (thread_dir / RUN_FILENAME).write_text(json.dumps(run_log))
+
+        threads = manager.list_threads()
+
+        dual_entries = [t for t in threads if t["thread_id"] == "dual-thread"]
+        assert len(dual_entries) == 1, "Thread must appear exactly once even if in both DB and run log"
+
+    def test_list_threads_ignores_dirs_without_run_json(self, manager, temp_dir):
+        """T003: directories in runs/ without a run.json file must not appear."""
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+
+        runs_dir = manager.base_dir / RUNS_DIR_NAME
+        # A directory without run.json
+        empty_dir = runs_dir / "no-run-json-thread"
+        empty_dir.mkdir(parents=True, exist_ok=True)
+
+        threads = manager.list_threads()
+
+        thread_ids = [t["thread_id"] for t in threads]
+        assert "no-run-json-thread" not in thread_ids
+
+    def test_list_threads_tolerates_corrupt_run_json(self, manager, temp_dir):
+        """F3: corrupt run.json must not crash list_threads — targeted exception handling."""
+        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+
+        runs_dir = manager.base_dir / RUNS_DIR_NAME
+        thread_dir = runs_dir / "corrupt-thread"
+        thread_dir.mkdir(parents=True, exist_ok=True)
+        # Write invalid JSON
+        (thread_dir / RUN_FILENAME).write_text("not valid json {{{")
+
+        # Must not raise; thread appears with fallback values
+        threads = manager.list_threads()
+        thread_ids = [t["thread_id"] for t in threads]
+        assert "corrupt-thread" in thread_ids
+        entry = next(t for t in threads if t["thread_id"] == "corrupt-thread")
+        # flow_name falls back to thread_id when JSON cannot be parsed
+        assert entry["flow_name"] == "corrupt-thread"
+
 
 class TestCheckpointManagerWithMock:
     def test_acquire_lock_concurrent_execution(self, manager):

--- a/tests/unit/test_claude_stream_parser.py
+++ b/tests/unit/test_claude_stream_parser.py
@@ -1,0 +1,341 @@
+"""Unit tests for Claude stream-json NDJSON parser (_make_stream_callback).
+
+Tests verify correct handling of:
+- text_delta events → text forwarded to callback and accumulated
+- thinking_delta events → thinking text forwarded to callback
+- tool_use content_block_start → tool name notification dispatched
+- result event → get_result() returns result field text
+- malformed JSON lines → silently skipped
+- missing result event → fallback to concatenated text_delta content
+- non-streaming / unknown event types → silently ignored
+"""
+
+import json
+
+from fdsx.providers.claude import (
+    ClaudeProvider,
+    _CONTENT_TYPE_TOOL_USE,
+    _DELTA_TYPE_TEXT,
+    _DELTA_TYPE_THINKING,
+    _EVENT_CONTENT_BLOCK_DELTA,
+    _EVENT_CONTENT_BLOCK_START,
+    _EVENT_RESULT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider() -> ClaudeProvider:
+    return ClaudeProvider()
+
+
+def _build_text_delta_line(text: str, index: int = 0) -> str:
+    return json.dumps({"type": _EVENT_CONTENT_BLOCK_DELTA, "index": index, "delta": {"type": _DELTA_TYPE_TEXT, "text": text}})
+
+
+def _build_thinking_delta_line(thinking: str, index: int = 0) -> str:
+    return json.dumps({"type": _EVENT_CONTENT_BLOCK_DELTA, "index": index, "delta": {"type": _DELTA_TYPE_THINKING, "thinking": thinking}})
+
+
+def _build_tool_use_start_line(tool_name: str, index: int = 1) -> str:
+    return json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": index, "content_block": {"type": _CONTENT_TYPE_TOOL_USE, "id": "tu_001", "name": tool_name}})
+
+
+def _build_result_line(result_text: str) -> str:
+    return json.dumps({"type": _EVENT_RESULT, "subtype": "success", "is_error": False, "result": result_text})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTextDelta:
+    """text_delta events dispatch text to callback and accumulate for fallback."""
+
+    def test_text_dispatched_to_callback(self) -> None:
+        """Each text_delta fragment is dispatched to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("Hello"))
+        cb(_build_text_delta_line(" world"))
+
+        assert received == ["Hello", " world"]
+
+    def test_empty_text_delta_not_dispatched(self) -> None:
+        """An empty text_delta string is not forwarded to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line(""))
+
+        assert received == []
+
+    def test_text_accumulated_for_fallback(self) -> None:
+        """text_delta fragments are concatenated when result event is absent."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_text_delta_line("foo"))
+        cb(_build_text_delta_line("bar"))
+
+        assert get_result() == "foobar"
+
+    def test_empty_text_delta_not_accumulated_in_fallback(self) -> None:
+        """Empty text_delta strings are not accumulated into text_parts (boundary-check)."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_text_delta_line(""))
+        cb(_build_text_delta_line(""))
+        # Only empty deltas — no result event — fallback should return None, not ""
+        assert get_result() is None
+
+
+class TestThinkingDelta:
+    """thinking_delta events dispatch thinking text to callback."""
+
+    def test_thinking_dispatched_to_callback(self) -> None:
+        """Non-empty thinking text is forwarded to output_callback with [thinking] prefix."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_thinking_delta_line("Let me think..."))
+
+        assert received == ["[thinking] Let me think..."]
+
+    def test_empty_thinking_not_dispatched(self) -> None:
+        """An empty thinking string is not forwarded to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_thinking_delta_line(""))
+
+        assert received == []
+
+    def test_thinking_does_not_contribute_to_fallback(self) -> None:
+        """thinking_delta content is NOT included in the fallback text accumulation."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_thinking_delta_line("internal reasoning"))
+        # No text_delta lines, no result event → get_result should return None
+        assert get_result() is None
+
+
+class TestToolUseContentBlockStart:
+    """tool_use content_block_start events dispatch a [tool: name] notification."""
+
+    def test_tool_name_dispatched(self) -> None:
+        """Tool name is dispatched to output_callback as '[tool: <name>]'."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+
+        assert received == ["[tool: Bash]"]
+
+    def test_unknown_tool_name_falls_back(self) -> None:
+        """Missing tool name in content_block falls back to 'unknown'."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": 0, "content_block": {"type": _CONTENT_TYPE_TOOL_USE}})
+        cb(line)
+
+        assert received == ["[tool: unknown]"]
+
+    def test_non_tool_use_content_block_start_ignored(self) -> None:
+        """content_block_start with type != tool_use is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": 0, "content_block": {"type": "text", "text": ""}})
+        cb(line)
+
+        assert received == []
+
+
+class TestResultEvent:
+    """result event with subtype=success sets the final stdout."""
+
+    def test_result_text_returned_by_get_result(self) -> None:
+        """get_result() returns the result field from the result event."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_result_line("Final answer text"))
+
+        assert get_result() == "Final answer text"
+
+    def test_result_takes_precedence_over_fallback(self) -> None:
+        """result event text takes precedence over accumulated text_delta content."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_text_delta_line("delta text"))
+        cb(_build_result_line("canonical result"))
+
+        assert get_result() == "canonical result"
+
+    def test_result_with_error_subtype_still_captured(self) -> None:
+        """result event with error subtype still captures text (exit_code conveys error)."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        line = json.dumps({"type": _EVENT_RESULT, "subtype": "error", "result": "error message text"})
+        cb(line)
+
+        assert get_result() == "error message text"
+
+    def test_empty_result_field(self) -> None:
+        """result event with empty string result field returns empty string."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_result_line(""))
+
+        assert get_result() == ""
+
+
+class TestMalformedJsonSkip:
+    """Malformed JSON lines are skipped with a warning logged."""
+
+    def test_malformed_line_skipped(self) -> None:
+        """A line that is not valid JSON is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb("not valid json {{{")
+
+        assert received == []
+        assert get_result() is None
+
+    def test_malformed_line_logs_warning(self) -> None:
+        """A malformed JSON line causes logger.warning to be called (FR-2.8)."""
+        import logging
+        from unittest.mock import patch
+
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None)
+
+        with patch("fdsx.providers.claude.logger") as mock_logger:
+            cb("not valid json {{{")
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            assert "Malformed JSON" in call_args[0]
+
+    def test_processing_continues_after_malformed_line(self) -> None:
+        """Valid lines after a malformed line are still processed."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb("not valid json")
+        cb(_build_text_delta_line("good"))
+
+        assert received == ["good"]
+
+    def test_empty_line_skipped(self) -> None:
+        """Empty and whitespace-only lines are silently skipped."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb("")
+        cb("   ")
+        cb("\t\n")
+
+        assert received == []
+
+
+class TestMissingResultFallback:
+    """When result event is absent, get_result falls back to accumulated text_delta."""
+
+    def test_no_events_returns_none(self) -> None:
+        """With no events processed, get_result() returns None."""
+        provider = _make_provider()
+        _, get_result = provider._make_stream_callback(lambda _: None)
+
+        assert get_result() is None
+
+    def test_fallback_to_text_delta_accumulation(self) -> None:
+        """Accumulated text_delta fragments are returned when result event is absent."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_text_delta_line("Hello"))
+        cb(_build_text_delta_line("! "))
+        cb(_build_text_delta_line("World"))
+        # No result event
+
+        assert get_result() == "Hello! World"
+
+
+class TestNonStreamingEventIgnore:
+    """Unknown or non-streaming event types are silently ignored."""
+
+    def test_system_event_ignored(self) -> None:
+        """system/init events produce no callback calls and no result."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": "system", "subtype": "init", "session_id": "abc"})
+        cb(line)
+
+        assert received == []
+        assert get_result() is None
+
+    def test_message_start_ignored(self) -> None:
+        """message_start events are silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": "message_start", "message": {}})
+        cb(line)
+
+        assert received == []
+
+    def test_message_stop_ignored(self) -> None:
+        """message_stop events are silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(json.dumps({"type": "message_stop"}))
+
+        assert received == []
+
+    def test_content_block_stop_ignored(self) -> None:
+        """content_block_stop events are silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(json.dumps({"type": "content_block_stop", "index": 0}))
+
+        assert received == []
+
+    def test_unknown_event_type_ignored(self) -> None:
+        """Completely unknown event types are silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(json.dumps({"type": "some_future_event", "data": "stuff"}))
+
+        assert received == []

--- a/tests/unit/test_claude_stream_parser.py
+++ b/tests/unit/test_claude_stream_parser.py
@@ -1,13 +1,15 @@
 """Unit tests for Claude stream-json NDJSON parser (_make_stream_callback).
 
 Tests verify correct handling of:
-- text_delta events → text forwarded to callback and accumulated
-- thinking_delta events → thinking text forwarded to callback
+- text_delta events → text buffered and emitted as lines
+- thinking_delta events → thinking text buffered with [thinking] prefix
 - tool_use content_block_start → tool name notification dispatched
 - result event → get_result() returns result field text
 - malformed JSON lines → silently skipped
 - missing result event → fallback to concatenated text_delta content
 - non-streaming / unknown event types → silently ignored
+- line buffering: fragments accumulated, emitted on newline or content_block_stop
+- stream_event envelope unwrapping
 """
 
 import json
@@ -19,6 +21,7 @@ from fdsx.providers.claude import (
     _DELTA_TYPE_THINKING,
     _EVENT_CONTENT_BLOCK_DELTA,
     _EVENT_CONTENT_BLOCK_START,
+    _EVENT_CONTENT_BLOCK_STOP,
     _EVENT_RESULT,
 )
 
@@ -44,8 +47,17 @@ def _build_tool_use_start_line(tool_name: str, index: int = 1) -> str:
     return json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": index, "content_block": {"type": _CONTENT_TYPE_TOOL_USE, "id": "tu_001", "name": tool_name}})
 
 
+def _build_content_block_stop_line(index: int = 0) -> str:
+    return json.dumps({"type": _EVENT_CONTENT_BLOCK_STOP, "index": index})
+
+
 def _build_result_line(result_text: str) -> str:
     return json.dumps({"type": _EVENT_RESULT, "subtype": "success", "is_error": False, "result": result_text})
+
+
+def _wrap_in_stream_event(inner_json: str) -> str:
+    """Wrap a raw event JSON string in the Claude CLI stream_event envelope."""
+    return json.dumps({"type": "stream_event", "event": json.loads(inner_json)})
 
 
 # ---------------------------------------------------------------------------
@@ -57,30 +69,32 @@ class TestTextDelta:
     """text_delta events dispatch text to callback and accumulate for fallback."""
 
     def test_text_dispatched_to_callback(self) -> None:
-        """Each text_delta fragment is dispatched to output_callback."""
+        """text_delta fragments are buffered and emitted as one line on flush."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb(_build_text_delta_line("Hello"))
         cb(_build_text_delta_line(" world"))
+        flush()
 
-        assert received == ["Hello", " world"]
+        assert received == ["Hello world"]
 
     def test_empty_text_delta_not_dispatched(self) -> None:
-        """An empty text_delta string is not forwarded to output_callback."""
+        """An empty text_delta string produces no output even after flush."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb(_build_text_delta_line(""))
+        flush()
 
         assert received == []
 
     def test_text_accumulated_for_fallback(self) -> None:
         """text_delta fragments are concatenated when result event is absent."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_text_delta_line("foo"))
         cb(_build_text_delta_line("bar"))
@@ -90,7 +104,7 @@ class TestTextDelta:
     def test_empty_text_delta_not_accumulated_in_fallback(self) -> None:
         """Empty text_delta strings are not accumulated into text_parts (boundary-check)."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_text_delta_line(""))
         cb(_build_text_delta_line(""))
@@ -102,12 +116,13 @@ class TestThinkingDelta:
     """thinking_delta events dispatch thinking text to callback."""
 
     def test_thinking_dispatched_to_callback(self) -> None:
-        """Non-empty thinking text is forwarded to output_callback with [thinking] prefix."""
+        """Non-empty thinking text is forwarded to output_callback with [thinking] prefix on flush."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb(_build_thinking_delta_line("Let me think..."))
+        flush()
 
         assert received == ["[thinking] Let me think..."]
 
@@ -115,16 +130,17 @@ class TestThinkingDelta:
         """An empty thinking string is not forwarded to output_callback."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb(_build_thinking_delta_line(""))
+        flush()
 
         assert received == []
 
     def test_thinking_does_not_contribute_to_fallback(self) -> None:
         """thinking_delta content is NOT included in the fallback text accumulation."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_thinking_delta_line("internal reasoning"))
         # No text_delta lines, no result event → get_result should return None
@@ -138,7 +154,7 @@ class TestToolUseContentBlockStart:
         """Tool name is dispatched to output_callback as '[tool: <name>]'."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, _ = provider._make_stream_callback(received.append)
 
         cb(_build_tool_use_start_line("Bash"))
 
@@ -148,7 +164,7 @@ class TestToolUseContentBlockStart:
         """Missing tool name in content_block falls back to 'unknown'."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, _ = provider._make_stream_callback(received.append)
 
         line = json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": 0, "content_block": {"type": _CONTENT_TYPE_TOOL_USE}})
         cb(line)
@@ -159,7 +175,7 @@ class TestToolUseContentBlockStart:
         """content_block_start with type != tool_use is silently ignored."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, _ = provider._make_stream_callback(received.append)
 
         line = json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": 0, "content_block": {"type": "text", "text": ""}})
         cb(line)
@@ -173,7 +189,7 @@ class TestResultEvent:
     def test_result_text_returned_by_get_result(self) -> None:
         """get_result() returns the result field from the result event."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_result_line("Final answer text"))
 
@@ -182,7 +198,7 @@ class TestResultEvent:
     def test_result_takes_precedence_over_fallback(self) -> None:
         """result event text takes precedence over accumulated text_delta content."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_text_delta_line("delta text"))
         cb(_build_result_line("canonical result"))
@@ -192,7 +208,7 @@ class TestResultEvent:
     def test_result_with_error_subtype_still_captured(self) -> None:
         """result event with error subtype still captures text (exit_code conveys error)."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         line = json.dumps({"type": _EVENT_RESULT, "subtype": "error", "result": "error message text"})
         cb(line)
@@ -202,7 +218,7 @@ class TestResultEvent:
     def test_empty_result_field(self) -> None:
         """result event with empty string result field returns empty string."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_result_line(""))
 
@@ -216,20 +232,20 @@ class TestMalformedJsonSkip:
         """A line that is not valid JSON is silently ignored."""
         received: list[str] = []
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(received.append)
+        cb, get_result, flush = provider._make_stream_callback(received.append)
 
         cb("not valid json {{{")
+        flush()
 
         assert received == []
         assert get_result() is None
 
     def test_malformed_line_logs_warning(self) -> None:
         """A malformed JSON line causes logger.warning to be called (FR-2.8)."""
-        import logging
         from unittest.mock import patch
 
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(lambda _: None)
+        cb, _, _ = provider._make_stream_callback(lambda _: None)
 
         with patch("fdsx.providers.claude.logger") as mock_logger:
             cb("not valid json {{{")
@@ -241,10 +257,11 @@ class TestMalformedJsonSkip:
         """Valid lines after a malformed line are still processed."""
         received: list[str] = []
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb("not valid json")
         cb(_build_text_delta_line("good"))
+        flush()
 
         assert received == ["good"]
 
@@ -252,11 +269,12 @@ class TestMalformedJsonSkip:
         """Empty and whitespace-only lines are silently skipped."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb("")
         cb("   ")
         cb("\t\n")
+        flush()
 
         assert received == []
 
@@ -267,14 +285,14 @@ class TestMissingResultFallback:
     def test_no_events_returns_none(self) -> None:
         """With no events processed, get_result() returns None."""
         provider = _make_provider()
-        _, get_result = provider._make_stream_callback(lambda _: None)
+        _, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         assert get_result() is None
 
     def test_fallback_to_text_delta_accumulation(self) -> None:
         """Accumulated text_delta fragments are returned when result event is absent."""
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(lambda _: None)
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
         cb(_build_text_delta_line("Hello"))
         cb(_build_text_delta_line("! "))
@@ -291,10 +309,11 @@ class TestNonStreamingEventIgnore:
         """system/init events produce no callback calls and no result."""
         received: list[str] = []
         provider = _make_provider()
-        cb, get_result = provider._make_stream_callback(received.append)
+        cb, get_result, flush = provider._make_stream_callback(received.append)
 
         line = json.dumps({"type": "system", "subtype": "init", "session_id": "abc"})
         cb(line)
+        flush()
 
         assert received == []
         assert get_result() is None
@@ -303,10 +322,11 @@ class TestNonStreamingEventIgnore:
         """message_start events are silently ignored."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         line = json.dumps({"type": "message_start", "message": {}})
         cb(line)
+        flush()
 
         assert received == []
 
@@ -314,19 +334,20 @@ class TestNonStreamingEventIgnore:
         """message_stop events are silently ignored."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb(json.dumps({"type": "message_stop"}))
+        flush()
 
         assert received == []
 
-    def test_content_block_stop_ignored(self) -> None:
-        """content_block_stop events are silently ignored."""
+    def test_content_block_stop_with_empty_buffer(self) -> None:
+        """content_block_stop with no buffered content produces no output."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, _ = provider._make_stream_callback(received.append)
 
-        cb(json.dumps({"type": "content_block_stop", "index": 0}))
+        cb(_build_content_block_stop_line())
 
         assert received == []
 
@@ -334,8 +355,213 @@ class TestNonStreamingEventIgnore:
         """Completely unknown event types are silently ignored."""
         received: list[str] = []
         provider = _make_provider()
-        cb, _ = provider._make_stream_callback(received.append)
+        cb, _, flush = provider._make_stream_callback(received.append)
 
         cb(json.dumps({"type": "some_future_event", "data": "stuff"}))
+        flush()
+
+        assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Line buffering behavior
+# ---------------------------------------------------------------------------
+
+
+class TestLineBuffering:
+    """Fragments are buffered and emitted as complete lines."""
+
+    def test_fragments_combined_on_content_block_stop(self) -> None:
+        """Multiple fragments without newlines combine into one line on content_block_stop."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("Hello"))
+        cb(_build_text_delta_line(" world"))
+        cb(_build_text_delta_line("!"))
+        assert received == []  # nothing emitted yet
+
+        cb(_build_content_block_stop_line())
+        assert received == ["Hello world!"]
+
+    def test_newlines_split_into_separate_callbacks(self) -> None:
+        """Fragments containing newlines emit complete lines immediately."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("line one\nline two\nline three"))
+        flush()
+
+        assert received == ["line one", "line two", "line three"]
+
+    def test_newline_mid_stream_emits_partial(self) -> None:
+        """A newline in the middle of streaming emits the first part, buffers the rest."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("first part"))
+        cb(_build_text_delta_line(" end\nsecond"))
+        assert received == ["first part end"]
+
+        cb(_build_text_delta_line(" part"))
+        flush()
+        assert received == ["first part end", "second part"]
+
+    def test_thinking_fragments_combined(self) -> None:
+        """Thinking fragments are combined with [thinking] prefix on flush."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_build_thinking_delta_line("The"))
+        cb(_build_thinking_delta_line(" user wants"))
+        cb(_build_thinking_delta_line(" to update docs"))
+        flush()
+
+        assert received == ["[thinking] The user wants to update docs"]
+
+    def test_thinking_to_text_transition_flushes(self) -> None:
+        """Switching from thinking to text flushes the thinking buffer first."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_build_thinking_delta_line("reasoning"))
+        assert received == []
+
+        cb(_build_text_delta_line("visible output"))
+        # Thinking should have been flushed by the type transition
+        assert received == ["[thinking] reasoning"]
+
+        flush()
+        assert received == ["[thinking] reasoning", "visible output"]
+
+    def test_text_to_thinking_transition_flushes(self) -> None:
+        """Switching from text to thinking flushes the text buffer first."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("some text"))
+        cb(_build_thinking_delta_line("now thinking"))
+        assert received == ["some text"]
+
+        flush()
+        assert received == ["some text", "[thinking] now thinking"]
+
+    def test_tool_use_flushes_buffer(self) -> None:
+        """tool_use content_block_start flushes any buffered text first."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("before tool"))
+        cb(_build_tool_use_start_line("Read"))
+
+        assert received == ["before tool", "[tool: Read]"]
+
+    def test_result_flushes_buffer(self) -> None:
+        """result event flushes any remaining buffered text."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("trailing text"))
+        cb(_build_result_line("final"))
+
+        assert received == ["trailing text"]
+        assert get_result() == "final"
+
+    def test_flush_is_idempotent(self) -> None:
+        """Calling flush() multiple times does not duplicate output."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_build_text_delta_line("hello"))
+        flush()
+        flush()
+        flush()
+
+        assert received == ["hello"]
+
+
+# ---------------------------------------------------------------------------
+# stream_event envelope unwrapping (Claude CLI wraps API events)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamEventEnvelope:
+    """Claude CLI wraps API-style events in {"type":"stream_event","event":{...}}.
+
+    The parser must unwrap this envelope to extract the inner event.
+    """
+
+    def test_text_delta_in_envelope(self) -> None:
+        """text_delta inside stream_event envelope is dispatched correctly."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_wrap_in_stream_event(_build_text_delta_line("Hello")))
+        flush()
+
+        assert received == ["Hello"]
+
+    def test_thinking_delta_in_envelope(self) -> None:
+        """thinking_delta inside stream_event envelope is dispatched correctly."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(_wrap_in_stream_event(_build_thinking_delta_line("reasoning...")))
+        flush()
+
+        assert received == ["[thinking] reasoning..."]
+
+    def test_tool_use_in_envelope(self) -> None:
+        """tool_use content_block_start inside stream_event envelope is dispatched."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_wrap_in_stream_event(_build_tool_use_start_line("Edit")))
+
+        assert received == ["[tool: Edit]"]
+
+    def test_text_accumulated_from_envelope(self) -> None:
+        """text_delta fragments from enveloped events accumulate for fallback."""
+        provider = _make_provider()
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
+
+        cb(_wrap_in_stream_event(_build_text_delta_line("foo")))
+        cb(_wrap_in_stream_event(_build_text_delta_line("bar")))
+
+        assert get_result() == "foobar"
+
+    def test_content_block_stop_in_envelope_flushes(self) -> None:
+        """content_block_stop inside stream_event envelope flushes buffer."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_wrap_in_stream_event(_build_text_delta_line("buffered")))
+        assert received == []
+
+        cb(_wrap_in_stream_event(_build_content_block_stop_line()))
+        assert received == ["buffered"]
+
+    def test_empty_inner_event_ignored(self) -> None:
+        """stream_event with missing/empty inner event is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, flush = provider._make_stream_callback(received.append)
+
+        cb(json.dumps({"type": "stream_event"}))
+        cb(json.dumps({"type": "stream_event", "event": {}}))
+        flush()
 
         assert received == []

--- a/tests/unit/test_codex_stream_parser.py
+++ b/tests/unit/test_codex_stream_parser.py
@@ -1,0 +1,501 @@
+"""Unit tests for Codex --json JSONL parser (_make_stream_callback).
+
+Tests verify correct handling of:
+- agent_message item.completed → text forwarded to callback and accumulated
+- reasoning item.completed → thinking text forwarded to callback with [thinking] prefix
+- command_execution item.started → [tool: {command}] dispatched to callback
+- file_change item.started → [tool: file_change] dispatched to callback
+- mcp_tool_call item.started → [tool: {name}] dispatched to callback
+- turn.failed event → warning logged, no callback
+- malformed JSON lines → silently skipped with warning
+- multiple agent_message events → concatenated in get_result()
+- partial collection on crash → get_result() returns partial content
+"""
+
+import json
+
+from fdsx.providers.codex import (
+    CodexProvider,
+    _EVENT_ERROR,
+    _EVENT_ITEM_COMPLETED,
+    _EVENT_ITEM_STARTED,
+    _EVENT_TURN_FAILED,
+    _ITEM_TYPE_AGENT_MESSAGE,
+    _ITEM_TYPE_COMMAND_EXECUTION,
+    _ITEM_TYPE_FILE_CHANGE,
+    _ITEM_TYPE_MCP_TOOL_CALL,
+    _ITEM_TYPE_REASONING,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider() -> CodexProvider:
+    return CodexProvider()
+
+
+def _build_item_started(item_type: str, **kwargs: object) -> str:
+    item: dict[str, object] = {"id": "item_001", "type": item_type}
+    item.update(kwargs)
+    return json.dumps({"type": _EVENT_ITEM_STARTED, "item": item})
+
+
+def _build_item_completed(item_type: str, **kwargs: object) -> str:
+    item: dict[str, object] = {"id": "item_001", "type": item_type}
+    item.update(kwargs)
+    return json.dumps({"type": _EVENT_ITEM_COMPLETED, "item": item})
+
+
+def _build_turn_failed(error: str = "Something went wrong") -> str:
+    return json.dumps({"type": _EVENT_TURN_FAILED, "error": error})
+
+
+# ---------------------------------------------------------------------------
+# Tests: agent_message
+# ---------------------------------------------------------------------------
+
+
+class TestAgentMessage:
+    """item.completed agent_message events dispatch text to callback and accumulate."""
+
+    def test_text_dispatched_to_callback(self) -> None:
+        """agent_message text is forwarded to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="Hello!"))
+
+        assert received == ["Hello!"]
+
+    def test_empty_text_not_dispatched(self) -> None:
+        """An empty agent_message text is not forwarded to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text=""))
+
+        assert received == []
+
+    def test_text_accumulated_for_result(self) -> None:
+        """agent_message texts are joined with newline separator in get_result()."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="Hello! "))
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="World"))
+
+        assert get_result() == "Hello! \nWorld"
+
+    def test_no_agent_message_returns_none(self) -> None:
+        """With no agent_message events, get_result() returns None."""
+        provider = _make_provider()
+        _, get_result = provider._make_stream_callback(lambda _: None)
+
+        assert get_result() is None
+
+    def test_agent_message_started_ignored(self) -> None:
+        """item.started for agent_message is silently ignored (text arrives on completed)."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb(_build_item_started(_ITEM_TYPE_AGENT_MESSAGE, text=""))
+
+        assert received == []
+        assert get_result() is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: reasoning
+# ---------------------------------------------------------------------------
+
+
+class TestReasoning:
+    """item.completed reasoning events dispatch thinking text to callback."""
+
+    def test_thinking_dispatched_with_prefix(self) -> None:
+        """Non-empty reasoning text is forwarded with [thinking] prefix."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_REASONING, text="Let me think..."))
+
+        assert received == ["[thinking] Let me think..."]
+
+    def test_empty_reasoning_not_dispatched(self) -> None:
+        """An empty reasoning text is not forwarded to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_REASONING, text=""))
+
+        assert received == []
+
+    def test_reasoning_does_not_contribute_to_result(self) -> None:
+        """Reasoning text is NOT included in get_result() accumulation."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_item_completed(_ITEM_TYPE_REASONING, text="internal reasoning"))
+        # No agent_message events → get_result should return None
+        assert get_result() is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: command_execution
+# ---------------------------------------------------------------------------
+
+
+class TestCommandExecution:
+    """item.started command_execution events dispatch [tool: {command}] to callback."""
+
+    def test_command_dispatched(self) -> None:
+        """Command is dispatched to output_callback as '[tool: <command>]'."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_started(_ITEM_TYPE_COMMAND_EXECUTION, command="echo hello"))
+
+        assert received == ["[tool: echo hello]"]
+
+    def test_missing_command_falls_back_to_unknown(self) -> None:
+        """Missing command field falls back to 'unknown'."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": _ITEM_TYPE_COMMAND_EXECUTION}})
+        cb(line)
+
+        assert received == ["[tool: unknown]"]
+
+    def test_command_execution_completed_ignored(self) -> None:
+        """item.completed for command_execution is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_COMMAND_EXECUTION, command="echo hello", output="hello"))
+
+        assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: file_change
+# ---------------------------------------------------------------------------
+
+
+class TestFileChange:
+    """item.started file_change events dispatch [tool: file_change] to callback."""
+
+    def test_file_change_dispatched(self) -> None:
+        """File change event dispatches '[tool: file_change]' to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_started(_ITEM_TYPE_FILE_CHANGE, path="src/main.py"))
+
+        assert received == ["[tool: file_change]"]
+
+    def test_file_change_completed_ignored(self) -> None:
+        """item.completed for file_change is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_FILE_CHANGE, path="src/main.py"))
+
+        assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: mcp_tool_call
+# ---------------------------------------------------------------------------
+
+
+class TestMcpToolCall:
+    """item.started mcp_tool_call events dispatch [tool: {name}] to callback."""
+
+    def test_tool_name_dispatched(self) -> None:
+        """MCP tool name is dispatched as '[tool: <name>]'."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_started(_ITEM_TYPE_MCP_TOOL_CALL, name="web_search"))
+
+        assert received == ["[tool: web_search]"]
+
+    def test_missing_name_falls_back_to_unknown(self) -> None:
+        """Missing name field falls back to 'unknown'."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": _ITEM_TYPE_MCP_TOOL_CALL}})
+        cb(line)
+
+        assert received == ["[tool: unknown]"]
+
+    def test_mcp_tool_call_completed_ignored(self) -> None:
+        """item.completed for mcp_tool_call is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_MCP_TOOL_CALL, name="web_search", result=""))
+
+        assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: turn.failed
+# ---------------------------------------------------------------------------
+
+
+class TestTurnFailed:
+    """turn.failed events log a warning and do not dispatch to callback."""
+
+    def test_turn_failed_no_callback(self) -> None:
+        """turn.failed does not dispatch any text to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_turn_failed("rate limit exceeded"))
+
+        assert received == []
+
+    def test_turn_failed_logs_warning(self) -> None:
+        """turn.failed causes logger.warning to be called."""
+        from unittest.mock import patch
+
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None)
+
+        with patch("fdsx.providers.codex.logger") as mock_logger:
+            cb(_build_turn_failed("something went wrong"))
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            assert "turn.failed" in call_args[0]
+
+    def test_turn_failed_partial_content_still_available(self) -> None:
+        """After turn.failed, previously accumulated agent_message text is still returned."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="partial"))
+        cb(_build_turn_failed("crash"))
+
+        assert get_result() == "partial"
+
+
+# ---------------------------------------------------------------------------
+# Tests: malformed JSON
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedJsonSkip:
+    """Malformed JSON lines are skipped with a warning logged."""
+
+    def test_malformed_line_skipped(self) -> None:
+        """A line that is not valid JSON is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb("not valid json {{{")
+
+        assert received == []
+        assert get_result() is None
+
+    def test_malformed_line_logs_warning(self) -> None:
+        """A malformed JSON line causes logger.warning to be called."""
+        from unittest.mock import patch
+
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None)
+
+        with patch("fdsx.providers.codex.logger") as mock_logger:
+            cb("not valid json {{{")
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            assert "Malformed JSON" in call_args[0]
+
+    def test_processing_continues_after_malformed_line(self) -> None:
+        """Valid lines after a malformed line are still processed."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb("not valid json")
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="good"))
+
+        assert received == ["good"]
+        assert get_result() == "good"
+
+    def test_empty_line_skipped(self) -> None:
+        """Empty and whitespace-only lines are silently skipped."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        cb("")
+        cb("   ")
+        cb("\t\n")
+
+        assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: multiple agent_message concatenation
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleAgentMessageConcatenation:
+    """Multiple agent_message completed events are concatenated in order."""
+
+    def test_three_messages_concatenated(self) -> None:
+        """Three agent_message blocks are joined with newline separator."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="foo"))
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="bar"))
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="baz"))
+
+        assert get_result() == "foo\nbar\nbaz"
+
+    def test_order_preserved(self) -> None:
+        """Concatenation order matches event arrival order."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="first "))
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="second"))
+
+        assert received == ["first ", "second"]
+        assert get_result() == "first \nsecond"
+
+
+# ---------------------------------------------------------------------------
+# Tests: partial collection on crash
+# ---------------------------------------------------------------------------
+
+
+class TestPartialCollection:
+    """get_result() returns accumulated agent_message content even without all events."""
+
+    def test_partial_result_before_all_events(self) -> None:
+        """If streaming stops early, collected agent_message content is still returned."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="partial answer"))
+        # Simulate no further events (process crash)
+
+        assert get_result() == "partial answer"
+
+    def test_no_events_returns_none(self) -> None:
+        """With no events at all, get_result() returns None."""
+        provider = _make_provider()
+        _, get_result = provider._make_stream_callback(lambda _: None)
+
+        assert get_result() is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: unknown event types ignored
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownEventsIgnored:
+    """Unknown event types and item types are silently ignored."""
+
+    def test_unknown_top_level_event_ignored(self) -> None:
+        """Completely unknown top-level event types produce no callback calls."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        cb(json.dumps({"type": "some_future_event", "data": "stuff"}))
+
+        assert received == []
+        assert get_result() is None
+
+    def test_unknown_item_type_in_started_ignored(self) -> None:
+        """item.started with an unknown item type is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": "future_item"}})
+        cb(line)
+
+        assert received == []
+
+    def test_unknown_item_type_in_completed_ignored(self) -> None:
+        """item.completed with an unknown item type is silently ignored."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_ITEM_COMPLETED, "item": {"id": "x", "type": "future_item"}})
+        cb(line)
+
+        assert received == []
+        assert get_result() is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: error event
+# ---------------------------------------------------------------------------
+
+
+class TestErrorEvent:
+    """error events log a warning and do not dispatch to callback."""
+
+    def test_error_event_no_callback(self) -> None:
+        """error event does not dispatch any text to output_callback."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(received.append)
+
+        line = json.dumps({"type": _EVENT_ERROR, "message": "something went wrong"})
+        cb(line)
+
+        assert received == []
+
+    def test_error_event_logs_warning(self) -> None:
+        """error event causes logger.warning to be called."""
+        from unittest.mock import patch
+
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None)
+
+        with patch("fdsx.providers.codex.logger") as mock_logger:
+            line = json.dumps({"type": _EVENT_ERROR, "message": "quota exceeded"})
+            cb(line)
+            mock_logger.warning.assert_called_once()
+            call_args = mock_logger.warning.call_args[0]
+            assert "error" in call_args[0].lower()
+
+    def test_error_event_partial_content_still_available(self) -> None:
+        """After error event, previously accumulated agent_message text is still returned."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="partial"))
+        cb(json.dumps({"type": _EVENT_ERROR, "message": "network error"}))
+
+        assert get_result() == "partial"

--- a/tests/unit/test_compiler_merge.py
+++ b/tests/unit/test_compiler_merge.py
@@ -1,0 +1,277 @@
+"""Unit tests for _merge_provider_options() in compiler (T016)."""
+
+import pytest
+
+from fdsx.core.compiler import _merge_provider_options
+from fdsx.core.config import FdsxConfig, ProviderConfigs
+from fdsx.models.flow import Flow, TaskState
+from fdsx.providers.claude import ClaudeOptions
+from fdsx.providers.codex import CodexOptions
+
+
+def _make_simple_flow(
+    providers: dict | None = None,
+    task_provider_options: dict | None = None,
+) -> Flow:
+    """Build a minimal single-task flow for testing."""
+    return Flow(
+        name="test",
+        description="Test flow",
+        start_at="step1",
+        states={
+            "step1": TaskState(
+                type="task",
+                provider="claude",
+                model="claude-sonnet",
+                prompt_template="test prompt",
+                result_path="$.result",
+                end=True,
+                provider_options=task_provider_options,
+            )
+        },
+        providers=providers,
+    )
+
+
+def _make_config(claude_options: dict | None = None) -> FdsxConfig:
+    """Build an FdsxConfig with optional claude provider options."""
+    if claude_options is None:
+        return FdsxConfig()
+    return FdsxConfig(
+        providers=ProviderConfigs(
+            claude=ClaudeOptions.model_validate(claude_options),
+        )
+    )
+
+
+class TestMergeProviderOptionsConfigOnly:
+    """Config-level options with no workflow or task overrides."""
+
+    def test_config_only_returns_config_options(self):
+        """Config-level options are returned when no workflow/task options set."""
+        config = _make_config({"permission_mode": "bypassPermissions"})
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        assert result["permission_mode"] == "bypassPermissions"
+
+    def test_config_defaults_excluded(self):
+        """ClaudeOptions defaults (False/[]) are not included in the merge result
+        so they cannot override workflow or task-level settings."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        # Defaults (dangerously_skip_permissions=False, allowed_tools=[]) must not appear
+        assert "dangerously_skip_permissions" not in result
+        assert "allowed_tools" not in result
+
+    def test_no_config_providers_returns_none(self):
+        """When config has no providers section, returns None."""
+        config = FdsxConfig()  # no providers
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is None
+
+    def test_none_config_returns_none(self):
+        """When config is None, returns None (no options from any level)."""
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(None, flow, "claude", None)
+
+        assert result is None
+
+
+class TestMergeProviderOptionsWorkflowOverrides:
+    """Workflow-level options override config-level options."""
+
+    def test_workflow_overrides_config(self):
+        """Workflow-level options override config-level options for same key."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow(providers={"claude": {"permission_mode": "bypassPermissions"}})
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        assert result["permission_mode"] == "bypassPermissions"
+
+    def test_workflow_only_no_config(self):
+        """Workflow-level options are used even when config has no providers."""
+        config = FdsxConfig()
+        flow = _make_simple_flow(providers={"claude": {"dangerously_skip_permissions": True}})
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        assert result["dangerously_skip_permissions"] is True
+
+    def test_workflow_adds_to_config(self):
+        """Workflow can set different keys from config (both keys appear in result)."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow(providers={"claude": {"dangerously_skip_permissions": True}})
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        assert result["permission_mode"] == "acceptEdits"
+        assert result["dangerously_skip_permissions"] is True
+
+    def test_no_workflow_providers_key_means_no_override(self):
+        """When flow.providers is None, config options pass through unchanged."""
+        config = _make_config({"permission_mode": "plan"})
+        flow = _make_simple_flow(providers=None)
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        assert result["permission_mode"] == "plan"
+
+    def test_workflow_providers_missing_provider_key(self):
+        """When flow.providers exists but not for this provider, config wins."""
+        config = _make_config({"permission_mode": "plan"})
+        flow = _make_simple_flow(providers={"codex": {"sandbox": "read-only"}})
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is not None
+        assert result["permission_mode"] == "plan"
+        assert "sandbox" not in result
+
+
+class TestMergeProviderOptionsTaskOverrides:
+    """Task-level options override workflow and config options."""
+
+    def test_task_overrides_workflow(self):
+        """Task-level options override workflow-level options for same key."""
+        config = FdsxConfig()
+        flow = _make_simple_flow(providers={"claude": {"permission_mode": "acceptEdits"}})
+        task_opts = {"permission_mode": "bypassPermissions"}
+
+        result = _merge_provider_options(config, flow, "claude", task_opts)
+
+        assert result is not None
+        assert result["permission_mode"] == "bypassPermissions"
+
+    def test_task_overrides_config(self):
+        """Task-level options override config-level options."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow()
+        task_opts = {"permission_mode": "bypassPermissions"}
+
+        result = _merge_provider_options(config, flow, "claude", task_opts)
+
+        assert result is not None
+        assert result["permission_mode"] == "bypassPermissions"
+
+    def test_task_only_no_higher_levels(self):
+        """Task-level options work when config and workflow have nothing."""
+        config = FdsxConfig()
+        flow = _make_simple_flow()
+        task_opts = {"dangerously_skip_permissions": True}
+
+        result = _merge_provider_options(config, flow, "claude", task_opts)
+
+        assert result is not None
+        assert result["dangerously_skip_permissions"] is True
+
+
+class TestMergeProviderOptionsFourLevel:
+    """Full 3-level merge (config → workflow → task) tests."""
+
+    def test_full_three_level_merge(self):
+        """All three levels are merged correctly with proper precedence."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow(providers={"claude": {"allowed_tools": ["Bash"]}})
+        task_opts = {"disallowed_tools": ["Write"]}
+
+        result = _merge_provider_options(config, flow, "claude", task_opts)
+
+        assert result is not None
+        assert result["permission_mode"] == "acceptEdits"  # from config
+        assert result["allowed_tools"] == ["Bash"]  # from workflow
+        assert result["disallowed_tools"] == ["Write"]  # from task
+
+    def test_task_wins_over_all(self):
+        """Task-level wins when all three levels set the same key."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow(providers={"claude": {"permission_mode": "plan"}})
+        task_opts = {"permission_mode": "bypassPermissions"}
+
+        result = _merge_provider_options(config, flow, "claude", task_opts)
+
+        assert result is not None
+        assert result["permission_mode"] == "bypassPermissions"
+
+
+class TestMergeProviderOptionsAllNone:
+    """Tests when all levels produce no options."""
+
+    def test_all_none_returns_none(self):
+        """When all levels are absent, returns None."""
+        config = FdsxConfig()
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "claude", None)
+
+        assert result is None
+
+    def test_empty_task_options_with_no_other_levels(self):
+        """Empty task_options dict with no higher-level options returns None."""
+        config = FdsxConfig()
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "claude", {})
+
+        assert result is None
+
+
+class TestMergeProviderOptionsDifferentProviders:
+    """Tests with different provider names."""
+
+    def test_codex_provider_merge(self):
+        """Merge works for codex provider."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                codex=CodexOptions.model_validate({"sandbox": "read-only"}),
+            )
+        )
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "codex", None)
+
+        assert result is not None
+        assert result["sandbox"] == "read-only"
+
+    def test_system_provider_returns_none_when_no_options(self):
+        """System provider has no config entry → returns None."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "system", None)
+
+        # config.providers has no 'system' attribute → no config-level options
+        assert result is None
+
+    def test_unknown_provider_returns_none_when_no_options(self):
+        """Unknown provider name with no task options → returns None gracefully."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "unknown_provider", None)
+
+        assert result is None
+
+    def test_config_for_one_provider_doesnt_affect_another(self):
+        """Config options for claude do not bleed into codex merge."""
+        config = _make_config({"permission_mode": "acceptEdits"})
+        flow = _make_simple_flow()
+
+        result = _merge_provider_options(config, flow, "codex", None)
+
+        assert result is None

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,281 @@
+"""Tests for the configuration system."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from fdsx.core.config import (
+    FdsxConfig,
+    TaskSplitterConfig,
+    WorkflowSelectorConfig,
+    load_config,
+)
+
+
+class TestTaskSplitterConfigDefaults:
+    def test_default_provider(self):
+        cfg = TaskSplitterConfig()
+        assert cfg.provider == "claude"
+
+    def test_default_model(self):
+        cfg = TaskSplitterConfig()
+        assert cfg.model == "claude-sonnet-4-6"
+
+    def test_custom_values(self):
+        cfg = TaskSplitterConfig(provider="opencode", model="gpt-4o")
+        assert cfg.provider == "opencode"
+        assert cfg.model == "gpt-4o"
+
+    def test_invalid_provider_rejected(self):
+        with pytest.raises(ValidationError):
+            TaskSplitterConfig(provider="invalid")
+
+
+class TestWorkflowSelectorConfigDefaults:
+    def test_default_provider(self):
+        cfg = WorkflowSelectorConfig()
+        assert cfg.provider == "claude"
+
+    def test_default_model(self):
+        cfg = WorkflowSelectorConfig()
+        assert cfg.model == "claude-sonnet-4-6"
+
+    def test_custom_values(self):
+        cfg = WorkflowSelectorConfig(provider="codex", model="o3")
+        assert cfg.provider == "codex"
+        assert cfg.model == "o3"
+
+    def test_invalid_provider_rejected(self):
+        with pytest.raises(ValidationError):
+            WorkflowSelectorConfig(provider="invalid")
+
+
+class TestFdsxConfigDefaults:
+    def test_default_task_splitter(self):
+        cfg = FdsxConfig()
+        assert isinstance(cfg.task_splitter, TaskSplitterConfig)
+        assert cfg.task_splitter.provider == "claude"
+        assert cfg.task_splitter.model == "claude-sonnet-4-6"
+
+    def test_default_workflow_selector(self):
+        cfg = FdsxConfig()
+        assert isinstance(cfg.workflow_selector, WorkflowSelectorConfig)
+        assert cfg.workflow_selector.provider == "claude"
+
+    def test_default_workflows_dir(self):
+        cfg = FdsxConfig()
+        assert cfg.workflows_dir == ".fdsx/workflows"
+
+    def test_default_auto_workflow(self):
+        cfg = FdsxConfig()
+        assert cfg.auto_workflow is False
+
+    def test_extra_fields_rejected(self):
+        with pytest.raises(ValidationError):
+            FdsxConfig.model_validate({"unknown_field": "value"})
+
+    def test_workflows_dir_rejects_absolute(self):
+        with pytest.raises(ValidationError):
+            FdsxConfig(workflows_dir="/etc/workflows")
+
+    def test_workflows_dir_accepts_relative(self):
+        cfg = FdsxConfig(workflows_dir="my-workflows")
+        assert cfg.workflows_dir == "my-workflows"
+
+    def test_workflows_dir_rejects_traversal(self):
+        """SEC-R2-2: paths with '..' components must be rejected."""
+        with pytest.raises(ValidationError):
+            FdsxConfig(workflows_dir="../shared-workflows")
+
+    def test_workflows_dir_rejects_nested_traversal(self):
+        """SEC-R2-2: nested '..' traversal must also be rejected."""
+        with pytest.raises(ValidationError):
+            FdsxConfig(workflows_dir="subdir/../../escape")
+
+
+class TestLoadConfigNoFiles:
+    def test_returns_defaults_when_no_files(self):
+        cfg = load_config(load_global=False, load_project=False)
+        assert cfg.task_splitter.provider == "claude"
+        assert cfg.task_splitter.model == "claude-sonnet-4-6"
+        assert cfg.workflow_selector.provider == "claude"
+        assert cfg.auto_workflow is False
+
+
+class TestLoadConfigGlobal:
+    def test_loads_global_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text(yaml.dump({"task_splitter": {"provider": "codex"}}))
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                cfg = load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+            assert cfg.task_splitter.provider == "codex"
+            assert cfg.task_splitter.model == "claude-sonnet-4-6"
+
+
+class TestLoadConfigProject:
+    def test_loads_project_config(self):
+        """Project-level .fdsx/config.yaml overrides global and defaults."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            fdsx_dir = project_dir / ".fdsx"
+            fdsx_dir.mkdir()
+            config_file = fdsx_dir / "config.yaml"
+            config_file.write_text(yaml.dump({"auto_workflow": True}))
+
+            cfg = load_config(
+                project_dir=project_dir, load_global=False, load_project=True
+            )
+            assert cfg.auto_workflow is True
+
+
+class TestLoadConfigMergePrecedence:
+    def test_project_overrides_global(self):
+        """Project-level config takes precedence over global config."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_dir = Path(tmpdir)
+            config_dir = Path(tmpdir) / "global_fdsx"
+            config_dir.mkdir()
+            global_file = config_dir / "config.yaml"
+            global_file.write_text(
+                yaml.dump({"task_splitter": {"model": "global-model"}})
+            )
+
+            fdsx_dir = project_dir / ".fdsx"
+            fdsx_dir.mkdir()
+            project_file = fdsx_dir / "config.yaml"
+            project_file.write_text(
+                yaml.dump({"task_splitter": {"model": "project-model"}})
+            )
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = str(config_dir.parent)
+            try:
+                cfg = load_config(
+                    project_dir=project_dir, load_global=True, load_project=True
+                )
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+            assert cfg.task_splitter.model == "project-model"
+
+    def test_global_overrides_defaults(self):
+        """Global config overrides built-in defaults."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            global_file = config_dir / "config.yaml"
+            global_file.write_text(
+                yaml.dump({"workflow_selector": {"model": "override-model"}})
+            )
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                cfg = load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+            assert cfg.workflow_selector.model == "override-model"
+
+
+class TestLoadConfigValidation:
+    def test_invalid_provider_in_global_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text(yaml.dump({"task_splitter": {"provider": "bad"}}))
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                with pytest.raises(ValidationError):
+                    load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+    def test_partial_global_override(self):
+        """Partial override in global config preserves other defaults."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text(
+                yaml.dump({"task_splitter": {"provider": "opencode"}})
+            )
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                cfg = load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+            assert cfg.task_splitter.provider == "opencode"
+            assert cfg.task_splitter.model == "claude-sonnet-4-6"
+
+    def test_malformed_yaml_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text(": :\n  - [invalid yaml {{")
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                with pytest.raises(ValueError, match="Invalid YAML"):
+                    load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+    def test_non_mapping_config_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text("- item1\n- item2\n")
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                with pytest.raises(ValueError, match="must be a YAML mapping"):
+                    load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,8 +12,10 @@ from pydantic import ValidationError
 
 from fdsx.core.config import (
     FdsxConfig,
+    ProviderConfigs,
     TaskSplitterConfig,
     WorkflowSelectorConfig,
+    _deep_merge,
     load_config,
 )
 
@@ -270,6 +272,207 @@ class TestLoadConfigValidation:
             os.environ["XDG_CONFIG_HOME"] = tmpdir
             try:
                 with pytest.raises(ValueError, match="must be a YAML mapping"):
+                    load_config(load_global=True, load_project=False)
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+
+# T008: Unit tests for _deep_merge()
+class TestDeepMerge:
+    def test_flat_dict_override(self):
+        """Override value replaces base value for the same key."""
+        result = _deep_merge({"a": 1, "b": 2}, {"b": 3, "c": 4})
+        assert result == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_recursive_merge(self):
+        """Nested dicts are merged field-by-field, not replaced wholesale."""
+        base = {"outer": {"a": 1, "b": 2}}
+        override = {"outer": {"b": 99, "c": 3}}
+        result = _deep_merge(base, override)
+        assert result == {"outer": {"a": 1, "b": 99, "c": 3}}
+
+    def test_scalar_to_dict_override(self):
+        """When base has a scalar and override has a dict, override wins."""
+        result = _deep_merge({"key": "scalar"}, {"key": {"nested": True}})
+        assert result["key"] == {"nested": True}
+
+    def test_dict_to_scalar_override(self):
+        """When base has a dict and override has a scalar, override wins."""
+        result = _deep_merge({"key": {"nested": True}}, {"key": "scalar"})
+        assert result["key"] == "scalar"
+
+    def test_empty_override_preserves_base(self):
+        """An empty override leaves the base unchanged."""
+        base = {"a": 1, "b": {"c": 2}}
+        result = _deep_merge(base, {})
+        assert result == base
+
+    def test_none_base_value_replaced_by_dict_override(self):
+        """None base value is replaced when override provides a dict."""
+        result = _deep_merge({"key": None}, {"key": {"nested": True}})
+        assert result["key"] == {"nested": True}
+
+    def test_base_not_mutated(self):
+        """The base dict is not mutated by the merge."""
+        base = {"outer": {"a": 1}}
+        override = {"outer": {"b": 2}}
+        _deep_merge(base, override)
+        assert base == {"outer": {"a": 1}}
+
+    def test_providers_merge_across_levels(self):
+        """Provider config fields from global and project are merged, not replaced."""
+        global_raw = {"providers": {"claude": {"permission_mode": "bypassPermissions"}}}
+        project_raw = {"providers": {"claude": {"dangerously_skip_permissions": True}}}
+        intermediate = _deep_merge({}, global_raw)
+        result = _deep_merge(intermediate, project_raw)
+        assert result["providers"]["claude"]["permission_mode"] == "bypassPermissions"
+        assert result["providers"]["claude"]["dangerously_skip_permissions"] is True
+
+
+# T010: Unit tests for FdsxConfig with providers section
+class TestFdsxConfigProviders:
+    def test_default_providers_is_none(self):
+        cfg = FdsxConfig()
+        assert cfg.providers is None
+
+    def test_valid_claude_options_parsed(self):
+        cfg = FdsxConfig.model_validate(
+            {"providers": {"claude": {"permission_mode": "bypassPermissions"}}}
+        )
+        assert cfg.providers is not None
+        assert cfg.providers.claude is not None
+        assert cfg.providers.claude.permission_mode == "bypassPermissions"
+
+    def test_invalid_claude_permission_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            FdsxConfig.model_validate(
+                {"providers": {"claude": {"permission_mode": "invalid_mode"}}}
+            )
+
+    def test_extra_provider_name_rejected(self):
+        """Unknown provider names in the providers section are rejected."""
+        with pytest.raises(ValidationError):
+            FdsxConfig.model_validate({"providers": {"unknown_provider": {}}})
+
+    def test_extra_claude_field_rejected(self):
+        """Unknown fields inside a provider's options are rejected."""
+        with pytest.raises(ValidationError):
+            FdsxConfig.model_validate(
+                {"providers": {"claude": {"unknown_flag": True}}}
+            )
+
+    def test_backward_compat_without_providers(self):
+        """Existing configs without a providers section still parse correctly."""
+        cfg = FdsxConfig.model_validate({"auto_workflow": True})
+        assert cfg.providers is None
+        assert cfg.auto_workflow is True
+
+    def test_valid_codex_options_parsed(self):
+        cfg = FdsxConfig.model_validate(
+            {"providers": {"codex": {"sandbox": "read-only"}}}
+        )
+        assert cfg.providers is not None
+        assert cfg.providers.codex is not None
+        assert cfg.providers.codex.sandbox == "read-only"
+
+    def test_valid_opencode_options_parsed(self):
+        cfg = FdsxConfig.model_validate({"providers": {"opencode": {}}})
+        assert cfg.providers is not None
+        assert cfg.providers.opencode is not None
+
+    def test_provider_configs_extra_field_rejected(self):
+        """ProviderConfigs itself rejects unknown keys."""
+        with pytest.raises(ValidationError):
+            ProviderConfigs.model_validate({"unknown_key": {}})
+
+
+class TestLoadConfigWithProviders:
+    def test_deep_merge_providers_across_global_and_project(self):
+        """Global sets claude.permission_mode; project adds dangerously_skip_permissions; both preserved."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            global_file = config_dir / "config.yaml"
+            global_file.write_text(
+                yaml.dump({"providers": {"claude": {"permission_mode": "bypassPermissions"}}})
+            )
+
+            project_dir = Path(tmpdir)
+            fdsx_dir = project_dir / ".fdsx"
+            fdsx_dir.mkdir()
+            project_file = fdsx_dir / "config.yaml"
+            project_file.write_text(
+                yaml.dump({"providers": {"claude": {"dangerously_skip_permissions": True}}})
+            )
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                cfg = load_config(
+                    project_dir=project_dir, load_global=True, load_project=True
+                )
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+            assert cfg.providers is not None
+            assert cfg.providers.claude is not None
+            assert cfg.providers.claude.permission_mode == "bypassPermissions"
+            assert cfg.providers.claude.dangerously_skip_permissions is True
+
+    def test_project_providers_key_overrides_global(self):
+        """Project-level overrides the same key in global for the providers section."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            global_file = config_dir / "config.yaml"
+            global_file.write_text(
+                yaml.dump({"providers": {"claude": {"permission_mode": "default"}}})
+            )
+
+            project_dir = Path(tmpdir)
+            fdsx_dir = project_dir / ".fdsx"
+            fdsx_dir.mkdir()
+            project_file = fdsx_dir / "config.yaml"
+            project_file.write_text(
+                yaml.dump({"providers": {"claude": {"permission_mode": "bypassPermissions"}}})
+            )
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                cfg = load_config(
+                    project_dir=project_dir, load_global=True, load_project=True
+                )
+            finally:
+                if original_xdg is None:
+                    os.environ.pop("XDG_CONFIG_HOME", None)
+                else:
+                    os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+            assert cfg.providers is not None
+            assert cfg.providers.claude is not None
+            assert cfg.providers.claude.permission_mode == "bypassPermissions"
+
+    def test_invalid_provider_option_in_config_file_raises(self):
+        """Invalid option value in a config file raises ValidationError at load time."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = Path(tmpdir) / "fdsx"
+            config_dir.mkdir()
+            config_file = config_dir / "config.yaml"
+            config_file.write_text(
+                yaml.dump({"providers": {"claude": {"permission_mode": "bad_mode"}}})
+            )
+
+            original_xdg = os.environ.get("XDG_CONFIG_HOME")
+            os.environ["XDG_CONFIG_HOME"] = tmpdir
+            try:
+                with pytest.raises(ValidationError):
                     load_config(load_global=True, load_project=False)
             finally:
                 if original_xdg is None:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -18,6 +18,7 @@ from fdsx.core.config import (
     _deep_merge,
     load_config,
 )
+from fdsx.models.flow import HookConfig, HookEntry
 
 
 class TestTaskSplitterConfigDefaults:
@@ -479,3 +480,112 @@ class TestLoadConfigWithProviders:
                     os.environ.pop("XDG_CONFIG_HOME", None)
                 else:
                     os.environ["XDG_CONFIG_HOME"] = original_xdg
+
+
+# T018: Unit tests for FdsxConfig.hooks field and _deep_merge hook list concatenation
+class TestFdsxConfigHooks:
+    def test_hooks_defaults_to_none(self):
+        """T018: FdsxConfig.hooks is None when not specified."""
+        cfg = FdsxConfig()
+        assert cfg.hooks is None
+
+    def test_hooks_accepts_hook_config(self):
+        """T018: FdsxConfig.hooks accepts a valid HookConfig."""
+        cfg = FdsxConfig(
+            hooks=HookConfig(
+                on_start=[HookEntry(command="setup.sh")],
+                on_complete=[HookEntry(command="teardown.sh", on_failure="abort")],
+            )
+        )
+        assert cfg.hooks is not None
+        assert cfg.hooks.on_start[0].command == "setup.sh"
+        assert cfg.hooks.on_complete[0].on_failure == "abort"
+
+    def test_hooks_parsed_from_dict(self):
+        """T018: FdsxConfig parses hooks from raw dict via model_validate."""
+        cfg = FdsxConfig.model_validate(
+            {
+                "hooks": {
+                    "on_start": [{"command": "init.sh"}],
+                    "on_complete": [],
+                }
+            }
+        )
+        assert cfg.hooks is not None
+        assert cfg.hooks.on_start[0].command == "init.sh"
+        assert cfg.hooks.on_complete == []
+
+    def test_hooks_invalid_on_failure_rejected(self):
+        """T018: Invalid on_failure value in hooks config must be rejected."""
+        with pytest.raises(ValidationError):
+            FdsxConfig.model_validate(
+                {"hooks": {"on_start": [{"command": "x", "on_failure": "skip"}]}}
+            )
+
+    def test_hooks_empty_command_rejected(self):
+        """T018: Empty command in hook entry must be rejected."""
+        with pytest.raises(ValidationError):
+            FdsxConfig.model_validate(
+                {"hooks": {"on_start": [{"command": ""}]}}
+            )
+
+
+class TestDeepMergeHookListConcatenation:
+    """T018: Tests for _deep_merge list concatenation for on_start/on_complete."""
+
+    def test_on_start_lists_are_concatenated(self):
+        """T018: on_start lists from base and override are concatenated."""
+        base = {"hooks": {"on_start": [{"command": "a.sh"}], "on_complete": []}}
+        override = {"hooks": {"on_start": [{"command": "b.sh"}], "on_complete": []}}
+        result = _deep_merge(base, override)
+        assert len(result["hooks"]["on_start"]) == 2
+        assert result["hooks"]["on_start"][0]["command"] == "a.sh"
+        assert result["hooks"]["on_start"][1]["command"] == "b.sh"
+
+    def test_on_complete_lists_are_concatenated(self):
+        """T018: on_complete lists from base and override are concatenated."""
+        base = {"hooks": {"on_start": [], "on_complete": [{"command": "cleanup.sh"}]}}
+        override = {"hooks": {"on_start": [], "on_complete": [{"command": "notify.sh"}]}}
+        result = _deep_merge(base, override)
+        assert len(result["hooks"]["on_complete"]) == 2
+        assert result["hooks"]["on_complete"][0]["command"] == "cleanup.sh"
+        assert result["hooks"]["on_complete"][1]["command"] == "notify.sh"
+
+    def test_empty_base_hook_list_with_override(self):
+        """T018: Empty base list + override list yields only override entries."""
+        base = {"hooks": {"on_start": [], "on_complete": []}}
+        override = {"hooks": {"on_start": [{"command": "x.sh"}], "on_complete": []}}
+        result = _deep_merge(base, override)
+        assert result["hooks"]["on_start"] == [{"command": "x.sh"}]
+
+    def test_empty_override_hook_list_with_base(self):
+        """T018: Base list + empty override list yields only base entries."""
+        base = {"hooks": {"on_start": [{"command": "base.sh"}], "on_complete": []}}
+        override = {"hooks": {"on_start": [], "on_complete": []}}
+        result = _deep_merge(base, override)
+        assert result["hooks"]["on_start"] == [{"command": "base.sh"}]
+
+    def test_non_hook_list_is_replaced_not_concatenated(self):
+        """T018: Regular list values (not on_start/on_complete) are replaced, not concatenated."""
+        base = {"items": [1, 2, 3]}
+        override = {"items": [4, 5]}
+        result = _deep_merge(base, override)
+        assert result["items"] == [4, 5]
+
+    def test_hook_list_concatenation_preserves_order(self):
+        """T018: Concatenation preserves global-first, project-second ordering."""
+        base = {
+            "hooks": {
+                "on_start": [{"command": "global1.sh"}, {"command": "global2.sh"}],
+                "on_complete": [],
+            }
+        }
+        override = {
+            "hooks": {
+                "on_start": [{"command": "project.sh"}],
+                "on_complete": [],
+            }
+        }
+        result = _deep_merge(base, override)
+        commands = [e["command"] for e in result["hooks"]["on_start"]]
+        assert commands == ["global1.sh", "global2.sh", "project.sh"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -59,9 +59,7 @@ class TestWorkflowSelectorConfigDefaults:
 class TestFdsxConfigDefaults:
     def test_default_task_splitter(self):
         cfg = FdsxConfig()
-        assert isinstance(cfg.task_splitter, TaskSplitterConfig)
-        assert cfg.task_splitter.provider == "claude"
-        assert cfg.task_splitter.model == "claude-sonnet-4-6"
+        assert cfg.task_splitter is None
 
     def test_default_workflow_selector(self):
         cfg = FdsxConfig()
@@ -102,8 +100,7 @@ class TestFdsxConfigDefaults:
 class TestLoadConfigNoFiles:
     def test_returns_defaults_when_no_files(self):
         cfg = load_config(load_global=False, load_project=False)
-        assert cfg.task_splitter.provider == "claude"
-        assert cfg.task_splitter.model == "claude-sonnet-4-6"
+        assert cfg.task_splitter is None
         assert cfg.workflow_selector.provider == "claude"
         assert cfg.auto_workflow is False
 

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,4 +1,9 @@
-from fdsx.core.engine import _extract_results
+from datetime import datetime, timedelta, timezone
+from io import StringIO
+from unittest.mock import patch
+
+from fdsx.core.engine import _calc_elapsed, _extract_results, _find_failed_state
+from fdsx.logging import RunRecorder
 
 
 class TestExtractResults:
@@ -28,3 +33,147 @@ class TestExtractResults:
         state = {}
         result = _extract_results(state, ["$.missing"])
         assert result == {}
+
+
+class TestCalcElapsed:
+    """Tests for _calc_elapsed helper in engine."""
+
+    def _make_recorder(self, started_offset_secs: float = 0.0) -> RunRecorder:
+        recorder = RunRecorder(
+            thread_id="test-thread-id",
+            flow_name="TestFlow",
+        )
+        # Override started_at to a known value
+        base = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        recorder.started_at = (
+            base + timedelta(seconds=started_offset_secs)
+        ).isoformat()
+        return recorder
+
+    def test_elapsed_with_completed_at(self):
+        """Elapsed time is correctly computed from started_at and completed_at."""
+        recorder = self._make_recorder()
+        base = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        recorder.completed_at = (base + timedelta(seconds=90)).isoformat()
+        elapsed = _calc_elapsed(recorder)
+        assert elapsed == 90.0
+
+    def test_elapsed_without_completed_at_uses_current_time(self):
+        """When completed_at is None, elapsed is computed from now (approximate)."""
+        recorder = self._make_recorder()
+        # started_at is fixed in the past — elapsed should be positive
+        base = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        recorder.started_at = base.isoformat()
+        elapsed = _calc_elapsed(recorder)
+        # Should be a large positive number (>= ~1 year in seconds)
+        assert elapsed > 0.0
+
+    def test_elapsed_invalid_timestamps_returns_zero(self):
+        """Malformed timestamps return 0.0 without raising."""
+        recorder = self._make_recorder()
+        recorder.started_at = "not-a-date"
+        recorder.completed_at = "also-not-a-date"
+        assert _calc_elapsed(recorder) == 0.0
+
+
+class TestFindFailedState:
+    """Tests for _find_failed_state helper in engine."""
+
+    def _make_recorder(self) -> RunRecorder:
+        return RunRecorder(
+            thread_id="test-thread-id",
+            flow_name="TestFlow",
+        )
+
+    def test_returns_none_when_no_error_states(self):
+        """Returns None when all states completed successfully."""
+        recorder = self._make_recorder()
+        recorder.states = [
+            {"name": "step1", "status": "completed"},
+            {"name": "step2", "status": "completed"},
+        ]
+        assert _find_failed_state(recorder) is None
+
+    def test_returns_error_state_name_and_error(self):
+        """Returns (name, error) for the first error state found (from end)."""
+        recorder = self._make_recorder()
+        recorder.states = [
+            {"name": "step1", "status": "completed"},
+            {"name": "step2", "status": "error", "error": "exit code 1"},
+        ]
+        result = _find_failed_state(recorder)
+        assert result is not None
+        assert result[0] == "step2"
+        assert result[1] == "exit code 1"
+
+    def test_returns_most_recent_error_state(self):
+        """Returns the most recent (last) error state when multiple exist."""
+        recorder = self._make_recorder()
+        recorder.states = [
+            {"name": "step1", "status": "error", "error": "first error"},
+            {"name": "step2", "status": "error", "error": "second error"},
+        ]
+        result = _find_failed_state(recorder)
+        assert result is not None
+        assert result[0] == "step2"
+        assert result[1] == "second error"
+
+    def test_returns_empty_error_string_when_no_error_key(self):
+        """Returns empty string for error when state has no 'error' key."""
+        recorder = self._make_recorder()
+        recorder.states = [{"name": "step1", "status": "error"}]
+        result = _find_failed_state(recorder)
+        assert result is not None
+        assert result[0] == "step1"
+        assert result[1] == ""
+
+    def test_empty_states_returns_none(self):
+        """Returns None when recorder has no states."""
+        recorder = self._make_recorder()
+        recorder.states = []
+        assert _find_failed_state(recorder) is None
+
+
+class TestErrorPathFallback:
+    """Regression: error path must always produce failure message.
+
+    When _find_failed_state returns None (exception before any state executes),
+    display_completion_summary must receive a non-None failed_state so it prints
+    the failure (✗) message rather than the success (✓) message.
+
+    family_tag: error-path-success-message-on-no-recorded-state
+    """
+
+    def test_error_fallback_produces_failure_message_not_success(self):
+        """Boundary: no recorder error state → 'unknown' fallback → failure message printed."""
+        from fdsx.display.terminal import display_completion_summary
+
+        stderr = StringIO()
+        # Simulate what engine.py does in the except block when
+        # _find_failed_state returns None:
+        #   failed_state_name = failed[0] if failed else "unknown"
+        failed = None  # _find_failed_state would return None
+        failed_state_name = failed[0] if failed else "unknown"
+        error_message = "infrastructure failure"
+
+        with patch("sys.stderr", stderr):
+            display_completion_summary(
+                "TestFlow", 1.0, failed_state_name, error_message
+            )
+
+        output = stderr.getvalue()
+        assert "✗" in output, "Must print failure symbol, not success"
+        assert "✓" not in output, "Must NOT print success symbol"
+        assert "unknown" in output
+        assert "infrastructure failure" in output
+
+    def test_error_fallback_is_unknown_not_none(self):
+        """Boundary: fallback state name for no-state errors is 'unknown', not None.
+
+        Regression guard: if this returns None, display_completion_summary would
+        print a success message inside an exception handler.
+        """
+        failed: tuple[str, str] | None = None
+        failed_state_name = failed[0] if failed else "unknown"
+        assert failed_state_name == "unknown"
+        assert failed_state_name is not None

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,0 +1,607 @@
+"""Unit tests for fdsx.core.hooks — T019, T020, T021."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.core.hooks import (
+    ENV_DATA_PATH,
+    ENV_FLOW_NAME,
+    ENV_STATE_NAME,
+    ENV_STATUS,
+    ENV_THREAD_ID,
+    HOOKS_DIR_NAME,
+    INPUT_FILENAME,
+    OUTPUT_FILENAME,
+    RUNS_DIR_NAME,
+    HookAbortError,
+    collect_hooks,
+    execute_hooks,
+    write_hook_data,
+)
+from fdsx.models.flow import HookConfig, HookEntry
+
+
+# ---------------------------------------------------------------------------
+# T019: execute_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteHooks:
+    """Tests for execute_hooks()."""
+
+    def _make_hook(self, command: str, on_failure: str = "warn") -> HookEntry:
+        return HookEntry(command=command, on_failure=on_failure)  # type: ignore[arg-type]
+
+    def test_empty_list_does_nothing(self, tmp_path: Path) -> None:
+        """No subprocess calls when hook list is empty."""
+        data_path = tmp_path / "data.json"
+        with patch("subprocess.run") as mock_run:
+            execute_hooks(
+                [],
+                state_name="MyState",
+                status="starting",
+                data_path=data_path,
+                thread_id="tid-001",
+                flow_name="MyFlow",
+            )
+        mock_run.assert_not_called()
+
+    def test_single_hook_called_with_shell_true(self, tmp_path: Path) -> None:
+        """subprocess.run is called with shell=True."""
+        hook = self._make_hook("echo hello")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="S1",
+                status="starting",
+                data_path=data_path,
+                thread_id="t1",
+                flow_name="F1",
+            )
+
+        assert mock_run.call_count == 1
+        _, kwargs = mock_run.call_args
+        assert kwargs.get("shell") is True
+
+    def test_positional_args_appended_to_command(self, tmp_path: Path) -> None:
+        """$1, $2, $3 are appended as quoted positional args."""
+        hook = self._make_hook("myscript.sh")
+        data_path = tmp_path / "state_data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="MyState",
+                status="completed",
+                data_path=data_path,
+                thread_id="t1",
+                flow_name="F1",
+            )
+
+        full_cmd: str = mock_run.call_args[0][0]
+        assert "MyState" in full_cmd
+        assert "completed" in full_cmd
+        assert str(data_path) in full_cmd
+
+    def test_env_vars_passed_correctly(self, tmp_path: Path) -> None:
+        """All five FDSX_ environment variables are present in env."""
+        hook = self._make_hook("true")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="StateX",
+                status="failed",
+                data_path=data_path,
+                thread_id="tid-42",
+                flow_name="FlowY",
+            )
+
+        env = mock_run.call_args[1]["env"]
+        assert env[ENV_STATE_NAME] == "StateX"
+        assert env[ENV_STATUS] == "failed"
+        assert env[ENV_DATA_PATH] == str(data_path)
+        assert env[ENV_THREAD_ID] == "tid-42"
+        assert env[ENV_FLOW_NAME] == "FlowY"
+
+    def test_warn_on_failure_does_not_raise(self, tmp_path: Path) -> None:
+        """on_failure='warn' logs a warning and continues without raising."""
+        hook = self._make_hook("false", on_failure="warn")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            # Must not raise
+            execute_hooks(
+                [hook],
+                state_name="S",
+                status="starting",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+            )
+
+    def test_abort_on_failure_raises_hook_abort_error(self, tmp_path: Path) -> None:
+        """on_failure='abort' raises HookAbortError on non-zero exit."""
+        hook = self._make_hook("false", on_failure="abort")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=2)
+            with pytest.raises(HookAbortError) as exc_info:
+                execute_hooks(
+                    [hook],
+                    state_name="S",
+                    status="starting",
+                    data_path=data_path,
+                    thread_id="t",
+                    flow_name="F",
+                )
+        assert exc_info.value.return_code == 2
+        assert exc_info.value.command == "false"
+
+    def test_abort_stops_subsequent_hooks(self, tmp_path: Path) -> None:
+        """After abort, remaining hooks are not executed."""
+        hooks = [
+            self._make_hook("cmd1", on_failure="abort"),
+            self._make_hook("cmd2", on_failure="warn"),
+        ]
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            with pytest.raises(HookAbortError):
+                execute_hooks(
+                    hooks,
+                    state_name="S",
+                    status="starting",
+                    data_path=data_path,
+                    thread_id="t",
+                    flow_name="F",
+                )
+        # Only cmd1 ran; cmd2 was skipped
+        assert mock_run.call_count == 1
+
+    def test_warn_continues_to_next_hook(self, tmp_path: Path) -> None:
+        """After warn failure, next hooks still execute."""
+        hooks = [
+            self._make_hook("cmd1", on_failure="warn"),
+            self._make_hook("cmd2", on_failure="warn"),
+        ]
+        data_path = tmp_path / "data.json"
+        return_codes = [1, 0]
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=rc) for rc in return_codes
+            ]
+            execute_hooks(
+                hooks,
+                state_name="S",
+                status="starting",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+            )
+        assert mock_run.call_count == 2
+
+    def test_hook_abort_error_message_contains_command(self, tmp_path: Path) -> None:
+        """HookAbortError message includes the command string."""
+        hook = self._make_hook("my-script.sh", on_failure="abort")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=5)
+            with pytest.raises(HookAbortError) as exc_info:
+                execute_hooks(
+                    [hook],
+                    state_name="S",
+                    status="starting",
+                    data_path=data_path,
+                    thread_id="t",
+                    flow_name="F",
+                )
+        assert "my-script.sh" in str(exc_info.value)
+
+    def test_multiple_hooks_run_in_order(self, tmp_path: Path) -> None:
+        """Multiple hooks run in list order."""
+        calls: list[str] = []
+        hooks = [
+            self._make_hook("hook-a"),
+            self._make_hook("hook-b"),
+            self._make_hook("hook-c"),
+        ]
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                hooks,
+                state_name="S",
+                status="starting",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+            )
+
+        assert mock_run.call_count == 3
+        cmd_a: str = mock_run.call_args_list[0][0][0]
+        cmd_b: str = mock_run.call_args_list[1][0][0]
+        cmd_c: str = mock_run.call_args_list[2][0][0]
+        assert cmd_a.startswith("hook-a ")
+        assert cmd_b.startswith("hook-b ")
+        assert cmd_c.startswith("hook-c ")
+
+    def test_special_characters_in_state_name_are_quoted(self, tmp_path: Path) -> None:
+        """State names with spaces/special chars are shell-quoted as positional args."""
+        hook = self._make_hook("myscript.sh")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="my state; rm -rf /",
+                status="starting",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+            )
+
+        full_cmd: str = mock_run.call_args[0][0]
+        # Verify the dangerous string is properly quoted (not expanded)
+        assert "rm -rf" not in full_cmd.replace("'my state; rm -rf /'", "")
+
+
+# ---------------------------------------------------------------------------
+# T020: write_hook_data
+# ---------------------------------------------------------------------------
+
+
+class TestWriteHookData:
+    """Tests for write_hook_data()."""
+
+    def test_writes_input_json_to_correct_path(self, tmp_path: Path) -> None:
+        """input.json is written under hooks/<state_name>/input.json."""
+        data = {"key": "value", "count": 42}
+        file_path = write_hook_data(
+            data,
+            state_name="Planner",
+            filename=INPUT_FILENAME,
+            thread_id="thread-001",
+            base_dir=tmp_path,
+        )
+
+        expected = (
+            tmp_path / RUNS_DIR_NAME / "thread-001" / HOOKS_DIR_NAME / "Planner" / INPUT_FILENAME
+        )
+        assert file_path == expected
+        assert file_path.exists()
+
+    def test_writes_output_json_to_correct_path(self, tmp_path: Path) -> None:
+        """output.json is written under hooks/<state_name>/output.json."""
+        data = {"result": "done"}
+        file_path = write_hook_data(
+            data,
+            state_name="Executor",
+            filename=OUTPUT_FILENAME,
+            thread_id="thread-002",
+            base_dir=tmp_path,
+        )
+
+        expected = (
+            tmp_path / RUNS_DIR_NAME / "thread-002" / HOOKS_DIR_NAME / "Executor" / OUTPUT_FILENAME
+        )
+        assert file_path == expected
+
+    def test_written_content_is_valid_json(self, tmp_path: Path) -> None:
+        """File content deserialises back to the original data dict."""
+        data = {"a": 1, "b": [1, 2, 3], "c": {"nested": True}}
+        file_path = write_hook_data(
+            data,
+            state_name="S",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+            base_dir=tmp_path,
+        )
+
+        with open(file_path) as f:
+            loaded = json.load(f)
+        assert loaded == data
+
+    def test_file_permissions_are_0o600(self, tmp_path: Path) -> None:
+        """File is created with mode 0o600."""
+        file_path = write_hook_data(
+            {},
+            state_name="S",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+            base_dir=tmp_path,
+        )
+
+        file_mode = stat.S_IMODE(os.stat(file_path).st_mode)
+        assert file_mode == 0o600
+
+    def test_directory_permissions_are_0o700(self, tmp_path: Path) -> None:
+        """State hooks directory is created with mode 0o700."""
+        write_hook_data(
+            {},
+            state_name="MyState",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+            base_dir=tmp_path,
+        )
+
+        hooks_state_dir = tmp_path / RUNS_DIR_NAME / "t" / HOOKS_DIR_NAME / "MyState"
+        dir_mode = stat.S_IMODE(os.stat(hooks_state_dir).st_mode)
+        assert dir_mode == 0o700
+
+    def test_creates_intermediate_directories(self, tmp_path: Path) -> None:
+        """Intermediate directories are created automatically."""
+        file_path = write_hook_data(
+            {"x": 1},
+            state_name="DeepState",
+            filename=OUTPUT_FILENAME,
+            thread_id="new-thread",
+            base_dir=tmp_path,
+        )
+
+        assert file_path.parent.is_dir()
+        assert file_path.exists()
+
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """A second write to the same path overwrites the first."""
+        first_data = {"version": 1}
+        second_data = {"version": 2}
+
+        write_hook_data(
+            first_data,
+            state_name="S",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+            base_dir=tmp_path,
+        )
+        file_path = write_hook_data(
+            second_data,
+            state_name="S",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+            base_dir=tmp_path,
+        )
+
+        with open(file_path) as f:
+            loaded = json.load(f)
+        assert loaded == second_data
+
+    def test_default_base_dir_uses_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When base_dir is None, path is rooted at CWD/.fdsx/."""
+        monkeypatch.chdir(tmp_path)
+        file_path = write_hook_data(
+            {},
+            state_name="S",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+        )
+
+        expected_root = tmp_path / ".fdsx" / RUNS_DIR_NAME / "t" / HOOKS_DIR_NAME / "S" / INPUT_FILENAME
+        assert file_path == expected_root
+
+    def test_returns_path_object(self, tmp_path: Path) -> None:
+        """Return value is a pathlib.Path."""
+        result = write_hook_data(
+            {},
+            state_name="S",
+            filename=INPUT_FILENAME,
+            thread_id="t",
+            base_dir=tmp_path,
+        )
+        assert isinstance(result, Path)
+
+    def test_traversal_via_thread_id_raises(self, tmp_path: Path) -> None:
+        """thread_id with path traversal segments raises ValueError."""
+        with pytest.raises(ValueError, match="path resolved outside runs directory"):
+            write_hook_data(
+                {},
+                state_name="S",
+                filename=INPUT_FILENAME,
+                thread_id="../../../etc",
+                base_dir=tmp_path,
+            )
+
+    def test_traversal_via_state_name_raises(self, tmp_path: Path) -> None:
+        """state_name with path traversal segments raises ValueError."""
+        with pytest.raises(ValueError, match="path resolved outside runs directory"):
+            write_hook_data(
+                {},
+                state_name="../../passwd",
+                filename=INPUT_FILENAME,
+                thread_id="t",
+                base_dir=tmp_path,
+            )
+
+
+# ---------------------------------------------------------------------------
+# T021: collect_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestCollectHooks:
+    """Tests for collect_hooks()."""
+
+    def _make_config(self, commands: list[str], event: str = "on_start") -> HookConfig:
+        entries = [HookEntry(command=cmd) for cmd in commands]
+        kwargs: dict = {"on_start": [], "on_complete": []}
+        kwargs[event] = entries
+        return HookConfig(**kwargs)
+
+    def test_all_none_returns_empty_list(self) -> None:
+        """All-None configs produces an empty list."""
+        result = collect_hooks(
+            "on_start",
+            global_hooks=None,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=None,
+        )
+        assert result == []
+
+    def test_single_level_global(self) -> None:
+        """Only global hooks are returned."""
+        global_cfg = self._make_config(["global-hook"])
+        result = collect_hooks(
+            "on_start",
+            global_hooks=global_cfg,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=None,
+        )
+        assert len(result) == 1
+        assert result[0].command == "global-hook"
+
+    def test_single_level_state(self) -> None:
+        """Only state hooks are returned."""
+        state_cfg = self._make_config(["state-hook"])
+        result = collect_hooks(
+            "on_start",
+            global_hooks=None,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=state_cfg,
+        )
+        assert len(result) == 1
+        assert result[0].command == "state-hook"
+
+    def test_merge_order_global_project_flow_state(self) -> None:
+        """Hooks are concatenated in global → project → flow → state order."""
+        global_cfg = self._make_config(["g1"])
+        project_cfg = self._make_config(["p1"])
+        flow_cfg = self._make_config(["fl1"])
+        state_cfg = self._make_config(["st1"])
+
+        result = collect_hooks(
+            "on_start",
+            global_hooks=global_cfg,
+            project_hooks=project_cfg,
+            flow_hooks=flow_cfg,
+            state_hooks=state_cfg,
+        )
+
+        assert [h.command for h in result] == ["g1", "p1", "fl1", "st1"]
+
+    def test_multiple_hooks_per_level(self) -> None:
+        """Multiple hooks within a level are included in order."""
+        global_cfg = self._make_config(["g1", "g2", "g3"])
+        state_cfg = self._make_config(["s1", "s2"])
+
+        result = collect_hooks(
+            "on_start",
+            global_hooks=global_cfg,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=state_cfg,
+        )
+
+        assert [h.command for h in result] == ["g1", "g2", "g3", "s1", "s2"]
+
+    def test_on_complete_event(self) -> None:
+        """on_complete event selects the correct hook list."""
+        config = HookConfig(
+            on_start=[HookEntry(command="start-hook")],
+            on_complete=[HookEntry(command="complete-hook")],
+        )
+
+        result_start = collect_hooks(
+            "on_start",
+            global_hooks=config,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=None,
+        )
+        result_complete = collect_hooks(
+            "on_complete",
+            global_hooks=config,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=None,
+        )
+
+        assert len(result_start) == 1
+        assert result_start[0].command == "start-hook"
+        assert len(result_complete) == 1
+        assert result_complete[0].command == "complete-hook"
+
+    def test_on_failure_policy_preserved(self) -> None:
+        """on_failure values are preserved through collection."""
+        cfg = HookConfig(
+            on_start=[
+                HookEntry(command="cmd-abort", on_failure="abort"),
+                HookEntry(command="cmd-warn", on_failure="warn"),
+            ]
+        )
+
+        result = collect_hooks(
+            "on_start",
+            global_hooks=cfg,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=None,
+        )
+
+        assert result[0].on_failure == "abort"
+        assert result[1].on_failure == "warn"
+
+    def test_returns_list_of_hook_entry(self) -> None:
+        """Return type is a list of HookEntry."""
+        cfg = self._make_config(["cmd"])
+        result = collect_hooks(
+            "on_start",
+            global_hooks=cfg,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=None,
+        )
+        assert isinstance(result, list)
+        assert all(isinstance(h, HookEntry) for h in result)
+
+    def test_skip_none_levels_seamlessly(self) -> None:
+        """None levels are skipped without error; remaining levels are included."""
+        project_cfg = self._make_config(["p1"])
+        state_cfg = self._make_config(["s1"])
+
+        result = collect_hooks(
+            "on_start",
+            global_hooks=None,
+            project_hooks=project_cfg,
+            flow_hooks=None,
+            state_hooks=state_cfg,
+        )
+
+        assert [h.command for h in result] == ["p1", "s1"]
+
+    def test_empty_hook_config_contributes_no_entries(self) -> None:
+        """HookConfig with empty on_start adds nothing."""
+        empty_cfg = HookConfig()
+        state_cfg = self._make_config(["s1"])
+
+        result = collect_hooks(
+            "on_start",
+            global_hooks=empty_cfg,
+            project_hooks=None,
+            flow_hooks=None,
+            state_hooks=state_cfg,
+        )
+
+        assert [h.command for h in result] == ["s1"]

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -48,6 +48,34 @@ class TestLoadFlow:
         flow, errors = load_flow(path)
         assert flow is None
 
+    def test_load_yaml_list_root_returns_error(self):
+        """Regression: non-dict YAML root (list) must not crash with TypeError."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("- item1\n- item2\n")
+            path = Path(f.name)
+
+        try:
+            flow, errors = load_flow(path)
+            assert flow is None
+            assert len(errors) > 0
+            assert "mapping" in errors[0].lower()
+        finally:
+            path.unlink()
+
+    def test_load_yaml_scalar_root_returns_error(self):
+        """Regression: non-dict YAML root (scalar string) must not crash with TypeError."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("just a string\n")
+            path = Path(f.name)
+
+        try:
+            flow, errors = load_flow(path)
+            assert flow is None
+            assert len(errors) > 0
+            assert "mapping" in errors[0].lower()
+        finally:
+            path.unlink()
+
 
 class TestValidateFlow:
     def test_validate_valid_flow(self):
@@ -88,6 +116,7 @@ class TestPromptFileResolution:
             # provider=claude requires prompt_template or prompt_file (no command)
             flow_yaml.write_text(
                 "name: test\n"
+                "description: test description\n"
                 "start_at: task1\n"
                 "states:\n"
                 "  task1:\n"
@@ -111,6 +140,7 @@ class TestPromptFileResolution:
             flow_yaml = Path(tmpdir) / "flow.yaml"
             flow_yaml.write_text(
                 "name: test\n"
+                "description: test description\n"
                 "start_at: task1\n"
                 "states:\n"
                 "  task1:\n"
@@ -133,6 +163,7 @@ class TestPromptFileResolution:
             flow_yaml = Path(tmpdir) / "flow.yaml"
             flow_yaml.write_text(
                 "name: test\n"
+                "description: test description\n"
                 "start_at: start\n"
                 "states:\n"
                 "  start:\n"
@@ -159,3 +190,69 @@ class TestPromptFileResolution:
                 f"Expected load to succeed but got: {no_warnings}"
             )
             assert len(no_warnings) == 0
+
+
+class TestDescriptionValidation:
+    """T10: Tests for description field pre-check in loader."""
+
+    def test_load_flow_missing_description(self):
+        """T10: Loader should provide actionable error for missing description."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            flow_yaml.write_text(
+                "name: test\n"
+                "start_at: start\n"
+                "states:\n"
+                "  start:\n"
+                "    type: task\n"
+                "    provider: system\n"
+                "    command: echo test\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+            flow, errors = load_flow(flow_yaml)
+            assert flow is None
+            assert len(errors) > 0
+            assert "description" in errors[0].lower()
+
+    def test_load_flow_empty_description(self):
+        """T10: Loader should reject empty description."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            flow_yaml.write_text(
+                "name: test\n"
+                "description: ''\n"
+                "start_at: start\n"
+                "states:\n"
+                "  start:\n"
+                "    type: task\n"
+                "    provider: system\n"
+                "    command: echo test\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+            flow, errors = load_flow(flow_yaml)
+            assert flow is None
+            assert len(errors) > 0
+            assert "description" in errors[0].lower()
+
+    def test_load_flow_with_valid_description(self):
+        """T10: Loader should accept valid description."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            flow_yaml.write_text(
+                "name: test\n"
+                "description: A valid test flow\n"
+                "start_at: start\n"
+                "states:\n"
+                "  start:\n"
+                "    type: task\n"
+                "    provider: system\n"
+                "    command: echo test\n"
+                "    result_path: '$.result'\n"
+                "    end: true\n"
+            )
+            flow, errors = load_flow(flow_yaml)
+            assert flow is not None
+            assert len(errors) == 0
+            assert flow.description == "A valid test flow"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -693,3 +693,126 @@ class TestTaskSplitterRemoval:
                     )
                 },
             )
+
+
+class TestFlowModelExtension:
+    """T012-T013: Tests for Flow.providers, TaskState.provider_options, Branch.provider_options."""
+
+    def _make_base_flow(self, **kwargs) -> Flow:
+        return Flow(
+            name="Test Flow",
+            description="Flow model extension test",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+            **kwargs,
+        )
+
+    # T013: Flow.providers field
+
+    def test_flow_providers_defaults_to_none(self):
+        """T013: Flow.providers is None when not specified."""
+        flow = self._make_base_flow()
+        assert flow.providers is None
+
+    def test_flow_providers_accepts_dict(self):
+        """T013: Flow.providers accepts a dict of provider name -> options."""
+        flow = self._make_base_flow(
+            providers={
+                "claude": {"model": "claude-opus-4-5", "temperature": 0.7},
+                "opencode": {"model": "gpt-4o"},
+            }
+        )
+        assert flow.providers is not None
+        assert flow.providers["claude"]["model"] == "claude-opus-4-5"
+        assert flow.providers["opencode"]["model"] == "gpt-4o"
+
+    def test_flow_providers_accepts_unknown_provider_names(self):
+        """T013: Unknown provider names must be accepted at parse time."""
+        flow = self._make_base_flow(
+            providers={"future-provider": {"endpoint": "https://api.example.com"}}
+        )
+        assert flow.providers is not None
+        assert "future-provider" in flow.providers
+
+    def test_flow_providers_accepts_empty_dict(self):
+        """T013: Flow.providers accepts an empty dict."""
+        flow = self._make_base_flow(providers={})
+        assert flow.providers == {}
+
+    # T012: TaskState.provider_options field
+
+    def test_task_state_provider_options_defaults_to_none(self):
+        """T012: TaskState.provider_options is None when not specified."""
+        state = TaskState(
+            type="task",
+            provider="system",
+            command="echo test",
+            result_path="$.result",
+        )
+        assert state.provider_options is None
+
+    def test_task_state_provider_options_accepts_dict(self):
+        """T012: TaskState.provider_options accepts arbitrary key-value pairs."""
+        state = TaskState(
+            type="task",
+            provider="claude",
+            model="opus",
+            prompt_template="Hello",
+            result_path="$.result",
+            provider_options={"temperature": 0.5, "max_tokens": 1000},
+        )
+        assert state.provider_options is not None
+        assert state.provider_options["temperature"] == 0.5
+        assert state.provider_options["max_tokens"] == 1000
+
+    # T012: Branch.provider_options field
+
+    def test_branch_provider_options_defaults_to_none(self):
+        """T012: Branch.provider_options is None when not specified."""
+        branch = Branch(
+            provider="system",
+            command="echo test",
+        )
+        assert branch.provider_options is None
+
+    def test_branch_provider_options_accepts_dict(self):
+        """T012: Branch.provider_options accepts arbitrary key-value pairs."""
+        branch = Branch(
+            provider="system",
+            command="echo test",
+            provider_options={"timeout_override": 30, "retry_delay": 1.5},
+        )
+        assert branch.provider_options is not None
+        assert branch.provider_options["timeout_override"] == 30
+
+    def test_flow_with_all_extension_fields(self):
+        """T012-T013: Flow with providers + TaskState with provider_options round-trips correctly."""
+        flow = Flow(
+            name="Extended Flow",
+            description="Flow with all extension fields",
+            start_at="start",
+            providers={"claude": {"model": "claude-opus-4-5"}},
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="claude",
+                    model="opus",
+                    prompt_template="Hello",
+                    result_path="$.result",
+                    provider_options={"temperature": 0.0},
+                    end=True,
+                )
+            },
+        )
+        assert flow.providers == {"claude": {"model": "claude-opus-4-5"}}
+        task = flow.states["start"]
+        assert isinstance(task, TaskState)
+        assert task.provider_options == {"temperature": 0.0}

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -84,6 +84,7 @@ class TestPydanticModels:
     def test_valid_flow(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for unit testing",
             start_at="start",
             states={
                 "start": TaskState(
@@ -102,6 +103,7 @@ class TestPydanticModels:
         with pytest.raises(ValueError, match="start_at"):
             Flow(
                 name="Test Flow",
+                description="Test flow with missing start_at",
                 start_at="nonexistent",
                 states={
                     "start": TaskState(
@@ -118,6 +120,7 @@ class TestPydanticModels:
         with pytest.raises(ValueError, match="does not exist"):
             Flow(
                 name="Test Flow",
+                description="Test flow with invalid next reference",
                 start_at="start",
                 states={
                     "start": TaskState(
@@ -198,6 +201,7 @@ class TestPydanticModels:
         with pytest.raises(ValueError, match="termination"):
             Flow(
                 name="Test Flow",
+                description="Test flow with no termination",
                 start_at="start",
                 states={
                     "start": TaskState(
@@ -270,6 +274,7 @@ class TestPydanticModels:
         through Flow's discriminated union using raw dicts (not pre-typed instances)."""
         flow = Flow(
             name="All State Types",
+            description="Test flow with all state types",
             start_at="task_step",
             states={
                 "task_step": {
@@ -549,3 +554,142 @@ class TestWebhookConfigValidation:
             template="Test",
         )
         assert config.url == "http://127.0.0.1:9000/webhook"
+
+
+class TestFlowDescriptionField:
+    """T8: Tests for the new required description field in Flow model."""
+
+    def test_flow_requires_description(self):
+        """T8: Flow model requires description field."""
+        with pytest.raises(ValidationError, match="description"):
+            Flow(
+                name="Test Flow",
+                start_at="start",
+                states={
+                    "start": TaskState(
+                        type="task",
+                        provider="system",
+                        command="echo test",
+                        result_path="$.result",
+                        end=True,
+                    )
+                },
+            )
+
+    def test_flow_accepts_valid_description(self):
+        """T8: Flow model accepts valid description."""
+        flow = Flow(
+            name="Test Flow",
+            description="A test flow with description",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        assert flow.description == "A test flow with description"
+
+    def test_flow_description_can_be_multiline(self):
+        """T8: Flow description can be a multiline string."""
+        flow = Flow(
+            name="Test Flow",
+            description="Line 1\nLine 2\nLine 3",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo test",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+        assert "Line 1" in flow.description
+
+    def test_flow_rejects_empty_description(self):
+        """T8: Flow model must reject empty string description (min_length=1)."""
+        with pytest.raises(ValidationError, match="description"):
+            Flow(
+                name="Test Flow",
+                description="",
+                start_at="start",
+                states={
+                    "start": TaskState(
+                        type="task",
+                        provider="system",
+                        command="echo test",
+                        result_path="$.result",
+                        end=True,
+                    )
+                },
+            )
+
+
+class TestTaskSplitterRemoval:
+    """T9: Tests for task_splitter removal from Flow model."""
+
+    def test_task_splitter_rejected_in_constructor(self):
+        """T9: task_splitter field must be rejected with migration error."""
+        with pytest.raises(ValidationError, match="task_splitter"):
+            Flow(
+                name="Test Flow",
+                description="Test flow",
+                start_at="start",
+                task_splitter={
+                    "provider": "claude",
+                    "model": "claude-3-5-sonnet-20241022",
+                },
+                states={
+                    "start": TaskState(
+                        type="task",
+                        provider="system",
+                        command="echo test",
+                        result_path="$.result",
+                        end=True,
+                    )
+                },
+            )
+
+    def test_task_splitter_null_also_rejected(self):
+        """T9: task_splitter: null must also be rejected with migration error."""
+        with pytest.raises(ValidationError, match="task_splitter"):
+            Flow(
+                name="Test Flow",
+                description="Test flow",
+                start_at="start",
+                task_splitter=None,
+                states={
+                    "start": TaskState(
+                        type="task",
+                        provider="system",
+                        command="echo test",
+                        result_path="$.result",
+                        end=True,
+                    )
+                },
+            )
+
+    def test_task_splitter_migration_error_message(self):
+        """T9: Error message should guide users to config file."""
+        with pytest.raises(ValidationError, match="config"):
+            Flow(
+                name="Test Flow",
+                description="Test flow",
+                start_at="start",
+                task_splitter={"provider": "claude", "model": "opus"},
+                states={
+                    "start": TaskState(
+                        type="task",
+                        provider="system",
+                        command="echo test",
+                        result_path="$.result",
+                        end=True,
+                    )
+                },
+            )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,6 +7,8 @@ from fdsx.models.flow import (
     ChoiceRule,
     ExtractRule,
     Flow,
+    HookConfig,
+    HookEntry,
     LLMClassifyFallback,
     ParallelState,
     PassState,
@@ -693,6 +695,172 @@ class TestTaskSplitterRemoval:
                     )
                 },
             )
+
+
+class TestHookEntryAndHookConfig:
+    """T016: Tests for HookEntry and HookConfig models."""
+
+    def test_hook_entry_defaults_on_failure_to_warn(self):
+        """T016: HookEntry.on_failure defaults to 'warn'."""
+        entry = HookEntry(command="echo hello")
+        assert entry.command == "echo hello"
+        assert entry.on_failure == "warn"
+
+    def test_hook_entry_accepts_abort(self):
+        """T016: HookEntry.on_failure accepts 'abort'."""
+        entry = HookEntry(command="./check.sh", on_failure="abort")
+        assert entry.on_failure == "abort"
+
+    def test_hook_entry_rejects_empty_command(self):
+        """T016: HookEntry.command must not be empty."""
+        with pytest.raises(ValidationError):
+            HookEntry(command="")
+
+    def test_hook_entry_rejects_invalid_on_failure(self):
+        """T016: HookEntry.on_failure must be 'abort' or 'warn'."""
+        with pytest.raises(ValidationError):
+            HookEntry(command="echo hello", on_failure="ignore")
+
+    def test_hook_config_defaults_to_empty_lists(self):
+        """T016: HookConfig.on_start and on_complete default to empty lists."""
+        config = HookConfig()
+        assert config.on_start == []
+        assert config.on_complete == []
+
+    def test_hook_config_accepts_entries(self):
+        """T016: HookConfig accepts HookEntry objects in both lists."""
+        config = HookConfig(
+            on_start=[HookEntry(command="echo start")],
+            on_complete=[HookEntry(command="echo done", on_failure="abort")],
+        )
+        assert len(config.on_start) == 1
+        assert config.on_start[0].command == "echo start"
+        assert len(config.on_complete) == 1
+        assert config.on_complete[0].on_failure == "abort"
+
+
+class TestHooksFieldOnStates:
+    """T017: Tests for hooks field on state types and Flow."""
+
+    def _base_task_state(self, **kwargs) -> TaskState:
+        return TaskState(
+            type="task",
+            provider="system",
+            command="echo test",
+            result_path="$.result",
+            end=True,
+            **kwargs,
+        )
+
+    def test_task_state_hooks_defaults_to_none(self):
+        """T017: TaskState.hooks is None when not specified."""
+        assert self._base_task_state().hooks is None
+
+    def test_task_state_accepts_hooks(self):
+        """T017: TaskState accepts a HookConfig."""
+        state = self._base_task_state(
+            hooks=HookConfig(on_start=[HookEntry(command="echo pre")])
+        )
+        assert state.hooks is not None
+        assert state.hooks.on_start[0].command == "echo pre"
+
+    def test_choice_state_hooks_defaults_to_none(self):
+        """T017: ChoiceState.hooks is None when not specified."""
+        state = ChoiceState(
+            type="choice",
+            choices=[ChoiceRule(variable="$.x", operator="equals", value="a", next="b")],
+        )
+        assert state.hooks is None
+
+    def test_choice_state_accepts_hooks(self):
+        """T017: ChoiceState accepts a HookConfig."""
+        state = ChoiceState(
+            type="choice",
+            choices=[ChoiceRule(variable="$.x", operator="equals", value="a", next="b")],
+            hooks=HookConfig(on_complete=[HookEntry(command="echo done")]),
+        )
+        assert state.hooks is not None
+
+    def test_parallel_state_hooks_defaults_to_none(self):
+        """T017: ParallelState.hooks is None when not specified."""
+        state = ParallelState(type="parallel", branches=[], result_path="$.r", end=True)
+        assert state.hooks is None
+
+    def test_parallel_state_accepts_hooks(self):
+        """T017: ParallelState accepts a HookConfig."""
+        state = ParallelState(
+            type="parallel",
+            branches=[],
+            result_path="$.r",
+            end=True,
+            hooks=HookConfig(on_start=[HookEntry(command="init.sh", on_failure="abort")]),
+        )
+        assert state.hooks is not None
+
+    def test_pass_state_hooks_defaults_to_none(self):
+        """T017: PassState.hooks is None when not specified."""
+        state = PassState(type="pass", end=True)
+        assert state.hooks is None
+
+    def test_pass_state_accepts_hooks(self):
+        """T017: PassState accepts a HookConfig."""
+        state = PassState(
+            type="pass",
+            end=True,
+            hooks=HookConfig(on_complete=[HookEntry(command="cleanup.sh")]),
+        )
+        assert state.hooks is not None
+
+    def test_wait_state_hooks_defaults_to_none(self):
+        """T017: WaitState.hooks is None when not specified."""
+        state = WaitState(
+            type="wait",
+            mode="prompt",
+            message="Go?",
+            choices=["yes"],
+            result_path="$.c",
+            end=True,
+        )
+        assert state.hooks is None
+
+    def test_wait_state_accepts_hooks(self):
+        """T017: WaitState accepts a HookConfig."""
+        state = WaitState(
+            type="wait",
+            mode="prompt",
+            message="Go?",
+            choices=["yes"],
+            result_path="$.c",
+            end=True,
+            hooks=HookConfig(on_start=[HookEntry(command="notify.sh")]),
+        )
+        assert state.hooks is not None
+
+    def test_flow_hooks_defaults_to_none(self):
+        """T017: Flow.hooks is None when not specified."""
+        flow = Flow(
+            name="Test",
+            description="Test flow",
+            start_at="s",
+            states={"s": self._base_task_state()},
+        )
+        assert flow.hooks is None
+
+    def test_flow_accepts_hooks(self):
+        """T017: Flow accepts a HookConfig at flow level."""
+        flow = Flow(
+            name="Test",
+            description="Test flow",
+            start_at="s",
+            states={"s": self._base_task_state()},
+            hooks=HookConfig(
+                on_start=[HookEntry(command="setup.sh")],
+                on_complete=[HookEntry(command="teardown.sh")],
+            ),
+        )
+        assert flow.hooks is not None
+        assert flow.hooks.on_start[0].command == "setup.sh"
+        assert flow.hooks.on_complete[0].command == "teardown.sh"
 
 
 class TestFlowModelExtension:

--- a/tests/unit/test_prompt_file.py
+++ b/tests/unit/test_prompt_file.py
@@ -14,6 +14,7 @@ class TestPromptFileWithVariables:
             prompt_file.write_text("Hello {name}, you are {age} years old.")
             flow_yaml.write_text(
                 "name: test\n"
+                "description: Test flow for prompt file\n"
                 "start_at: task1\n"
                 "max_loop: 1\n"
                 "states:\n"
@@ -39,6 +40,7 @@ class TestPromptFileWithVariables:
             flow_yaml = Path(tmpdir) / "flow.yaml"
             flow_yaml.write_text(
                 "name: test\n"
+                "description: Test flow for prompt file not found\n"
                 "start_at: task1\n"
                 "max_loop: 1\n"
                 "states:\n"
@@ -66,6 +68,7 @@ class TestPromptFileParallelBranch:
             branch_prompt.write_text("Branch prompt content")
             flow_yaml.write_text(
                 "name: test\n"
+                "description: Test flow for parallel branch\n"
                 "start_at: parallel1\n"
                 "max_loop: 1\n"
                 "states:\n"
@@ -101,6 +104,7 @@ class TestPromptFileEdgeCases:
             empty_prompt.write_text("")
             flow_yaml.write_text(
                 "name: test\n"
+                "description: Test flow for empty content\n"
                 "start_at: task1\n"
                 "max_loop: 1\n"
                 "states:\n"
@@ -128,6 +132,7 @@ class TestPromptFileEdgeCases:
             special_prompt.write_text("Line 1\nLine 2\nLine 3\nSpecial: ${{var}}")
             flow_yaml.write_text(
                 "name: test\n"
+                "description: Test flow for special characters\n"
                 "start_at: task1\n"
                 "max_loop: 1\n"
                 "states:\n"

--- a/tests/unit/test_provider_options.py
+++ b/tests/unit/test_provider_options.py
@@ -1,11 +1,13 @@
-"""Unit tests for provider option models (T004, T006, T007)."""
+"""Unit tests for provider option models (T004, T006, T007) and get_provider factory (T014)."""
 
 import pytest
 from pydantic import ValidationError
 
-from fdsx.providers.claude import ClaudeOptions
-from fdsx.providers.codex import CodexOptions
-from fdsx.providers.opencode import OpenCodeOptions
+from fdsx.providers.base import get_provider
+from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
+from fdsx.providers.codex import CodexOptions, CodexProvider
+from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
+from fdsx.providers.system import SystemProvider
 
 
 class TestClaudeOptions:
@@ -182,3 +184,74 @@ class TestOpenCodeOptions:
         """Extra fields must be rejected."""
         with pytest.raises(ValidationError):
             OpenCodeOptions(unknown_field="value")  # type: ignore[call-arg]
+
+
+class TestGetProvider:
+    """T014: Tests for get_provider() factory with options parameter."""
+
+    def test_get_provider_claude_no_options(self):
+        """get_provider('claude') returns ClaudeProvider with default options."""
+        provider = get_provider("claude")
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options == ClaudeOptions()
+
+    def test_get_provider_claude_with_options(self):
+        """get_provider('claude', options) returns ClaudeProvider with typed options."""
+        provider = get_provider("claude", {"permission_mode": "bypassPermissions"})
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options.permission_mode == "bypassPermissions"
+
+    def test_get_provider_claude_options_reflected_in_flags(self):
+        """Options passed to get_provider are reflected in to_cli_flags()."""
+        provider = get_provider("claude", {"dangerously_skip_permissions": True})
+        assert isinstance(provider, ClaudeProvider)
+        assert "--dangerously-skip-permissions" in provider.options.to_cli_flags()
+
+    def test_get_provider_codex_no_options(self):
+        """get_provider('codex') returns CodexProvider with default options."""
+        provider = get_provider("codex")
+        assert isinstance(provider, CodexProvider)
+        assert provider.options == CodexOptions()
+
+    def test_get_provider_codex_with_options(self):
+        """get_provider('codex', options) returns CodexProvider with typed options."""
+        provider = get_provider("codex", {"sandbox": "workspace-write"})
+        assert isinstance(provider, CodexProvider)
+        assert provider.options.sandbox == "workspace-write"
+
+    def test_get_provider_opencode_no_options(self):
+        """get_provider('opencode') returns OpenCodeProvider with default options."""
+        provider = get_provider("opencode")
+        assert isinstance(provider, OpenCodeProvider)
+        assert provider.options == OpenCodeOptions()
+
+    def test_get_provider_opencode_with_options(self):
+        """get_provider('opencode', options={}) returns OpenCodeProvider."""
+        provider = get_provider("opencode", {})
+        assert isinstance(provider, OpenCodeProvider)
+
+    def test_get_provider_system_no_options(self):
+        """get_provider('system') returns SystemProvider."""
+        provider = get_provider("system")
+        assert isinstance(provider, SystemProvider)
+
+    def test_get_provider_system_ignores_options(self):
+        """get_provider('system', options) ignores options and returns SystemProvider."""
+        provider = get_provider("system", {"some_option": "value"})
+        assert isinstance(provider, SystemProvider)
+
+    def test_get_provider_unknown_raises(self):
+        """get_provider with unknown name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown provider"):
+            get_provider("unknown_provider")
+
+    def test_get_provider_claude_none_options(self):
+        """get_provider('claude', None) is same as no options."""
+        provider = get_provider("claude", None)
+        assert isinstance(provider, ClaudeProvider)
+        assert provider.options == ClaudeOptions()
+
+    def test_get_provider_claude_invalid_options_raises(self):
+        """get_provider with invalid options dict raises ValidationError."""
+        with pytest.raises(ValidationError):
+            get_provider("claude", {"permission_mode": "invalid_mode"})

--- a/tests/unit/test_provider_options.py
+++ b/tests/unit/test_provider_options.py
@@ -1,0 +1,184 @@
+"""Unit tests for provider option models (T004, T006, T007)."""
+
+import pytest
+from pydantic import ValidationError
+
+from fdsx.providers.claude import ClaudeOptions
+from fdsx.providers.codex import CodexOptions
+from fdsx.providers.opencode import OpenCodeOptions
+
+
+class TestClaudeOptions:
+    """T004: Tests for ClaudeOptions model."""
+
+    def test_claude_options_defaults(self):
+        """All fields default to None/False/[] when not provided."""
+        opts = ClaudeOptions()
+        assert opts.permission_mode is None
+        assert opts.dangerously_skip_permissions is False
+        assert opts.allowed_tools == []
+        assert opts.disallowed_tools == []
+
+    def test_claude_options_permission_mode_valid(self):
+        """Valid permission_mode literals must be accepted."""
+        for mode in ("default", "acceptEdits", "bypassPermissions", "dontAsk", "plan", "auto"):
+            opts = ClaudeOptions(permission_mode=mode)
+            assert opts.permission_mode == mode
+
+    def test_claude_options_permission_mode_invalid(self):
+        """Invalid permission_mode must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ClaudeOptions(permission_mode="invalid_mode")
+
+    def test_claude_options_to_cli_flags_permission_mode(self):
+        """permission_mode maps to --permission-mode <value>."""
+        opts = ClaudeOptions(permission_mode="acceptEdits")
+        assert opts.to_cli_flags() == ["--permission-mode", "acceptEdits"]
+
+    def test_claude_options_to_cli_flags_dangerously_skip(self):
+        """dangerously_skip_permissions=True maps to --dangerously-skip-permissions."""
+        opts = ClaudeOptions(dangerously_skip_permissions=True)
+        assert opts.to_cli_flags() == ["--dangerously-skip-permissions"]
+
+    def test_claude_options_to_cli_flags_dangerously_skip_false(self):
+        """dangerously_skip_permissions=False produces no flags."""
+        opts = ClaudeOptions(dangerously_skip_permissions=False)
+        assert opts.to_cli_flags() == []
+
+    def test_claude_options_to_cli_flags_allowed_tools(self):
+        """allowed_tools maps to repeated --allowedTools <tool>."""
+        opts = ClaudeOptions(allowed_tools=["Bash", "Read"])
+        assert opts.to_cli_flags() == ["--allowedTools", "Bash", "--allowedTools", "Read"]
+
+    def test_claude_options_to_cli_flags_disallowed_tools(self):
+        """disallowed_tools maps to repeated --disallowedTools <tool>."""
+        opts = ClaudeOptions(disallowed_tools=["Write"])
+        assert opts.to_cli_flags() == ["--disallowedTools", "Write"]
+
+    def test_claude_options_to_cli_flags_empty(self):
+        """All defaults produce an empty flags list."""
+        opts = ClaudeOptions()
+        assert opts.to_cli_flags() == []
+
+    def test_claude_options_forbids_extra(self):
+        """Extra fields must be rejected."""
+        with pytest.raises(ValidationError):
+            ClaudeOptions(unknown_field="value")  # type: ignore[call-arg]
+
+    def test_claude_options_to_cli_flags_combined(self):
+        """All fields set together produce correct combined flags in order."""
+        opts = ClaudeOptions(
+            permission_mode="bypassPermissions",
+            dangerously_skip_permissions=True,
+            allowed_tools=["Bash"],
+            disallowed_tools=["Write"],
+        )
+        assert opts.to_cli_flags() == [
+            "--permission-mode", "bypassPermissions",
+            "--dangerously-skip-permissions",
+            "--allowedTools", "Bash",
+            "--disallowedTools", "Write",
+        ]
+
+
+class TestCodexOptions:
+    """T006: Tests for CodexOptions model."""
+
+    def test_codex_options_defaults(self):
+        """All fields default to None/False when not provided."""
+        opts = CodexOptions()
+        assert opts.sandbox is None
+        assert opts.approval_policy is None
+        assert opts.full_auto is False
+        assert opts.dangerously_bypass_approvals_and_sandbox is False
+
+    def test_codex_options_sandbox_valid(self):
+        """Valid sandbox literals must be accepted."""
+        for value in ("read-only", "workspace-write", "danger-full-access"):
+            opts = CodexOptions(sandbox=value)
+            assert opts.sandbox == value
+
+    def test_codex_options_sandbox_invalid(self):
+        """Invalid sandbox value must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            CodexOptions(sandbox="full")
+
+    def test_codex_options_approval_policy_valid(self):
+        """Valid approval_policy literals must be accepted."""
+        for value in ("untrusted", "on-request", "never"):
+            opts = CodexOptions(approval_policy=value)
+            assert opts.approval_policy == value
+
+    def test_codex_options_approval_policy_invalid(self):
+        """Invalid approval_policy value must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            CodexOptions(approval_policy="unknown")
+
+    def test_codex_options_to_cli_flags_sandbox(self):
+        """sandbox maps to --sandbox <value>."""
+        opts = CodexOptions(sandbox="workspace-write")
+        assert opts.to_cli_flags() == ["--sandbox", "workspace-write"]
+
+    def test_codex_options_to_cli_flags_approval_policy(self):
+        """approval_policy maps to --approval-policy <value>."""
+        opts = CodexOptions(approval_policy="on-request")
+        assert opts.to_cli_flags() == ["--approval-policy", "on-request"]
+
+    def test_codex_options_to_cli_flags_full_auto(self):
+        """full_auto=True maps to --full-auto."""
+        opts = CodexOptions(full_auto=True)
+        assert opts.to_cli_flags() == ["--full-auto"]
+
+    def test_codex_options_to_cli_flags_full_auto_false(self):
+        """full_auto=False produces no flags."""
+        opts = CodexOptions(full_auto=False)
+        assert opts.to_cli_flags() == []
+
+    def test_codex_options_to_cli_flags_dangerously_bypass(self):
+        """dangerously_bypass_approvals_and_sandbox=True maps to flag."""
+        opts = CodexOptions(dangerously_bypass_approvals_and_sandbox=True)
+        assert opts.to_cli_flags() == ["--dangerously-bypass-approvals-and-sandbox"]
+
+    def test_codex_options_to_cli_flags_empty(self):
+        """All defaults produce an empty flags list."""
+        opts = CodexOptions()
+        assert opts.to_cli_flags() == []
+
+    def test_codex_options_forbids_extra(self):
+        """Extra fields must be rejected."""
+        with pytest.raises(ValidationError):
+            CodexOptions(unknown_field="value")  # type: ignore[call-arg]
+
+    def test_codex_options_to_cli_flags_combined(self):
+        """All fields set together produce correct combined flags in order."""
+        opts = CodexOptions(
+            sandbox="workspace-write",
+            approval_policy="on-request",
+            full_auto=True,
+            dangerously_bypass_approvals_and_sandbox=True,
+        )
+        assert opts.to_cli_flags() == [
+            "--sandbox", "workspace-write",
+            "--approval-policy", "on-request",
+            "--full-auto",
+            "--dangerously-bypass-approvals-and-sandbox",
+        ]
+
+
+class TestOpenCodeOptions:
+    """T007: Tests for OpenCodeOptions model."""
+
+    def test_opencode_options_defaults(self):
+        """OpenCodeOptions can be instantiated with no arguments."""
+        opts = OpenCodeOptions()
+        assert opts is not None
+
+    def test_opencode_options_to_cli_flags_empty(self):
+        """to_cli_flags() always returns an empty list."""
+        opts = OpenCodeOptions()
+        assert opts.to_cli_flags() == []
+
+    def test_opencode_options_forbids_extra(self):
+        """Extra fields must be rejected."""
+        with pytest.raises(ValidationError):
+            OpenCodeOptions(unknown_field="value")  # type: ignore[call-arg]

--- a/tests/unit/test_provider_stdin_fallback.py
+++ b/tests/unit/test_provider_stdin_fallback.py
@@ -22,6 +22,9 @@ SMALL_PROMPT = "hello world"
 LARGE_PROMPT = "x" * ARG_MAX_STDIN_THRESHOLD
 """A prompt exactly at the ARG_MAX_STDIN_THRESHOLD (boundary / >= case)."""
 
+ABOVE_THRESHOLD_PROMPT = "x" * (ARG_MAX_STDIN_THRESHOLD + 1)
+"""A prompt one byte above the ARG_MAX_STDIN_THRESHOLD."""
+
 FAKE_SUCCESS = ProviderResult(exit_code=0, stdout="ok", stderr="")
 """Reusable successful ProviderResult for use as mock return value."""
 
@@ -34,16 +37,117 @@ FAKE_SUCCESS = ProviderResult(exit_code=0, stdout="ok", stderr="")
 class TestClaudeStdinFallback:
     """T002: stdin fallback tests for ClaudeProvider."""
 
-    pass
+    def test_small_prompt_uses_args(self) -> None:
+        """T01: prompt < threshold → prompt in args, stdin_data=None."""
+        provider = ClaudeProvider()
+        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(SMALL_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert SMALL_PROMPT in kwargs["args"]
+        assert kwargs.get("stdin_data") is None
+
+    def test_large_prompt_uses_stdin(self) -> None:
+        """T02: prompt above threshold → prompt NOT in args, stdin_data=prompt."""
+        provider = ClaudeProvider()
+        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(ABOVE_THRESHOLD_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert ABOVE_THRESHOLD_PROMPT not in kwargs["args"]
+        assert kwargs.get("stdin_data") == ABOVE_THRESHOLD_PROMPT
+
+    def test_large_prompt_with_flags_keeps_flags_in_args(self) -> None:
+        """T03: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt."""
+        options = ClaudeOptions(dangerously_skip_permissions=True)
+        provider = ClaudeProvider(options)
+        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(ABOVE_THRESHOLD_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert ABOVE_THRESHOLD_PROMPT not in kwargs["args"]
+        assert "--dangerously-skip-permissions" in kwargs["args"]
+        assert kwargs.get("stdin_data") == ABOVE_THRESHOLD_PROMPT
+
+    def test_prompt_at_threshold_uses_stdin(self) -> None:
+        """T10: prompt exactly at threshold → uses stdin (boundary case)."""
+        provider = ClaudeProvider()
+        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(LARGE_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert LARGE_PROMPT not in kwargs["args"]
+        assert kwargs.get("stdin_data") == LARGE_PROMPT
 
 
 class TestCodexStdinFallback:
     """T003: stdin fallback tests for CodexProvider."""
 
-    pass
+    def test_small_prompt_uses_args(self) -> None:
+        """T04: prompt < threshold → prompt in args, stdin_data=None."""
+        provider = CodexProvider()
+        with patch("fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(SMALL_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert SMALL_PROMPT in kwargs["args"]
+        assert kwargs.get("stdin_data") is None
+
+    def test_large_prompt_uses_stdin(self) -> None:
+        """T05: prompt >= threshold → prompt NOT in args, stdin_data=prompt."""
+        provider = CodexProvider()
+        with patch("fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(ABOVE_THRESHOLD_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert ABOVE_THRESHOLD_PROMPT not in kwargs["args"]
+        assert kwargs.get("stdin_data") == ABOVE_THRESHOLD_PROMPT
+
+    def test_large_prompt_with_flags_keeps_flags_in_args(self) -> None:
+        """T06: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt."""
+        options = CodexOptions(full_auto=True)
+        provider = CodexProvider(options)
+        with patch("fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(ABOVE_THRESHOLD_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert ABOVE_THRESHOLD_PROMPT not in kwargs["args"]
+        assert "--full-auto" in kwargs["args"]
+        assert kwargs.get("stdin_data") == ABOVE_THRESHOLD_PROMPT
 
 
 class TestOpenCodeStdinFallback:
     """T004: stdin fallback tests for OpenCodeProvider."""
 
-    pass
+    def test_small_prompt_uses_args(self) -> None:
+        """T07: prompt < threshold → prompt in args, stdin_data=None."""
+        provider = OpenCodeProvider()
+        with patch("fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(SMALL_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert SMALL_PROMPT in kwargs["args"]
+        assert kwargs.get("stdin_data") is None
+
+    def test_large_prompt_uses_stdin(self) -> None:
+        """T08: prompt >= threshold → prompt NOT in args, stdin_data=prompt."""
+        provider = OpenCodeProvider()
+        with patch("fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(ABOVE_THRESHOLD_PROMPT)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert ABOVE_THRESHOLD_PROMPT not in kwargs["args"]
+        assert kwargs.get("stdin_data") == ABOVE_THRESHOLD_PROMPT
+
+    def test_large_prompt_with_model_flag_keeps_model_in_args(self) -> None:
+        """T09: prompt >= threshold + model flag → `-m model` in args, prompt NOT in args, stdin_data=prompt."""
+        model = "gpt-4o"
+        provider = OpenCodeProvider()
+        with patch("fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+            provider.execute(ABOVE_THRESHOLD_PROMPT, model=model)
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert ABOVE_THRESHOLD_PROMPT not in kwargs["args"]
+        assert "-m" in kwargs["args"]
+        assert model in kwargs["args"]
+        assert kwargs.get("stdin_data") == ABOVE_THRESHOLD_PROMPT

--- a/tests/unit/test_provider_stdin_fallback.py
+++ b/tests/unit/test_provider_stdin_fallback.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderResult
 from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
 from fdsx.providers.codex import CodexOptions, CodexProvider
-from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
+from fdsx.providers.opencode import OpenCodeProvider
 
 # ---------------------------------------------------------------------------
 # Shared test constants

--- a/tests/unit/test_provider_stdin_fallback.py
+++ b/tests/unit/test_provider_stdin_fallback.py
@@ -1,0 +1,49 @@
+"""Unit tests for stdin fallback behaviour in CLI providers.
+
+Tests verify that prompts at or above ARG_MAX_STDIN_THRESHOLD are piped via
+stdin instead of being passed as a command-line argument, avoiding
+"Argument list too long" (ENOMSG/E2BIG) errors.
+"""
+
+from unittest.mock import patch
+
+from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderResult
+from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
+from fdsx.providers.codex import CodexOptions, CodexProvider
+from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
+
+# ---------------------------------------------------------------------------
+# Shared test constants
+# ---------------------------------------------------------------------------
+
+SMALL_PROMPT = "hello world"
+"""A prompt well below the ARG_MAX_STDIN_THRESHOLD."""
+
+LARGE_PROMPT = "x" * ARG_MAX_STDIN_THRESHOLD
+"""A prompt exactly at the ARG_MAX_STDIN_THRESHOLD (boundary / >= case)."""
+
+FAKE_SUCCESS = ProviderResult(exit_code=0, stdout="ok", stderr="")
+"""Reusable successful ProviderResult for use as mock return value."""
+
+
+# ---------------------------------------------------------------------------
+# Test classes (populated in T002–T004)
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeStdinFallback:
+    """T002: stdin fallback tests for ClaudeProvider."""
+
+    pass
+
+
+class TestCodexStdinFallback:
+    """T003: stdin fallback tests for CodexProvider."""
+
+    pass
+
+
+class TestOpenCodeStdinFallback:
+    """T004: stdin fallback tests for OpenCodeProvider."""
+
+    pass

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from fdsx.logging.recorder import RunRecorder, OUTPUT_PREVIEW_MAX_LENGTH
+from fdsx.logging.recorder import RunRecorder, OUTPUT_PREVIEW_MAX_LENGTH, RUN_FILENAME
 
 
 class TestRunRecorder:
@@ -178,7 +178,7 @@ class TestRunRecorder:
 
             file_path = recorder.save(base_dir=Path(tmpdir))
 
-            assert file_path == Path(tmpdir) / "runs" / "test-123.json"
+            assert file_path == Path(tmpdir) / "runs" / "test-123" / RUN_FILENAME
             assert file_path.exists()
 
             with open(file_path, "r") as f:
@@ -202,11 +202,15 @@ class TestRunRecorder:
             runs_dir = Path(tmpdir) / "runs"
             assert runs_dir.exists()
             assert runs_dir.is_dir()
+            thread_dir = runs_dir / "test-123"
+            assert thread_dir.exists()
+            assert thread_dir.is_dir()
 
     def test_save_resume_append(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             runs_dir = Path(tmpdir) / "runs"
-            runs_dir.mkdir()
+            thread_dir = runs_dir / "test-123"
+            thread_dir.mkdir(parents=True)
 
             existing_log = {
                 "thread_id": "test-123",
@@ -227,7 +231,7 @@ class TestRunRecorder:
                 ],
             }
 
-            existing_file = runs_dir / "test-123.json"
+            existing_file = thread_dir / RUN_FILENAME
             with open(existing_file, "w") as f:
                 json.dump(existing_log, f)
 
@@ -256,6 +260,27 @@ class TestRunRecorder:
             assert data["states"][0]["name"] == "planner"
             assert data["states"][1]["name"] == "implementer"
             assert data["started_at"] == "2026-03-14T10:00:00Z"
+
+    def test_save_no_base_dir_uses_fdsx_dir(self):
+        """T001: save() with no base_dir saves to {CWD}/.fdsx/runs/<thread_id>/run.json."""
+        import os
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                recorder = RunRecorder(
+                    thread_id="test-nobase",
+                    flow_name="test_flow",
+                )
+                recorder.finalize({"key": "value"}, "completed")
+                file_path = recorder.save()
+
+                expected = Path(tmpdir) / ".fdsx" / "runs" / "test-nobase" / RUN_FILENAME
+                assert file_path == expected
+                assert file_path.exists()
+            finally:
+                os.chdir(original_cwd)
 
     def test_to_dict(self):
         recorder = RunRecorder(
@@ -382,9 +407,14 @@ class TestRunRecorderSecurity:
             recorder.save(base_dir=Path(tmpdir))
 
             runs_dir = Path(tmpdir) / "runs"
+            thread_dir = runs_dir / "test-123"
             import os
 
             stat_info = os.stat(runs_dir)
+            mode = stat_info.st_mode & 0o777
+            assert mode == 0o700
+
+            stat_info = os.stat(thread_dir)
             mode = stat_info.st_mode & 0o777
             assert mode == 0o700
 
@@ -405,6 +435,11 @@ class TestRunRecorderSecurity:
             recorder.save(base_dir=Path(tmpdir))
 
             stat_info = os.stat(runs_dir)
+            mode = stat_info.st_mode & 0o777
+            assert mode == 0o700
+
+            thread_dir = runs_dir / "test-hardendir"
+            stat_info = os.stat(thread_dir)
             mode = stat_info.st_mode & 0o777
             assert mode == 0o700
 

--- a/tests/unit/test_result_file.py
+++ b/tests/unit/test_result_file.py
@@ -7,10 +7,15 @@ Phase 1:
 Phase 2:
   T006: Tests for _meta.run_dir propagation in run_flow()
   T008: Tests for static analysis recognizing result_file variables
+
+Phase 3:
+  T011: Tests for task node result_file wiring in compiler
+  T013: Tests for parallel collector node result_file wiring in compiler
 """
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -425,3 +430,214 @@ class TestStaticAnalysisResultFile:
         )
         errors = analyze_variable_references(flow)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# T011: Task node result_file wiring in compiler
+# ---------------------------------------------------------------------------
+
+
+class TestTaskNodeResultFileWiring:
+    """T011: Tests for result_file wiring in _create_task_node()."""
+
+    def _make_state_dict(self, run_dir: str) -> dict:
+        return {"_meta": {"run_dir": run_dir}}
+
+    def _run_task_node(
+        self,
+        state: TaskState,
+        state_dict: dict,
+        mock_write: MagicMock,
+    ) -> dict:
+        """Run _create_task_node with a mocked system provider and write_result_to_file."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        flow = MagicMock(spec=Flow)
+        flow.providers = None
+
+        with (
+            patch.object(compiler, "get_provider") as mock_get_provider,
+            patch("fdsx.core.compiler.write_result_to_file", mock_write),
+        ):
+            mock_provider = MagicMock()
+            mock_provider.execute.return_value = MagicMock(
+                exit_code=0, stdout="task output", stderr=""
+            )
+            mock_get_provider.return_value = mock_provider
+
+            node_fn = compiler._create_task_node("test_state", state, flow, None)
+            return node_fn(state_dict)
+
+    def test_file_only_mode_writes_file_and_stores_path(self, tmp_path: Path) -> None:
+        """Task with result_file only → file written, path stored in variable."""
+        state = TaskState(
+            type="task",
+            provider="system",
+            command="echo hello",
+            result_path="$.raw_output",
+            result_file="$.plan_ref",
+            end=True,
+        )
+        run_dir = str(tmp_path)
+        state_dict = self._make_state_dict(run_dir)
+
+        mock_write = MagicMock(return_value="/abs/path/to/plan_ref.md")
+        result = self._run_task_node(state, state_dict, mock_write)
+
+        mock_write.assert_called_once()
+        call_args = mock_write.call_args
+        assert call_args[0][0] == "plan_ref"  # varname
+        assert call_args[0][1] == "task output"  # value (stdout)
+        assert isinstance(call_args[0][2], Path)  # run_dir as Path
+
+        assert result.get("plan_ref") == "/abs/path/to/plan_ref.md"
+
+    def test_both_result_path_and_result_file_set(self, tmp_path: Path) -> None:
+        """Task with both result_path and result_file → both set correctly."""
+        state = TaskState(
+            type="task",
+            provider="system",
+            command="echo hello",
+            result_path="$.raw_output",
+            result_file="$.plan_ref",
+            end=True,
+        )
+        run_dir = str(tmp_path)
+        state_dict = self._make_state_dict(run_dir)
+
+        mock_write = MagicMock(return_value="/abs/path/to/plan_ref.md")
+        result = self._run_task_node(state, state_dict, mock_write)
+
+        assert result.get("raw_output") == "task output"
+        assert result.get("plan_ref") == "/abs/path/to/plan_ref.md"
+
+    def test_no_result_file_no_file_io(self, tmp_path: Path) -> None:
+        """Task without result_file → write_result_to_file not called."""
+        state = TaskState(
+            type="task",
+            provider="system",
+            command="echo hello",
+            result_path="$.raw_output",
+            end=True,
+        )
+        run_dir = str(tmp_path)
+        state_dict = self._make_state_dict(run_dir)
+
+        mock_write = MagicMock()
+        result = self._run_task_node(state, state_dict, mock_write)
+
+        mock_write.assert_not_called()
+        assert result.get("raw_output") == "task output"
+
+
+# ---------------------------------------------------------------------------
+# T013: Parallel collector node result_file wiring in compiler
+# ---------------------------------------------------------------------------
+
+
+class TestCollectorNodeResultFileWiring:
+    """T013: Tests for result_file wiring in _create_collector_node()."""
+
+    def _make_branch_results(self, state_name: str, results: list[dict]) -> dict:
+        """Build a state_dict with branch results and _meta."""
+        return {
+            f"_br_{state_name}": results,
+            "_meta": {"run_dir": "/tmp/test_run"},
+        }
+
+    def _run_collector_node(
+        self,
+        state_name: str,
+        state: ParallelState,
+        state_dict: dict,
+        mock_write: MagicMock,
+    ) -> dict:
+        """Run _create_collector_node with mocked write_result_to_file."""
+        import fdsx.core.compiler as compiler
+        from fdsx.models.flow import Flow
+
+        flow = MagicMock(spec=Flow)
+
+        with patch("fdsx.core.compiler.write_result_to_file", mock_write):
+            node_fn = compiler._create_collector_node(state_name, state, flow, None)
+            return node_fn(state_dict)
+
+    def test_parallel_with_result_file_writes_file_and_stores_path(self) -> None:
+        """Parallel with result_file → clean_results written to file, path stored."""
+        from fdsx.models.flow import Branch
+
+        state = ParallelState(
+            type="parallel",
+            branches=[
+                Branch(provider="system", command="echo b1"),
+                Branch(provider="system", command="echo b2"),
+            ],
+            result_path="$.par_output",
+            result_file="$.reviews_ref",
+            end=True,
+        )
+        branch_results = [
+            {"index": 0, "exit_code": 0, "stdout": "b1"},
+            {"index": 1, "exit_code": 0, "stdout": "b2"},
+        ]
+        state_dict = self._make_branch_results("par_state", branch_results)
+
+        mock_write = MagicMock(return_value="/abs/path/to/reviews_ref.json")
+        result = self._run_collector_node("par_state", state, state_dict, mock_write)
+
+        mock_write.assert_called_once()
+        call_args = mock_write.call_args
+        assert call_args[0][0] == "reviews_ref"  # varname
+        assert isinstance(call_args[0][1], list)  # clean_results list
+        assert isinstance(call_args[0][2], Path)  # run_dir as Path
+
+        assert result.get("reviews_ref") == "/abs/path/to/reviews_ref.json"
+
+    def test_parallel_with_both_result_path_and_result_file(self) -> None:
+        """Parallel with both result_path and result_file → both set."""
+        from fdsx.models.flow import Branch
+
+        state = ParallelState(
+            type="parallel",
+            branches=[
+                Branch(provider="system", command="echo b1"),
+            ],
+            result_path="$.par_output",
+            result_file="$.reviews_ref",
+            end=True,
+        )
+        branch_results = [
+            {"index": 0, "exit_code": 0, "stdout": "b1"},
+        ]
+        state_dict = self._make_branch_results("par_state", branch_results)
+
+        mock_write = MagicMock(return_value="/abs/reviews_ref.json")
+        result = self._run_collector_node("par_state", state, state_dict, mock_write)
+
+        par_output = result.get("par_output")
+        assert isinstance(par_output, list)
+        assert result.get("reviews_ref") == "/abs/reviews_ref.json"
+
+    def test_parallel_without_result_file_unchanged_behavior(self) -> None:
+        """Parallel without result_file → write_result_to_file not called."""
+        from fdsx.models.flow import Branch
+
+        state = ParallelState(
+            type="parallel",
+            branches=[
+                Branch(provider="system", command="echo b1"),
+            ],
+            result_path="$.par_output",
+            end=True,
+        )
+        branch_results = [
+            {"index": 0, "exit_code": 0, "stdout": "b1"},
+        ]
+        state_dict = self._make_branch_results("par_state", branch_results)
+
+        mock_write = MagicMock()
+        result = self._run_collector_node("par_state", state, state_dict, mock_write)
+
+        mock_write.assert_not_called()
+        assert isinstance(result.get("par_output"), list)

--- a/tests/unit/test_result_file.py
+++ b/tests/unit/test_result_file.py
@@ -1,7 +1,12 @@
-"""Phase 1 TDD tests: write_result_to_file() helper and result_file model field.
+"""TDD tests for result_file variable passing.
 
-T001: Tests for write_result_to_file() helper
-T003: Tests for result_file model field validation
+Phase 1:
+  T001: Tests for write_result_to_file() helper
+  T003: Tests for result_file model field validation
+
+Phase 2:
+  T006: Tests for _meta.run_dir propagation in run_flow()
+  T008: Tests for static analysis recognizing result_file variables
 """
 
 import json
@@ -201,3 +206,222 @@ class TestParallelStateResultFile:
         for varname in ("$.reviews_ref", "$.summary_ref", "$.r"):
             state = self._base_parallel(result_file=varname)
             assert state.result_file == varname
+
+
+# ---------------------------------------------------------------------------
+# T006: _meta.run_dir propagation in run_flow()
+# ---------------------------------------------------------------------------
+
+
+class TestMetaRunDir:
+    """T006: Tests that run_flow() sets _meta.run_dir in initial_state."""
+
+    def _make_flow_yaml(self, path: Path) -> Path:
+        """Create a minimal single-state flow YAML for testing."""
+        flow_path = path / "test_flow.yaml"
+        flow_path.write_text(
+            "name: test\n"
+            "description: test flow\n"
+            "start_at: start\n"
+            "states:\n"
+            "  start:\n"
+            "    type: task\n"
+            "    provider: system\n"
+            "    command: echo test\n"
+            "    result_path: $.output\n"
+            "    end: true\n"
+        )
+        return flow_path
+
+    def _run_flow_with_capture(self, flow_path: Path, thread_id: str) -> dict:
+        """Run flow with mocked compile_flow and return captured initial_state."""
+        from unittest.mock import MagicMock, patch
+
+        from fdsx.core.engine import run_flow
+
+        captured: list[dict] = []
+        mock_graph = MagicMock()
+        mock_graph.stream.side_effect = lambda state, **kw: (
+            captured.append(state) or []
+        )
+        mock_graph.get_state.return_value = MagicMock(tasks=[], values={})
+        mock_compiled = MagicMock()
+        mock_compiled.graph = mock_graph
+        mock_compiled.result_paths = []
+
+        with (
+            patch("fdsx.core.engine.compile_flow", return_value=mock_compiled),
+            patch("fdsx.core.engine.RunRecorder") as mock_recorder_cls,
+            patch("fdsx.core.engine.display_completion_summary"),
+            patch("fdsx.core.engine.load_config"),
+        ):
+            mock_recorder_instance = MagicMock()
+            mock_recorder_instance.started_at = "2026-01-01T00:00:00+00:00"
+            mock_recorder_instance.completed_at = None
+            mock_recorder_instance.states = []
+            mock_recorder_instance.flow_name = "test"
+            mock_recorder_cls.return_value = mock_recorder_instance
+            run_flow(flow_path, thread_id=thread_id)
+
+        assert len(captured) == 1, "compile_flow.graph.stream was not called"
+        return captured[0]
+
+    def test_run_flow_sets_meta_run_dir(self, tmp_path: Path) -> None:
+        """initial_state['_meta']['run_dir'] is set in run_flow."""
+        flow_path = self._make_flow_yaml(tmp_path)
+        initial_state = self._run_flow_with_capture(flow_path, "test-thread-t006a")
+        assert "_meta" in initial_state
+        assert "run_dir" in initial_state["_meta"], (
+            f"Expected 'run_dir' in _meta, got: {initial_state['_meta']}"
+        )
+
+    def test_run_dir_value_matches_runs_base_runs_thread_id(
+        self, tmp_path: Path
+    ) -> None:
+        """run_dir value matches <_runs_base>/runs/<thread_id>."""
+        from fdsx.logging.recorder import RUNS_DIR_NAME
+
+        flow_path = self._make_flow_yaml(tmp_path)
+        thread_id = "test-thread-t006b"
+        initial_state = self._run_flow_with_capture(flow_path, thread_id)
+        run_dir = initial_state["_meta"]["run_dir"]
+        expected_suffix = f"{RUNS_DIR_NAME}/{thread_id}"
+        assert run_dir.endswith(expected_suffix), (
+            f"Expected run_dir to end with {expected_suffix!r}, got {run_dir!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T008: Static analysis recognizes result_file variables
+# ---------------------------------------------------------------------------
+
+
+class TestStaticAnalysisResultFile:
+    """T008: Tests that analyze_variable_references() does not flag result_file
+    variables as undefined when they are set by an upstream state."""
+
+    def test_task_result_file_variable_not_flagged_downstream(self) -> None:
+        """analyze_variable_references() does not flag a variable set via
+        TaskState result_file when it is referenced in a downstream state."""
+        from fdsx.core.variables import analyze_variable_references
+        from fdsx.models.flow import Flow
+
+        flow = Flow(
+            name="result_file flow",
+            description="Test result_file static analysis",
+            start_at="produce",
+            states={
+                "produce": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo content",
+                    result_path="$.output",
+                    result_file="$.plan_ref",
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {plan_ref}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_parallel_result_file_variable_not_flagged_downstream(self) -> None:
+        """analyze_variable_references() does not flag a variable set via
+        ParallelState result_file when it is referenced downstream."""
+        from fdsx.core.variables import analyze_variable_references
+        from fdsx.models.flow import Branch, Flow
+
+        flow = Flow(
+            name="parallel result_file flow",
+            description="Test parallel result_file static analysis",
+            start_at="par",
+            states={
+                "par": ParallelState(
+                    type="parallel",
+                    branches=[
+                        Branch(provider="system", command="echo branch1"),
+                        Branch(provider="system", command="echo branch2"),
+                    ],
+                    result_path="$.par_output",
+                    result_file="$.reviews_ref",
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {reviews_ref}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_result_file_variable_undefined_still_flagged(self) -> None:
+        """A variable referenced downstream that has NOT been set via result_file
+        or result_path is still flagged as undefined."""
+        from fdsx.core.variables import analyze_variable_references
+        from fdsx.models.flow import Flow
+
+        flow = Flow(
+            name="undefined ref flow",
+            description="Test that undefined var is still flagged",
+            start_at="produce",
+            states={
+                "produce": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo content",
+                    result_path="$.output",
+                    result_file="$.plan_ref",
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {not_set_anywhere}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 1
+        assert "not_set_anywhere" in errors[0]
+
+    def test_result_file_and_result_path_both_recognized(self) -> None:
+        """Both result_file and result_path on the same state are recognized."""
+        from fdsx.core.variables import analyze_variable_references
+        from fdsx.models.flow import Flow
+
+        flow = Flow(
+            name="both fields flow",
+            description="Test both result_file and result_path",
+            start_at="produce",
+            states={
+                "produce": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo content",
+                    result_path="$.raw_result",
+                    result_file="$.file_ref",
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {raw_result} {file_ref}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"

--- a/tests/unit/test_result_file.py
+++ b/tests/unit/test_result_file.py
@@ -1,0 +1,203 @@
+"""Phase 1 TDD tests: write_result_to_file() helper and result_file model field.
+
+T001: Tests for write_result_to_file() helper
+T003: Tests for result_file model field validation
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from fdsx.core.variables import write_result_to_file
+from fdsx.models.flow import ParallelState, TaskState
+
+
+# ---------------------------------------------------------------------------
+# T001: write_result_to_file() helper
+# ---------------------------------------------------------------------------
+
+
+class TestWriteResultToFile:
+    """T001: Tests for the write_result_to_file() helper function."""
+
+    def test_string_value_creates_md_file(self, tmp_path: Path) -> None:
+        """String value → creates <varname>.md with string content."""
+        result = write_result_to_file("plan", "Hello world", tmp_path)
+        expected = tmp_path / "data" / "plan.md"
+        assert expected.exists()
+        assert expected.read_text(encoding="utf-8") == "Hello world"
+        assert result == str(expected.resolve())
+
+    def test_dict_value_creates_json_file(self, tmp_path: Path) -> None:
+        """Dict value → creates <varname>.json with JSON content."""
+        value = {"key": "value", "count": 42}
+        result = write_result_to_file("metadata", value, tmp_path)
+        expected = tmp_path / "data" / "metadata.json"
+        assert expected.exists()
+        loaded = json.loads(expected.read_text(encoding="utf-8"))
+        assert loaded == value
+        assert result == str(expected.resolve())
+
+    def test_list_value_creates_json_file(self, tmp_path: Path) -> None:
+        """List value → creates <varname>.json with JSON content."""
+        value = ["item1", "item2", {"nested": True}]
+        result = write_result_to_file("reviews", value, tmp_path)
+        expected = tmp_path / "data" / "reviews.json"
+        assert expected.exists()
+        loaded = json.loads(expected.read_text(encoding="utf-8"))
+        assert loaded == value
+        assert result == str(expected.resolve())
+
+    def test_data_directory_created_automatically(self, tmp_path: Path) -> None:
+        """data/ directory created automatically if missing."""
+        data_dir = tmp_path / "data"
+        assert not data_dir.exists()
+        write_result_to_file("output", "content", tmp_path)
+        assert data_dir.exists()
+        assert data_dir.is_dir()
+
+    def test_file_overwritten_on_second_call(self, tmp_path: Path) -> None:
+        """File overwritten on second call with same varname."""
+        write_result_to_file("output", "first content", tmp_path)
+        write_result_to_file("output", "second content", tmp_path)
+        expected = tmp_path / "data" / "output.md"
+        assert expected.read_text(encoding="utf-8") == "second content"
+
+    def test_returns_absolute_file_path(self, tmp_path: Path) -> None:
+        """Returns absolute file path as string."""
+        result = write_result_to_file("result", "content", tmp_path)
+        assert Path(result).is_absolute()
+
+    def test_utf8_encoding_for_non_ascii(self, tmp_path: Path) -> None:
+        """UTF-8 encoding for non-ASCII content."""
+        value = "日本語テスト: 🚀 émojis"
+        write_result_to_file("unicode_result", value, tmp_path)
+        expected = tmp_path / "data" / "unicode_result.md"
+        assert expected.read_text(encoding="utf-8") == value
+
+    def test_json_content_is_valid_json(self, tmp_path: Path) -> None:
+        """JSON files must be parseable."""
+        value = {"nested": {"deep": [1, 2, 3]}}
+        write_result_to_file("complex", value, tmp_path)
+        file_path = tmp_path / "data" / "complex.json"
+        content = file_path.read_text(encoding="utf-8")
+        parsed = json.loads(content)
+        assert parsed == value
+
+
+# ---------------------------------------------------------------------------
+# T003: result_file model field validation
+# ---------------------------------------------------------------------------
+
+
+class TestTaskStateResultFile:
+    """T003: Tests for result_file field on TaskState."""
+
+    def _base_task(self, **kwargs) -> TaskState:
+        return TaskState(
+            type="task",
+            provider="system",
+            command="echo test",
+            result_path="$.result",
+            end=True,
+            **kwargs,
+        )
+
+    def test_accepts_valid_result_file(self) -> None:
+        """TaskState accepts result_file: '$.plan_ref'."""
+        state = self._base_task(result_file="$.plan_ref")
+        assert state.result_file == "$.plan_ref"
+
+    def test_defaults_to_none_when_not_set(self) -> None:
+        """result_file defaults to None when not set."""
+        state = self._base_task()
+        assert state.result_file is None
+
+    def test_rejects_missing_dollar_prefix(self) -> None:
+        """Rejects result_file without '$.' prefix."""
+        with pytest.raises(ValidationError, match=r"\$\."):
+            self._base_task(result_file="plan_ref")
+
+    def test_rejects_nested_path(self) -> None:
+        """Rejects nested path like '$.foo.bar'."""
+        with pytest.raises(ValidationError, match="nested"):
+            self._base_task(result_file="$.foo.bar")
+
+    def test_rejects_nested_bracket_path(self) -> None:
+        """Rejects bracket-notation nested path like '$.foo[0]'."""
+        with pytest.raises(ValidationError, match="nested"):
+            self._base_task(result_file="$.foo[0]")
+
+    def test_result_file_and_result_path_coexist(self) -> None:
+        """result_file and result_path can coexist with different variable names."""
+        state = self._base_task(result_file="$.plan_ref")
+        assert state.result_path == "$.result"
+        assert state.result_file == "$.plan_ref"
+
+    def test_rejects_empty_varname(self) -> None:
+        """Rejects '$.' with no variable name after the prefix."""
+        with pytest.raises(ValidationError, match="variable name"):
+            self._base_task(result_file="$.")
+
+    def test_accepts_various_valid_varnames(self) -> None:
+        """Various valid top-level variable names are accepted."""
+        for varname in ("$.output_ref", "$.my_var", "$.x"):
+            state = self._base_task(result_file=varname)
+            assert state.result_file == varname
+
+
+class TestParallelStateResultFile:
+    """T003: Tests for result_file field on ParallelState."""
+
+    def _base_parallel(self, **kwargs) -> ParallelState:
+        return ParallelState(
+            type="parallel",
+            branches=[],
+            result_path="$.results",
+            end=True,
+            **kwargs,
+        )
+
+    def test_accepts_valid_result_file(self) -> None:
+        """ParallelState accepts result_file: '$.reviews_ref'."""
+        state = self._base_parallel(result_file="$.reviews_ref")
+        assert state.result_file == "$.reviews_ref"
+
+    def test_defaults_to_none_when_not_set(self) -> None:
+        """result_file defaults to None when not set."""
+        state = self._base_parallel()
+        assert state.result_file is None
+
+    def test_rejects_missing_dollar_prefix(self) -> None:
+        """Rejects result_file without '$.' prefix."""
+        with pytest.raises(ValidationError, match=r"\$\."):
+            self._base_parallel(result_file="reviews_ref")
+
+    def test_rejects_nested_path(self) -> None:
+        """Rejects nested path like '$.foo.bar'."""
+        with pytest.raises(ValidationError, match="nested"):
+            self._base_parallel(result_file="$.foo.bar")
+
+    def test_rejects_nested_bracket_path(self) -> None:
+        """Rejects bracket-notation nested path like '$.results[0]'."""
+        with pytest.raises(ValidationError, match="nested"):
+            self._base_parallel(result_file="$.results[0]")
+
+    def test_result_file_and_result_path_coexist(self) -> None:
+        """result_file and result_path can coexist with different variable names."""
+        state = self._base_parallel(result_file="$.reviews_ref")
+        assert state.result_path == "$.results"
+        assert state.result_file == "$.reviews_ref"
+
+    def test_rejects_empty_varname(self) -> None:
+        """Rejects '$.' with no variable name after the prefix."""
+        with pytest.raises(ValidationError, match="variable name"):
+            self._base_parallel(result_file="$.")
+
+    def test_accepts_various_valid_varnames(self) -> None:
+        """Various valid top-level variable names are accepted."""
+        for varname in ("$.reviews_ref", "$.summary_ref", "$.r"):
+            state = self._base_parallel(result_file=varname)
+            assert state.result_file == varname

--- a/tests/unit/test_resume_display.py
+++ b/tests/unit/test_resume_display.py
@@ -1,0 +1,193 @@
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.display.terminal import display_resume_command
+
+
+class TestDisplayResumeCommandSingleFlow:
+    """Tests for display_resume_command in single-flow mode."""
+
+    def test_displays_single_flow_resume_command(self):
+        """Single-flow mode displays fdsx resume --thread-id with correct format."""
+        buf = StringIO()
+        display_resume_command(
+            mode="single-flow",
+            thread_id="abc-123-xyz",
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "fdsx resume --thread-id abc-123-xyz" in output
+        assert "To resume this flow, run:" in output
+
+    def test_single_flow_box_format(self):
+        """Resume command is displayed in a box format with borders."""
+        buf = StringIO()
+        display_resume_command(
+            mode="single-flow",
+            thread_id="test-thread",
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        lines = output.strip().split("\n")
+        assert any(line.startswith("+--") for line in lines)
+        assert any("|  $ fdsx resume" in line for line in lines)
+        border_lines = [line for line in lines if line.startswith("+")]
+        assert any(line.rstrip().endswith("+") for line in border_lines)
+
+    def test_single_flow_thread_id_sanitized(self):
+        """ANSI escape sequences in thread_id are sanitized."""
+        buf = StringIO()
+        display_resume_command(
+            mode="single-flow",
+            thread_id="\x1b[31mevil\x1b[0m",
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "evil" in output
+
+    def test_single_flow_with_extra_args(self):
+        """Extra arguments are appended to the resume command."""
+        buf = StringIO()
+        display_resume_command(
+            mode="single-flow",
+            thread_id="test-id",
+            extra_args=["--base-dir", "/custom/path"],
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "fdsx resume --thread-id test-id --base-dir /custom/path" in output
+
+    def test_single_flow_extra_args_sanitized(self):
+        """Extra arguments are sanitized."""
+        buf = StringIO()
+        display_resume_command(
+            mode="single-flow",
+            thread_id="test-id",
+            extra_args=["\x1b[32mevil\x1b[0m"],
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "evil" in output
+
+    def test_single_flow_requires_thread_id(self):
+        """ValueError is raised if thread_id is None in single-flow mode."""
+        buf = StringIO()
+        with pytest.raises(ValueError, match="thread_id is required"):
+            display_resume_command(
+                mode="single-flow",
+                thread_id=None,
+                stream=buf,
+            )
+
+    def test_single_flow_output_goes_to_stream(self):
+        """Output is written to the specified stream."""
+        buf = StringIO()
+        display_resume_command(
+            mode="single-flow",
+            thread_id="test-id",
+            stream=buf,
+        )
+
+        assert "fdsx resume" in buf.getvalue()
+
+
+class TestDisplayResumeCommandTasksDir:
+    """Tests for display_resume_command in tasks-dir mode."""
+
+    def test_displays_tasks_dir_run_command(self):
+        """Tasks-dir mode displays fdsx run --tasks-dir with correct format."""
+        buf = StringIO()
+        display_resume_command(
+            mode="tasks-dir",
+            tasks_dir=Path("/path/to/tasks"),
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "fdsx run --tasks-dir /path/to/tasks" in output
+        assert "To continue processing, run:" in output
+
+    def test_tasks_dir_box_format(self):
+        """Resume command is displayed in a box format with borders."""
+        buf = StringIO()
+        display_resume_command(
+            mode="tasks-dir",
+            tasks_dir=Path("./tasks"),
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        lines = output.strip().split("\n")
+        assert any(line.startswith("+--") for line in lines)
+        assert any("|  $ fdsx run" in line for line in lines)
+
+    def test_tasks_dir_path_sanitized(self):
+        """ANSI escape sequences in path are sanitized."""
+        buf = StringIO()
+        display_resume_command(
+            mode="tasks-dir",
+            tasks_dir=Path("\x1b[31mevil\x1b[0m"),
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "evil" in output
+
+    def test_tasks_dir_requires_tasks_dir(self):
+        """ValueError is raised if tasks_dir is None in tasks-dir mode."""
+        buf = StringIO()
+        with pytest.raises(ValueError, match="tasks_dir is required"):
+            display_resume_command(
+                mode="tasks-dir",
+                tasks_dir=None,
+                stream=buf,
+            )
+
+    def test_tasks_dir_with_extra_args(self):
+        """Extra arguments are appended to the run command."""
+        buf = StringIO()
+        display_resume_command(
+            mode="tasks-dir",
+            tasks_dir=Path("/path/to/tasks"),
+            extra_args=["--auto-workflow"],
+            stream=buf,
+        )
+
+        output = buf.getvalue()
+        assert "fdsx run --tasks-dir /path/to/tasks --auto-workflow" in output
+
+
+class TestDisplayResumeCommandDefaults:
+    """Tests for default behavior of display_resume_command."""
+
+    def test_defaults_to_stderr(self):
+        """When no stream is provided, output goes to sys.stderr."""
+        with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            display_resume_command(
+                mode="single-flow",
+                thread_id="test-id",
+            )
+
+        output = mock_stderr.getvalue()
+        assert "fdsx resume" in output
+
+    def test_invalid_mode_raises_error(self):
+        """Invalid mode raises ValueError."""
+        buf = StringIO()
+        with pytest.raises(ValueError, match="Invalid mode"):
+            display_resume_command(
+                mode="invalid-mode",
+                thread_id="test-id",
+                stream=buf,
+            )

--- a/tests/unit/test_selector.py
+++ b/tests/unit/test_selector.py
@@ -1,0 +1,642 @@
+"""Unit tests for the workflow selector module."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from fdsx.core.config import WorkflowSelectorConfig
+from fdsx.core.selector import (
+    _build_workflow_selection_prompt,
+    _parse_workflow_selection,
+    confirm_workflow_selection,
+    discover_workflows,
+    pick_workflow_manually,
+    resolve_workflow_for_task,
+    select_workflow,
+)
+
+
+class TestDiscoverWorkflows:
+    def test_discovers_yaml_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "b-workflow.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "B",
+                        "description": "B workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo b",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            (workflows_dir / "a-workflow.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "A",
+                        "description": "A workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo a",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+
+            results = discover_workflows(workflows_dir)
+
+            assert len(results) == 2
+            names = [p.name for p, _ in results]
+            assert names == ["a-workflow.yaml", "b-workflow.yaml"]
+            assert results[0][1] == "A workflow"
+            assert results[1][1] == "B workflow"
+
+    def test_returns_empty_for_nonexistent_dir(self):
+        results = discover_workflows(Path("/nonexistent/path"))
+        assert results == []
+
+    def test_raises_on_symlinked_dir(self, tmp_path):
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+        link_dir = tmp_path / "link"
+        link_dir.symlink_to(real_dir)
+
+        with pytest.raises(ValueError, match="must not be a symlink"):
+            discover_workflows(link_dir)
+
+    def test_skips_invalid_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "valid.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "V",
+                        "description": "Valid",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo v",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            (workflows_dir / "invalid.yaml").write_text("not: [valid: yaml")
+
+            with pytest.warns(RuntimeWarning, match="Skipping invalid workflow"):
+                results = discover_workflows(workflows_dir)
+
+            assert len(results) == 1
+            assert results[0][0].name == "valid.yaml"
+
+    def test_skips_symlinked_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            real_file = workflows_dir / "workflow.yaml"
+            real_file.write_text(
+                yaml.dump(
+                    {
+                        "name": "W",
+                        "description": "Workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo w",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            symlink_file = workflows_dir / "link.yaml"
+            symlink_file.symlink_to(real_file)
+
+            with pytest.warns(RuntimeWarning, match="Skipping symlinked workflow file"):
+                results = discover_workflows(workflows_dir)
+
+            assert len(results) == 1
+            assert results[0][0].name == "workflow.yaml"
+
+    def test_empty_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            results = discover_workflows(workflows_dir)
+            assert results == []
+
+
+class TestBuildWorkflowSelectionPrompt:
+    def test_includes_task_description(self):
+        workflows = [(Path("plan.yaml"), "Plan workflow")]
+        prompt = _build_workflow_selection_prompt("Implement a feature", workflows)
+        assert "Implement a feature" in prompt
+
+    def test_includes_workflow_descriptions(self):
+        workflows = [
+            (Path("plan.yaml"), "Planning phase"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+        prompt = _build_workflow_selection_prompt("Build something", workflows)
+        assert "plan.yaml" in prompt
+        assert "Planning phase" in prompt
+        assert "implement.yaml" in prompt
+        assert "Implementation" in prompt
+
+    def test_requests_filename_only(self):
+        workflows = [(Path("test.yaml"), "Test workflow")]
+        prompt = _build_workflow_selection_prompt("Test task", workflows)
+        assert "filename" in prompt.lower()
+        assert "Return ONLY" in prompt or "only" in prompt.lower()
+
+
+class TestParseWorkflowSelection:
+    def test_parses_plain_filename(self):
+        result = _parse_workflow_selection("plan-implement.yaml")
+        assert result == "plan-implement.yaml"
+
+    def test_strips_markdown_code_block(self):
+        result = _parse_workflow_selection("```yaml\nplan-implement.yaml\n```")
+        assert result == "plan-implement.yaml"
+
+    def test_strips_yaml_code_block_with_quotes(self):
+        result = _parse_workflow_selection('```yaml\n"plan.yaml"\n```')
+        assert result == "plan.yaml"
+
+    def test_strips_quotes(self):
+        assert _parse_workflow_selection('"plan.yaml"') == "plan.yaml"
+        assert _parse_workflow_selection("'plan.yaml'") == "plan.yaml"
+
+    def test_strips_whitespace(self):
+        result = _parse_workflow_selection("  plan.yaml  \n")
+        assert result == "plan.yaml"
+
+    def test_missing_yaml_extension_parsed_for_matching(self):
+        result = _parse_workflow_selection("plan-implement")
+        assert result == "plan-implement"
+
+    def test_raises_on_empty_response(self):
+        with pytest.raises(ValueError, match="Empty workflow selection"):
+            _parse_workflow_selection("")
+
+    def test_raises_on_whitespace_only_response(self):
+        with pytest.raises(ValueError, match="Empty workflow selection"):
+            _parse_workflow_selection("   \n  ")
+
+
+class TestSelectWorkflow:
+    def test_single_workflow_shortcut(self):
+        workflows = [(Path("only.yaml"), "Only workflow")]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        result = select_workflow("Do something", workflows, config)
+
+        assert result == Path("only.yaml")
+
+    def test_no_workflows_raises(self):
+        workflows: list[tuple[Path, str]] = []
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with pytest.raises(ValueError, match="No workflows found"):
+            select_workflow("Do something", workflows, config)
+
+    def test_multiple_workflows_calls_llm(self):
+        workflows = [
+            (Path("plan.yaml"), "Planning workflow"),
+            (Path("implement.yaml"), "Implementation workflow"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="plan.yaml",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            result = select_workflow("Build a feature", workflows, config)
+
+        assert result == Path("plan.yaml")
+        call_kwargs = mock_provider.execute.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-6"
+
+    def test_llm_response_with_code_block(self):
+        workflows = [(Path("implement.yaml"), "Implementation")]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="```yaml\nimplement.yaml\n```",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            result = select_workflow("Implement feature", workflows, config)
+
+        assert result == Path("implement.yaml")
+
+    def test_llm_selects_nonexistent_workflow_raises(self):
+        workflows = [
+            (Path("plan.yaml"), "Planning"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="nonexistent.yaml",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with pytest.raises(ValueError, match="does not match any available"):
+                select_workflow("Build something", workflows, config)
+
+    def test_llm_response_without_yaml_extension_matches(self):
+        workflows = [
+            (Path("plan.yaml"), "Planning"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="implement",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            result = select_workflow("Build something", workflows, config)
+
+        assert result == Path("implement.yaml")
+
+    def test_llm_response_with_prefix_matches(self):
+        workflows = [
+            (Path("plan.yaml"), "Planning"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="I recommend implement.yaml",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            result = select_workflow("Build something", workflows, config)
+
+        assert result == Path("implement.yaml")
+
+    def test_stem_overlap_does_not_match_wrong_workflow(self):
+        """Regression: Strategy 3 must not match 'code.yaml' when LLM says 'review-code'.
+        Previously, `wf_path.stem in selected_name` would match 'code' in 'review-code'.
+        """
+        workflows = [
+            (Path("code.yaml"), "Code workflow"),
+            (Path("review.yaml"), "Review workflow"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="review-code",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with pytest.raises(ValueError, match="does not match any available"):
+                select_workflow("Review code", workflows, config)
+
+    def test_ambiguous_filename_match_raises(self):
+        """Regression: Strategy 3 must raise if multiple filenames appear in the response."""
+        workflows = [
+            (Path("plan.yaml"), "Planning"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="either plan.yaml or implement.yaml would work",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with pytest.raises(ValueError, match="does not match any available"):
+                select_workflow("Ambiguous task", workflows, config)
+
+    def test_stem_in_surrounding_text_matches(self):
+        """Regression (Finding 2): stem matching should still work when LLM wraps the
+        stem in surrounding text like 'I recommend implement' (no .yaml extension).
+        """
+        workflows = [
+            (Path("plan.yaml"), "Planning"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="I recommend implement",
+            stderr="",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            result = select_workflow("Build something", workflows, config)
+
+        assert result == Path("implement.yaml")
+
+    def test_provider_failure_raises(self):
+        workflows = [(Path("a.yaml"), "A"), (Path("b.yaml"), "B")]
+        config = WorkflowSelectorConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=1,
+            stdout="",
+            stderr="Provider error",
+        )
+
+        with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+            with pytest.raises(RuntimeError, match="Workflow selector failed"):
+                select_workflow("Build something", workflows, config)
+
+
+class TestConfirmWorkflowSelection:
+    def test_approve_returns_true(self):
+        with patch("builtins.input", return_value="y"):
+            result = confirm_workflow_selection(
+                Path("plan.yaml"), "Implement a feature"
+            )
+        assert result is True
+
+    def test_reject_returns_false(self):
+        with patch("builtins.input", return_value="n"):
+            result = confirm_workflow_selection(
+                Path("plan.yaml"), "Implement a feature"
+            )
+        assert result is False
+
+    def test_list_returns_false(self):
+        with patch("builtins.input", return_value="l"):
+            result = confirm_workflow_selection(
+                Path("plan.yaml"), "Implement a feature"
+            )
+        assert result is False
+
+    def test_invalid_then_approve(self):
+        inputs = iter(["invalid", "y"])
+        with patch("builtins.input", lambda x: next(inputs)):
+            result = confirm_workflow_selection(
+                Path("plan.yaml"), "Implement a feature"
+            )
+        assert result is True
+
+
+class TestPickWorkflowManually:
+    def test_pick_valid_number(self):
+        workflows = [
+            (Path("plan.yaml"), "Planning"),
+            (Path("implement.yaml"), "Implementation"),
+        ]
+
+        with patch("builtins.input", return_value="1"):
+            result = pick_workflow_manually(workflows)
+
+        assert result == Path("plan.yaml")
+
+    def test_cancel_returns_none(self):
+        workflows = [(Path("plan.yaml"), "Planning")]
+
+        with patch("builtins.input", return_value="c"):
+            result = pick_workflow_manually(workflows)
+
+        assert result is None
+
+    def test_invalid_number_prompts_again(self):
+        workflows = [(Path("plan.yaml"), "Planning")]
+
+        inputs = iter(["0", "1"])
+        with patch("builtins.input", lambda x: next(inputs)):
+            result = pick_workflow_manually(workflows)
+
+        assert result == Path("plan.yaml")
+
+
+class TestResolveWorkflowForTask:
+    def test_no_workflows_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            with pytest.raises(ValueError, match="No workflows found"):
+                resolve_workflow_for_task(
+                    task_description="Do something",
+                    workflows_dir=workflows_dir,
+                    selector_config=config,
+                    auto_workflow=True,
+                )
+
+    def test_single_workflow_auto_mode(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "only.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Only",
+                        "description": "Only workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo o",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            result = resolve_workflow_for_task(
+                task_description="Do something",
+                workflows_dir=workflows_dir,
+                selector_config=config,
+                auto_workflow=True,
+            )
+
+            assert result == Path(tmpdir) / "only.yaml"
+
+    def test_calls_llm_when_multiple_and_auto(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "plan.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Plan",
+                        "description": "Plan workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo p",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            (workflows_dir / "implement.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Impl",
+                        "description": "Impl workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo i",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            mock_provider = MagicMock()
+            mock_provider.execute.return_value = MagicMock(
+                exit_code=0,
+                stdout="implement.yaml",
+                stderr="",
+            )
+
+            with patch("fdsx.core.selector.get_provider", return_value=mock_provider):
+                result = resolve_workflow_for_task(
+                    task_description="Build something",
+                    workflows_dir=workflows_dir,
+                    selector_config=config,
+                    auto_workflow=True,
+                )
+
+            assert result == Path(tmpdir) / "implement.yaml"
+
+    def test_confirm_prompt_when_not_auto(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "only.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Only",
+                        "description": "Only workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo o",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            with patch("builtins.input", return_value="y"):
+                result = resolve_workflow_for_task(
+                    task_description="Do something",
+                    workflows_dir=workflows_dir,
+                    selector_config=config,
+                    auto_workflow=False,
+                )
+
+            assert result == Path(tmpdir) / "only.yaml"
+
+    def test_auto_workflow_true_never_calls_input(self):
+        """Regression (FR-6.3): auto_workflow=True must never call input() during
+        pre-computation. The engine always passes auto_workflow=True to this function
+        so the batch confirmation is the sole confirm gate.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workflows_dir = Path(tmpdir)
+            (workflows_dir / "only.yaml").write_text(
+                yaml.dump(
+                    {
+                        "name": "Only",
+                        "description": "Only workflow",
+                        "start_at": "s",
+                        "states": {
+                            "s": {
+                                "type": "task",
+                                "provider": "system",
+                                "command": "echo o",
+                                "result_path": "$.x",
+                                "end": True,
+                            }
+                        },
+                    }
+                )
+            )
+            config = WorkflowSelectorConfig(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+
+            # input() must NOT be called — if it is, the MagicMock raises on iteration
+            with patch("builtins.input", side_effect=AssertionError("input() must not be called in auto mode")):
+                result = resolve_workflow_for_task(
+                    task_description="Do something",
+                    workflows_dir=workflows_dir,
+                    selector_config=config,
+                    auto_workflow=True,
+                )
+
+            assert result == Path(tmpdir) / "only.yaml"

--- a/tests/unit/test_spinner.py
+++ b/tests/unit/test_spinner.py
@@ -1,0 +1,339 @@
+import sys
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.display.terminal import Spinner, is_interactive
+
+
+class TestIsInteractive:
+    """Tests for is_interactive function."""
+
+    def test_returns_true_when_stderr_is_tty(self):
+        """When stderr is a TTY, is_interactive returns True."""
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = True
+            result = is_interactive()
+
+        assert result is True
+
+    def test_returns_false_when_stderr_is_not_tty(self):
+        """When stderr is not a TTY (piped/redirected), is_interactive returns False."""
+        with patch("sys.stderr") as mock_stderr:
+            mock_stderr.isatty.return_value = False
+            result = is_interactive()
+
+        assert result is False
+
+
+class TestSpinnerTTYMode:
+    """Tests for Spinner in TTY mode."""
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_start_creates_daemon_thread(self, _mock):
+        """start() spawns a daemon thread in TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+
+        assert spinner._thread is not None
+        assert spinner._thread.daemon is True
+        assert spinner._running is True
+        spinner.stop()
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_start_returns_self(self, _mock):
+        """start() returns the Spinner instance itself."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        result = spinner.start()
+
+        assert result is spinner
+        spinner.stop()
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_stop_joins_thread(self, _mock):
+        """stop() joins the thread and sets _running to False."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        spinner.stop()
+
+        assert spinner._thread is None
+        assert spinner._running is False
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_update_changes_message(self, _mock):
+        """update() changes the internal message in TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        spinner.update("Updated message")
+
+        assert spinner._message == "Updated message"
+        spinner.stop()
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_double_start_no_concurrent_threads(self, _mock):
+        """Calling start() twice does not create concurrent threads."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        first_thread = spinner._thread
+        assert first_thread is not None
+
+        spinner.start()
+        second_thread = spinner._thread
+        assert second_thread is not None
+
+        assert first_thread is not second_thread
+        assert not first_thread.is_alive()
+        assert spinner._running is True
+        spinner.stop()
+        assert spinner._thread is None
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_writes_frames_to_stream(self, _mock):
+        """Spinner writes braille frame characters to the stream in TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Working", stream=buf)
+        spinner.start()
+        spinner._stop_event.wait(0.25)
+        spinner.stop()
+
+        output = buf.getvalue()
+        assert "Working" in output
+        # At least one braille character should appear
+        assert any(ch in output for ch in Spinner._FRAMES)
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_stop_with_final_message(self, _mock):
+        """stop(final_message) prints the message after clearing the line."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        spinner.stop("Done!")
+
+        output = buf.getvalue()
+        assert "Done!" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_stop_clears_line(self, _mock):
+        """stop() writes carriage-return + erase-line sequence in TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        spinner.stop()
+
+        output = buf.getvalue()
+        assert "\r\033[K" in output
+
+
+class TestSpinnerNonTTYMode:
+    """Tests for Spinner in non-TTY mode."""
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_start_prints_message_no_thread(self, _mock):
+        """start() prints message once and spawns no thread in non-TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Processing", stream=buf)
+        spinner.start()
+
+        output = buf.getvalue()
+        assert "Processing\n" in output
+        assert spinner._thread is None
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_update_prints_new_line(self, _mock):
+        """update() prints the new message as a newline in non-TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Step 1", stream=buf)
+        spinner.start()
+        spinner.update("Step 2")
+
+        output = buf.getvalue()
+        assert "Step 1\n" in output
+        assert "Step 2\n" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_stop_with_final_message(self, _mock):
+        """stop(final_message) prints the message in non-TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Processing", stream=buf)
+        spinner.start()
+        spinner.stop("Complete")
+
+        output = buf.getvalue()
+        assert "Complete\n" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_no_carriage_return(self, _mock):
+        """Spinner does not write \\r in non-TTY mode (CI/log compatible)."""
+        buf = StringIO()
+        spinner = Spinner("Running", stream=buf)
+        spinner.start()
+        spinner.update("Still running")
+        spinner.stop("Finished")
+
+        output = buf.getvalue()
+        assert "\r" not in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_only_prints_once_on_start(self, _mock):
+        """start() prints the message exactly once in non-TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("Single print", stream=buf)
+        spinner.start()
+
+        output = buf.getvalue()
+        assert output.count("Single print") == 1
+
+
+class TestSpinnerContextManager:
+    """Tests for Spinner used as a context manager."""
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_context_manager_starts_and_stops(self, _mock):
+        """Context manager starts and stops the spinner automatically."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+
+        with spinner as s:
+            assert s is spinner
+            assert s._running is True
+
+        assert spinner._running is False
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_context_manager_stops_on_exception(self, _mock):
+        """Context manager stops the spinner even when an exception is raised."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+
+        with pytest.raises(ValueError):
+            with spinner:
+                raise ValueError("test error")
+
+        assert spinner._running is False
+        assert spinner._thread is None
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_context_manager_non_tty(self, _mock):
+        """Context manager works correctly in non-TTY mode."""
+        buf = StringIO()
+        with Spinner("Loading", stream=buf) as spinner:
+            assert spinner._thread is None
+
+        output = buf.getvalue()
+        assert "Loading\n" in output
+
+
+class TestSpinnerSecurity:
+    """Tests that spinner messages are sanitized to prevent ANSI injection."""
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=True)
+    def test_ansi_escapes_sanitized_in_tty_mode(self, _mock):
+        """ANSI escape sequences in messages are stripped in TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("\x1b[31mevil\x1b[0m", stream=buf)
+        spinner.start()
+        spinner._stop_event.wait(0.15)
+        spinner.stop()
+
+        output = buf.getvalue()
+        output_sanitized = output.replace("\033[K", "")
+        assert "\x1b" not in output_sanitized
+        assert "evil" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_ansi_escapes_sanitized_in_non_tty_mode(self, _mock):
+        """ANSI escape sequences in messages are stripped in non-TTY mode."""
+        buf = StringIO()
+        spinner = Spinner("\x1b[31mevil\x1b[0m", stream=buf)
+        spinner.start()
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "evil" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_ansi_in_final_message_sanitized(self, _mock):
+        """ANSI escape sequences in stop(final_message) are stripped."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        spinner.stop("\x1b[32mDone\x1b[0m")
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "Done" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_ansi_in_update_sanitized(self, _mock):
+        """ANSI escape sequences in update() messages are stripped."""
+        buf = StringIO()
+        spinner = Spinner("Loading", stream=buf)
+        spinner.start()
+        spinner.update("\x1b[31mstep 2\x1b[0m")
+
+        output = buf.getvalue()
+        assert "\x1b" not in output
+        assert "step 2" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_newline_in_message_sanitized(self, _mock):
+        """Newlines in messages are replaced to prevent log injection."""
+        buf = StringIO()
+        spinner = Spinner("syncing\n[12:00:00] ✓ deploy complete", stream=buf)
+        spinner.start()
+
+        output = buf.getvalue()
+        lines = output.strip().split("\n")
+        assert len(lines) == 1
+        assert "syncing" in output
+        assert "deploy complete" in output
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_newline_in_update_sanitized(self, _mock):
+        """Newlines in update() messages are replaced."""
+        buf = StringIO()
+        spinner = Spinner("start", stream=buf)
+        spinner.start()
+        spinner.update("line1\nline2")
+
+        output = buf.getvalue()
+        update_lines = [line for line in output.strip().split("\n") if "line1" in line]
+        assert len(update_lines) == 1
+        assert "line2" in update_lines[0]
+
+
+class TestSpinnerEdgeCases:
+    """Tests for Spinner edge cases."""
+
+    def test_defaults_to_stderr(self):
+        """Spinner uses sys.stderr by default when no stream provided."""
+        with patch("fdsx.display.terminal.is_interactive", return_value=False):
+            spinner = Spinner()
+        assert spinner._stream is sys.stderr
+
+    def test_custom_stream(self):
+        """Spinner uses provided custom stream."""
+        buf = StringIO()
+        with patch("fdsx.display.terminal.is_interactive", return_value=False):
+            spinner = Spinner(stream=buf)
+        assert spinner._stream is buf
+
+    def test_frame_sequence_valid(self):
+        """Spinner frames are valid Unicode braille characters."""
+        assert len(Spinner._FRAMES) > 0
+        for frame in Spinner._FRAMES:
+            assert len(frame) == 1
+            assert ord(frame) >= 0x2800
+
+    @patch("fdsx.display.terminal.is_interactive", return_value=False)
+    def test_default_message_empty(self, _mock):
+        """Spinner initializes with an empty message by default."""
+        buf = StringIO()
+        spinner = Spinner(stream=buf)
+        assert spinner._message == ""

--- a/tests/unit/test_stream_logger.py
+++ b/tests/unit/test_stream_logger.py
@@ -198,6 +198,60 @@ class TestStreamLoggerFileWriting:
         logger.close()  # Should not raise
 
 
+class TestStreamLoggerQuietMode:
+    """Tests for StreamLogger quiet mode (T015, FR-5.1, FR-5.4)."""
+
+    def test_quiet_false_is_default(self, capsys):
+        """quiet=False is the default: stderr output is produced."""
+        logger = StreamLogger("State")
+        assert logger.quiet is False
+        logger.on_stdout("hello")
+        captured = capsys.readouterr()
+        assert "[State] hello" in captured.err
+
+    def test_quiet_true_suppresses_stdout_stderr_print(self, capsys):
+        """quiet=True suppresses print to stderr for on_stdout."""
+        logger = StreamLogger("State", quiet=True)
+        logger.on_stdout("hello")
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_quiet_true_suppresses_on_stderr_print(self, capsys):
+        """quiet=True suppresses print to stderr for on_stderr."""
+        logger = StreamLogger("State", quiet=True)
+        logger.on_stderr("error line")
+        captured = capsys.readouterr()
+        assert captured.err == ""
+
+    def test_quiet_true_log_file_content_matches_non_quiet(self, tmp_path):
+        """quiet=True writes identical log file content as quiet=False."""
+        log_dir_normal = tmp_path / "normal"
+        log_dir_quiet = tmp_path / "quiet"
+
+        logger_normal = StreamLogger("State", log_dir_normal, quiet=False)
+        logger_normal.on_stdout("line one")
+        logger_normal.on_stderr("line two")
+        logger_normal.close()
+
+        logger_quiet = StreamLogger("State", log_dir_quiet, quiet=True)
+        logger_quiet.on_stdout("line one")
+        logger_quiet.on_stderr("line two")
+        logger_quiet.close()
+
+        normal_content = (log_dir_normal / f"State{LOG_FILE_SUFFIX}").read_text(encoding="utf-8")
+        quiet_content = (log_dir_quiet / f"State{LOG_FILE_SUFFIX}").read_text(encoding="utf-8")
+        assert normal_content == quiet_content
+
+    def test_quiet_true_log_file_still_created(self, tmp_path):
+        """quiet=True still creates the log file on first write (FR-5.4)."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("State", log_dir, quiet=True)
+        logger.on_stdout("trigger")
+        logger.close()
+
+        assert (log_dir / f"State{LOG_FILE_SUFFIX}").exists()
+
+
 class TestStreamLoggerThreadSafety:
     """Tests for thread-safe behaviour."""
 

--- a/tests/unit/test_stream_logger.py
+++ b/tests/unit/test_stream_logger.py
@@ -11,6 +11,7 @@ Tests verify:
 - Thread-safe writes (multiple threads can call on_stdout/on_stderr)
 """
 
+import sys
 import threading
 from io import StringIO
 from pathlib import Path
@@ -79,6 +80,34 @@ class TestStreamLoggerTerminalOutput:
         captured = capsys.readouterr()
         assert "[State] line" in captured.err
         assert "[State] err line" in captured.err
+
+    def test_on_stdout_flushes_stderr(self):
+        """on_stdout calls sys.stderr.flush() after print (T006)."""
+        logger = StreamLogger("FlushState")
+        with patch.object(sys.stderr, "flush") as mock_flush:
+            logger.on_stdout("hello")
+        mock_flush.assert_called_once()
+
+    def test_on_stderr_flushes_stderr(self):
+        """on_stderr calls sys.stderr.flush() after print (T007)."""
+        logger = StreamLogger("FlushState")
+        with patch.object(sys.stderr, "flush") as mock_flush:
+            logger.on_stderr("error")
+        mock_flush.assert_called_once()
+
+    def test_on_stdout_no_flush_when_quiet(self):
+        """on_stdout does NOT flush when quiet=True (no print, no flush)."""
+        logger = StreamLogger("FlushState", quiet=True)
+        with patch.object(sys.stderr, "flush") as mock_flush:
+            logger.on_stdout("hello")
+        mock_flush.assert_not_called()
+
+    def test_on_stderr_no_flush_when_quiet(self):
+        """on_stderr does NOT flush when quiet=True (no print, no flush)."""
+        logger = StreamLogger("FlushState", quiet=True)
+        with patch.object(sys.stderr, "flush") as mock_flush:
+            logger.on_stderr("error")
+        mock_flush.assert_not_called()
 
 
 class TestStreamLoggerFileWriting:

--- a/tests/unit/test_stream_logger.py
+++ b/tests/unit/test_stream_logger.py
@@ -1,0 +1,248 @@
+"""Unit tests for StreamLogger (T010).
+
+Tests verify:
+- on_stdout and on_stderr prefix lines with [state_name] and print to stderr
+- Lines are written to the per-state log file
+- Log file is created lazily (only when first line arrives)
+- No log file created when no output is produced (FR-2.6)
+- ANSI escape codes pass through without sanitization (FR-2.7)
+- close() flushes and closes the file handle
+- log_dir=None suppresses file writes but terminal output still works
+- Thread-safe writes (multiple threads can call on_stdout/on_stderr)
+"""
+
+import threading
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.logging.stream_logger import LOG_FILE_SUFFIX, StreamLogger
+
+
+class TestStreamLoggerTerminalOutput:
+    """Tests for terminal (stderr) streaming behaviour."""
+
+    def test_on_stdout_prefixes_line(self, capsys):
+        """on_stdout prints '[state_name] line' to stderr."""
+        logger = StreamLogger("MyState")
+        logger.on_stdout("hello world")
+        captured = capsys.readouterr()
+        assert captured.err == "[MyState] hello world\n"
+
+    def test_on_stderr_prefixes_line(self, capsys):
+        """on_stderr prints '[state_name] line' to stderr."""
+        logger = StreamLogger("SomeState")
+        logger.on_stderr("error line")
+        captured = capsys.readouterr()
+        assert captured.err == "[SomeState] error line\n"
+
+    def test_multiple_lines_all_prefixed(self, capsys):
+        """Each line gets its own [state_name] prefix."""
+        logger = StreamLogger("Planner")
+        logger.on_stdout("line one")
+        logger.on_stdout("line two")
+        captured = capsys.readouterr()
+        lines = captured.err.splitlines()
+        assert lines == ["[Planner] line one", "[Planner] line two"]
+
+    def test_ansi_passthrough_stdout(self, capsys):
+        """ANSI escape codes pass through as-is (FR-2.7)."""
+        ansi_line = "\x1b[32mgreen text\x1b[0m"
+        logger = StreamLogger("ColorState")
+        logger.on_stdout(ansi_line)
+        captured = capsys.readouterr()
+        assert ansi_line in captured.err
+
+    def test_ansi_passthrough_stderr(self, capsys):
+        """ANSI escape codes in stderr lines pass through as-is (FR-2.7)."""
+        ansi_line = "\x1b[31merror in red\x1b[0m"
+        logger = StreamLogger("ColorState")
+        logger.on_stderr(ansi_line)
+        captured = capsys.readouterr()
+        assert ansi_line in captured.err
+
+    def test_empty_line_still_prefixed(self, capsys):
+        """Empty lines are still printed with the prefix."""
+        logger = StreamLogger("State")
+        logger.on_stdout("")
+        captured = capsys.readouterr()
+        assert captured.err == "[State] \n"
+
+    def test_no_log_dir_does_not_raise(self, capsys):
+        """StreamLogger with log_dir=None works without errors."""
+        logger = StreamLogger("State", log_dir=None)
+        logger.on_stdout("line")
+        logger.on_stderr("err line")
+        logger.close()
+        captured = capsys.readouterr()
+        assert "[State] line" in captured.err
+        assert "[State] err line" in captured.err
+
+
+class TestStreamLoggerFileWriting:
+    """Tests for per-state log file writing."""
+
+    def test_log_file_created_on_first_stdout(self, tmp_path):
+        """Log file is created lazily on first stdout line (FR-2.6)."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("TestState", log_dir)
+
+        # File should not exist before first write
+        log_path = log_dir / f"TestState{LOG_FILE_SUFFIX}"
+        assert not log_path.exists()
+
+        logger.on_stdout("first line")
+        logger.close()
+
+        assert log_path.exists()
+
+    def test_log_file_created_on_first_stderr(self, tmp_path):
+        """Log file is created lazily on first stderr line (FR-2.6)."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("TestState", log_dir)
+
+        log_path = log_dir / f"TestState{LOG_FILE_SUFFIX}"
+        assert not log_path.exists()
+
+        logger.on_stderr("error line")
+        logger.close()
+
+        assert log_path.exists()
+
+    def test_no_log_file_when_no_output(self, tmp_path):
+        """No log file is created when no output is produced (FR-2.6)."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("EmptyState", log_dir)
+        logger.close()
+
+        log_path = log_dir / f"EmptyState{LOG_FILE_SUFFIX}"
+        assert not log_path.exists()
+
+    def test_log_file_contains_stdout_lines(self, tmp_path):
+        """Stdout lines are written verbatim to the log file (no prefix)."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("Writer", log_dir)
+        logger.on_stdout("line one")
+        logger.on_stdout("line two")
+        logger.close()
+
+        log_path = log_dir / f"Writer{LOG_FILE_SUFFIX}"
+        content = log_path.read_text(encoding="utf-8")
+        assert "line one\n" in content
+        assert "line two\n" in content
+
+    def test_log_file_contains_stderr_lines(self, tmp_path):
+        """Stderr lines are written verbatim to the log file."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("Writer", log_dir)
+        logger.on_stderr("stderr line")
+        logger.close()
+
+        log_path = log_dir / f"Writer{LOG_FILE_SUFFIX}"
+        content = log_path.read_text(encoding="utf-8")
+        assert "stderr line\n" in content
+
+    def test_log_file_has_no_prefix_in_content(self, tmp_path):
+        """Log file content does not include the [state_name] prefix."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("PrefixCheck", log_dir)
+        logger.on_stdout("raw line")
+        logger.close()
+
+        log_path = log_dir / f"PrefixCheck{LOG_FILE_SUFFIX}"
+        content = log_path.read_text(encoding="utf-8")
+        assert "[PrefixCheck]" not in content
+        assert "raw line\n" in content
+
+    def test_ansi_codes_written_to_log_file(self, tmp_path):
+        """ANSI codes pass through to log file as-is (FR-2.7)."""
+        log_dir = tmp_path / "logs"
+        ansi_line = "\x1b[32mcolored\x1b[0m"
+        logger = StreamLogger("AnsiState", log_dir)
+        logger.on_stdout(ansi_line)
+        logger.close()
+
+        log_path = log_dir / f"AnsiState{LOG_FILE_SUFFIX}"
+        content = log_path.read_text(encoding="utf-8")
+        assert ansi_line in content
+
+    def test_log_dir_created_automatically(self, tmp_path):
+        """log_dir is created automatically if it does not exist."""
+        log_dir = tmp_path / "nested" / "logs"
+        assert not log_dir.exists()
+
+        logger = StreamLogger("AutoDir", log_dir)
+        logger.on_stdout("trigger creation")
+        logger.close()
+
+        assert log_dir.exists()
+        assert (log_dir / f"AutoDir{LOG_FILE_SUFFIX}").exists()
+
+    def test_log_file_stem_matches_state_name(self, tmp_path):
+        """Log file stem matches exactly the state_name."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("my_state", log_dir)
+        logger.on_stdout("x")
+        logger.close()
+
+        assert (log_dir / f"my_state{LOG_FILE_SUFFIX}").exists()
+
+    def test_close_idempotent(self, tmp_path):
+        """Calling close() multiple times does not raise."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("State", log_dir)
+        logger.on_stdout("line")
+        logger.close()
+        logger.close()  # Should not raise
+
+
+class TestStreamLoggerThreadSafety:
+    """Tests for thread-safe behaviour."""
+
+    def test_concurrent_writes_from_same_logger(self, tmp_path):
+        """Multiple threads writing through the same StreamLogger instance are safe."""
+        log_dir = tmp_path / "logs"
+        logger = StreamLogger("ThreadedState", log_dir)
+
+        errors: list[Exception] = []
+
+        def write_lines(n: int) -> None:
+            try:
+                for i in range(n):
+                    logger.on_stdout(f"thread line {i}")
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=write_lines, args=(20,)) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        logger.close()
+
+        assert not errors, f"Errors in threads: {errors}"
+        log_path = log_dir / f"ThreadedState{LOG_FILE_SUFFIX}"
+        content = log_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        # 5 threads × 20 lines = 100 total lines
+        assert len(lines) == 100
+
+    def test_parallel_branches_share_log_file(self, tmp_path):
+        """Two StreamLogger instances with the same state_name append to the same file."""
+        log_dir = tmp_path / "logs"
+        logger_a = StreamLogger("parallel_state", log_dir)
+        logger_b = StreamLogger("parallel_state", log_dir)
+
+        logger_a.on_stdout("branch_a line")
+        logger_b.on_stdout("branch_b line")
+
+        logger_a.close()
+        logger_b.close()
+
+        log_path = log_dir / f"parallel_state{LOG_FILE_SUFFIX}"
+        content = log_path.read_text(encoding="utf-8")
+        assert "branch_a line" in content
+        assert "branch_b line" in content

--- a/tests/unit/test_subprocess_realtime_streaming.py
+++ b/tests/unit/test_subprocess_realtime_streaming.py
@@ -1,0 +1,105 @@
+"""Regression tests for real-time streaming delivery (T001, T002).
+
+These tests verify that stdout/stderr lines from _run_subprocess are delivered
+to callbacks BEFORE the subprocess exits — i.e., in real-time as lines arrive.
+
+These tests are written in RED (failing) state first to confirm the bug:
+`for line in process.stdout:` and `for raw_line in process.stderr:` use
+Python's iterator with ~8KB read-ahead buffering, causing all lines to be
+delivered at once near process exit instead of incrementally.
+
+T001: stdout real-time delivery
+T002: stderr real-time delivery
+"""
+
+import time
+
+from fdsx.providers.base import _run_subprocess
+
+# Subprocess command that prints 3 lines with 0.3s sleep between each.
+# flush=True is critical: ensures the child process flushes to the pipe
+# immediately, isolating the Python-side iterator buffering as the sole cause.
+_STDOUT_CMD = (
+    "python3 -c \""
+    "import sys, time; "
+    "[print(f'line{i}', flush=True) or time.sleep(0.3) for i in range(3)]"
+    "\""
+)
+
+_STDERR_CMD = (
+    "python3 -c \""
+    "import sys, time; "
+    "[print(f'line{i}', file=sys.stderr, flush=True) or time.sleep(0.3) for i in range(3)]"
+    "\""
+)
+
+# A callback firing this many seconds before process completion is evidence of
+# real-time delivery (the subprocess sleeps 0.3s between lines, so total
+# runtime ≈ 0.9s; the first callback should arrive ~0.6s before completion).
+_MIN_LEAD_SECONDS = 0.2
+
+
+class TestRealtimeStreamingDelivery:
+    """Tests for real-time line delivery via output_callback / stderr_callback."""
+
+    def test_stdout_lines_delivered_before_process_exits(self):
+        """stdout callback receives lines incrementally BEFORE the process exits.
+
+        The subprocess prints line0, sleeps 0.3s, prints line1, sleeps 0.3s,
+        prints line2, then exits. With real-time streaming, at least one
+        callback fires >0.2s before _run_subprocess returns.
+
+        With the current buffered iterator the assertion FAILS (RED) because all
+        callbacks fire within milliseconds of each other at process exit.
+        """
+        timestamps: list[float] = []
+
+        def _capture(line: str) -> None:
+            timestamps.append(time.time())
+
+        _run_subprocess(
+            args=[_STDOUT_CMD],
+            shell=True,
+            output_callback=_capture,
+        )
+        completion_time = time.time()
+
+        assert len(timestamps) == 3, f"Expected 3 callbacks, got {len(timestamps)}"
+
+        earliest = min(timestamps)
+        lead = completion_time - earliest
+        assert lead > _MIN_LEAD_SECONDS, (
+            f"First stdout callback fired only {lead:.3f}s before completion "
+            f"(need >{_MIN_LEAD_SECONDS}s). Lines were buffered instead of streamed."
+        )
+
+    def test_stderr_lines_delivered_before_process_exits(self):
+        """stderr callback receives lines incrementally BEFORE the process exits.
+
+        The subprocess writes line0 to stderr, sleeps 0.3s, writes line1,
+        sleeps 0.3s, writes line2, then exits. With real-time streaming, at
+        least one callback fires >0.2s before _run_subprocess returns.
+
+        With the current buffered iterator the assertion FAILS (RED) because all
+        callbacks fire within milliseconds of each other at process exit.
+        """
+        timestamps: list[float] = []
+
+        def _capture(line: str) -> None:
+            timestamps.append(time.time())
+
+        _run_subprocess(
+            args=[_STDERR_CMD],
+            shell=True,
+            stderr_callback=_capture,
+        )
+        completion_time = time.time()
+
+        assert len(timestamps) == 3, f"Expected 3 callbacks, got {len(timestamps)}"
+
+        earliest = min(timestamps)
+        lead = completion_time - earliest
+        assert lead > _MIN_LEAD_SECONDS, (
+            f"First stderr callback fired only {lead:.3f}s before completion "
+            f"(need >{_MIN_LEAD_SECONDS}s). Lines were buffered instead of streamed."
+        )

--- a/tests/unit/test_subprocess_stdin.py
+++ b/tests/unit/test_subprocess_stdin.py
@@ -1,0 +1,107 @@
+"""Unit tests for _run_subprocess stdin fallback (T001).
+
+Tests verify that commands >= 128KB are piped via stdin to `sh` instead of
+passed as argv to `sh -c`, preventing ARG_MAX overflow errors.
+"""
+
+from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, _run_subprocess
+
+
+class TestSubprocessStdinFallback:
+    """Tests for ARG_MAX stdin fallback in _run_subprocess."""
+
+    def test_small_command_uses_sh_c(self):
+        """Commands well below 128KB use the normal sh -c path and execute correctly."""
+        cmd = "echo hello"
+        result = _run_subprocess(args=[cmd], shell=True)
+
+        assert result.exit_code == 0
+        assert result.stdout == "hello"
+
+    def test_large_command_uses_stdin_piping(self):
+        """Commands >= 128KB are piped via stdin to sh and execute correctly."""
+        # Build a command that exceeds ARG_MAX_STDIN_THRESHOLD bytes.
+        # Use a variable assignment padding + echo so sh executes it correctly.
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        cmd = f"_pad={padding}; echo large_ok"
+
+        assert len(cmd.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
+
+        result = _run_subprocess(args=[cmd], shell=True)
+
+        assert result.exit_code == 0
+        assert result.stdout == "large_ok"
+
+    def test_stdin_fallback_produces_identical_output(self):
+        """Small and large command paths produce identical stdout/stderr/exit_code for equivalent logic."""
+        # Small version
+        small_cmd = "echo same_output"
+        small_result = _run_subprocess(args=[small_cmd], shell=True)
+
+        # Large version: same logic, padded to exceed threshold
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        large_cmd = f"_pad={padding}; echo same_output"
+        large_result = _run_subprocess(args=[large_cmd], shell=True)
+
+        assert small_result.exit_code == large_result.exit_code
+        assert small_result.stdout == large_result.stdout
+
+    def test_stdin_fallback_preserves_shell_features(self):
+        """Pipes, variable substitution, and subshells work via stdin fallback."""
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        # Test pipes
+        cmd_pipe = f"_pad={padding}; echo 'hello world' | tr ' ' '_'"
+        result_pipe = _run_subprocess(args=[cmd_pipe], shell=True)
+        assert result_pipe.exit_code == 0
+        assert result_pipe.stdout == "hello_world"
+
+        # Test variable substitution
+        cmd_var = f"_pad={padding}; MY_VAR=42; echo $MY_VAR"
+        result_var = _run_subprocess(args=[cmd_var], shell=True)
+        assert result_var.exit_code == 0
+        assert result_var.stdout == "42"
+
+        # Test subshell
+        cmd_sub = f"_pad={padding}; echo $(echo subshell_works)"
+        result_sub = _run_subprocess(args=[cmd_sub], shell=True)
+        assert result_sub.exit_code == 0
+        assert result_sub.stdout == "subshell_works"
+
+    def test_boundary_exactly_128kb(self):
+        """Command of exactly 131,072 bytes triggers stdin fallback."""
+        # Construct a command that is exactly ARG_MAX_STDIN_THRESHOLD bytes.
+        # Format: "_pad=<padding>; echo boundary_ok"
+        prefix = "_pad="
+        suffix = "; echo boundary_ok"
+        padding_len = ARG_MAX_STDIN_THRESHOLD - len(prefix.encode("utf-8")) - len(suffix.encode("utf-8"))
+        cmd = prefix + ("x" * padding_len) + suffix
+
+        assert len(cmd.encode("utf-8")) == ARG_MAX_STDIN_THRESHOLD
+
+        result = _run_subprocess(args=[cmd], shell=True)
+
+        assert result.exit_code == 0
+        assert result.stdout == "boundary_ok"
+
+    def test_command_just_below_threshold_uses_sh_c(self):
+        """Command of 131,071 bytes (threshold - 1) uses sh -c, not stdin."""
+        # Construct a command that is exactly one byte below threshold.
+        prefix = "_pad="
+        suffix = "; echo below_ok"
+        padding_len = ARG_MAX_STDIN_THRESHOLD - 1 - len(prefix.encode("utf-8")) - len(suffix.encode("utf-8"))
+        cmd = prefix + ("x" * padding_len) + suffix
+
+        assert len(cmd.encode("utf-8")) == ARG_MAX_STDIN_THRESHOLD - 1
+
+        result = _run_subprocess(args=[cmd], shell=True)
+
+        assert result.exit_code == 0
+        assert result.stdout == "below_ok"
+
+    def test_exit_code_preserved_via_stdin_fallback(self):
+        """Non-zero exit codes are correctly preserved when using stdin fallback."""
+        padding = "x" * ARG_MAX_STDIN_THRESHOLD
+        cmd = f"_pad={padding}; exit 42"
+        result = _run_subprocess(args=[cmd], shell=True)
+
+        assert result.exit_code == 42

--- a/tests/unit/test_subprocess_stdin.py
+++ b/tests/unit/test_subprocess_stdin.py
@@ -1,7 +1,9 @@
-"""Unit tests for _run_subprocess stdin fallback (T001).
+"""Unit tests for _run_subprocess stdin fallback and stderr_callback (T001, T008).
 
 Tests verify that commands >= 128KB are piped via stdin to `sh` instead of
 passed as argv to `sh -c`, preventing ARG_MAX overflow errors.
+
+T008 tests verify that stderr lines are streamed line-by-line via stderr_callback.
 """
 
 from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, _run_subprocess
@@ -105,3 +107,91 @@ class TestSubprocessStdinFallback:
         result = _run_subprocess(args=[cmd], shell=True)
 
         assert result.exit_code == 42
+
+
+class TestStderrCallback:
+    """Tests for stderr_callback line-by-line streaming (T008)."""
+
+    def test_stderr_callback_receives_lines(self):
+        """stderr_callback is called once per stderr line."""
+        received: list[str] = []
+
+        result = _run_subprocess(
+            args=["echo errline >&2"],
+            shell=True,
+            stderr_callback=received.append,
+        )
+
+        assert result.exit_code == 0
+        assert "errline" in received
+
+    def test_stderr_callback_multiple_lines(self):
+        """Each stderr line triggers a separate callback invocation."""
+        received: list[str] = []
+
+        result = _run_subprocess(
+            args=["echo line1 >&2; echo line2 >&2"],
+            shell=True,
+            stderr_callback=received.append,
+        )
+
+        assert result.exit_code == 0
+        assert "line1" in received
+        assert "line2" in received
+
+    def test_stderr_still_in_result_with_callback(self):
+        """ProviderResult.stderr still contains full stderr even when callback is used."""
+        received: list[str] = []
+
+        result = _run_subprocess(
+            args=["echo captured >&2"],
+            shell=True,
+            stderr_callback=received.append,
+        )
+
+        assert result.exit_code == 0
+        assert "captured" in result.stderr
+        assert "captured" in received
+
+    def test_stderr_callback_none_does_not_raise(self):
+        """Passing stderr_callback=None (default) works without errors."""
+        result = _run_subprocess(
+            args=["echo no_callback >&2"],
+            shell=True,
+            stderr_callback=None,
+        )
+
+        assert result.exit_code == 0
+        assert "no_callback" in result.stderr
+
+    def test_stderr_lines_have_no_trailing_newline(self):
+        """Lines delivered to stderr_callback do not include trailing newline."""
+        received: list[str] = []
+
+        _run_subprocess(
+            args=["printf 'line_a\\nline_b\\n' >&2"],
+            shell=True,
+            stderr_callback=received.append,
+        )
+
+        for line in received:
+            assert not line.endswith("\n"), f"Line has trailing newline: {line!r}"
+
+    def test_stdout_and_stderr_callbacks_independent(self):
+        """stdout and stderr callbacks are called independently."""
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+
+        result = _run_subprocess(
+            args=["echo stdout_line; echo stderr_line >&2"],
+            shell=True,
+            output_callback=stdout_lines.append,
+            stderr_callback=stderr_lines.append,
+        )
+
+        assert result.exit_code == 0
+        assert "stdout_line" in stdout_lines
+        assert "stderr_line" in stderr_lines
+        # Lines should not cross-contaminate
+        assert not any("stderr_line" in l for l in stdout_lines)
+        assert not any("stdout_line" in l for l in stderr_lines)

--- a/tests/unit/test_task_model.py
+++ b/tests/unit/test_task_model.py
@@ -382,6 +382,30 @@ class TestRoundTrip:
             assert loaded.entries[0].workflow == "plan.yaml"
 
 
+class TestLoadTaskFileSymlinkProtection:
+    """SEC: TOCTOU — load_task_file() must refuse symlinks at the read call site."""
+
+    def test_load_rejects_symlinked_task_file(self):
+        """SEC-TOCTOU-1: load_task_file() must raise ValueError when target is a symlink.
+
+        This covers the TOCTOU race window: even if a pre-check in the caller passed,
+        a symlink swapped in before open() must be rejected by O_NOFOLLOW.
+        """
+        if not hasattr(__import__("os"), "O_NOFOLLOW"):
+            pytest.skip("O_NOFOLLOW not available on this platform")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_file = Path(tmpdir) / "real.yaml"
+            real_file.write_text(
+                yaml.dump({"description": "Real task", "status": "pending"})
+            )
+            sym_file = Path(tmpdir) / "task.yaml"
+            sym_file.symlink_to(real_file)
+
+            with pytest.raises(ValueError, match="symlink"):
+                load_task_file(sym_file)
+
+
 class TestSaveTaskFileSecurity:
     def test_symlinked_ancestor_raises_before_mkdir(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_task_model.py
+++ b/tests/unit/test_task_model.py
@@ -1,0 +1,399 @@
+"""Tests for task file models."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
+
+
+class TestTaskEntryDefaults:
+    def test_default_status_pending(self):
+        entry = TaskEntry(description="Do the thing")
+        assert entry.status == "pending"
+
+    def test_all_statuses_allowed(self):
+        for status in ("pending", "running", "completed", "failed"):
+            entry = TaskEntry(description="test", status=status)
+            assert entry.status == status
+
+    def test_invalid_status_rejected(self):
+        with pytest.raises(ValidationError):
+            TaskEntry(description="test", status="invalid")
+
+    def test_thread_id_and_error_optional(self):
+        entry = TaskEntry(description="test", thread_id="abc123", error="boom")
+        assert entry.thread_id == "abc123"
+        assert entry.error == "boom"
+
+    def test_workflow_optional(self):
+        entry = TaskEntry(description="test", workflow="plan.yaml")
+        assert entry.workflow == "plan.yaml"
+
+    def test_workflow_default_none(self):
+        entry = TaskEntry(description="test")
+        assert entry.workflow is None
+
+    def test_workflow_path_traversal_rejected(self):
+        with pytest.raises(ValidationError):
+            TaskEntry(description="test", workflow="../../evil.yaml")
+
+    def test_workflow_absolute_path_rejected(self):
+        with pytest.raises(ValidationError):
+            TaskEntry(description="test", workflow="/etc/evil.yaml")
+
+    def test_workflow_valid_filename_accepted(self):
+        entry = TaskEntry(description="test", workflow="plan-review.yaml")
+        assert entry.workflow == "plan-review.yaml"
+
+    def test_workflow_backslash_rejected(self):
+        """SEC-R2-3: explicit backslash must be rejected on all platforms."""
+        with pytest.raises(ValidationError):
+            TaskEntry(description="test", workflow="subdir\\evil.yaml")
+
+    def test_workflow_double_dot_filename_accepted(self):
+        """CQ-R3-2: plan..review.yaml is a valid filename, not path traversal."""
+        entry = TaskEntry(description="test", workflow="plan..review.yaml")
+        assert entry.workflow == "plan..review.yaml"
+
+    def test_workflow_bare_dotdot_rejected(self):
+        """CQ-R4-1: bare '..' must be explicitly rejected as a special path component."""
+        with pytest.raises(ValidationError):
+            TaskEntry(description="test", workflow="..")
+
+    def test_workflow_bare_dot_rejected(self):
+        """CQ-R4-1: bare '.' must also be explicitly rejected."""
+        with pytest.raises(ValidationError):
+            TaskEntry(description="test", workflow=".")
+
+
+class TestTaskFileSingleEntry:
+    def test_flat_format_parsed(self):
+        tf = TaskFile(entries=[TaskEntry(description="Fix the bug", status="pending")])
+        assert len(tf.entries) == 1
+        assert tf.entries[0].description == "Fix the bug"
+
+    def test_flat_format_round_trip(self):
+        entry = TaskEntry(description="Fix the bug", status="pending")
+        tf = TaskFile(entries=[entry])
+        data = tf.model_dump()
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["description"] == "Fix the bug"
+        assert data["entries"][0]["status"] == "pending"
+
+
+class TestTaskFileMultiEntry:
+    def test_multiple_entries(self):
+        entries = [
+            TaskEntry(description="Task 1"),
+            TaskEntry(description="Task 2"),
+        ]
+        tf = TaskFile(entries=entries)
+        assert len(tf.entries) == 2
+
+    def test_multi_entry_format_round_trip(self):
+        entries = [TaskEntry(description="Task 1"), TaskEntry(description="Task 2")]
+        tf = TaskFile(entries=entries)
+        data = tf.model_dump()
+        assert len(data["entries"]) == 2
+
+
+class TestLoadTaskFileFlat:
+    def test_loads_flat_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(
+                yaml.dump({"description": "Fix login bug", "status": "pending"})
+            )
+
+            tf = load_task_file(path)
+            assert len(tf.entries) == 1
+            assert tf.entries[0].description == "Fix login bug"
+            assert tf.entries[0].status == "pending"
+
+    def test_loads_flat_yaml_default_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(yaml.dump({"description": "Fix login bug"}))
+
+            tf = load_task_file(path)
+            assert tf.entries[0].status == "pending"
+
+
+class TestLoadTaskFileList:
+    def test_loads_list_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(
+                yaml.dump(
+                    {
+                        "tasks": [
+                            {"description": "Fix login bug", "status": "pending"},
+                            {"description": "Write tests", "status": "completed"},
+                        ]
+                    }
+                )
+            )
+
+            tf = load_task_file(path)
+            assert len(tf.entries) == 2
+            assert tf.entries[0].description == "Fix login bug"
+            assert tf.entries[1].description == "Write tests"
+            assert tf.entries[1].status == "completed"
+
+    def test_loads_list_yaml_default_status(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(yaml.dump({"tasks": [{"description": "Fix login bug"}]}))
+
+            tf = load_task_file(path)
+            assert tf.entries[0].status == "pending"
+
+
+class TestLoadTaskFileRawListRejected:
+    def test_raw_list_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(yaml.dump([{"description": "Task 1"}]))
+            with pytest.raises(ValueError, match="expected a YAML mapping"):
+                load_task_file(path)
+
+
+class TestLoadTaskFileEdgeCases:
+    def test_empty_file_returns_empty(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "empty.yaml"
+            path.write_text("")
+
+            tf = load_task_file(path)
+            assert len(tf.entries) == 0
+
+    def test_file_not_found_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_task_file(Path("/nonexistent/task.yaml"))
+
+    def test_invalid_yaml_raises_value_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "bad.yaml"
+            path.write_text(": :\n  - [invalid yaml {{")
+            with pytest.raises(ValueError, match="Invalid YAML"):
+                load_task_file(path)
+
+    def test_tasks_key_not_list_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(yaml.dump({"tasks": "oops"}))
+            with pytest.raises(ValueError, match="must be a list"):
+                load_task_file(path)
+
+    def test_tasks_entry_not_mapping_raises(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(yaml.dump({"tasks": ["just a string"]}))
+            with pytest.raises(ValueError, match="must be a mapping"):
+                load_task_file(path)
+
+    def test_flat_missing_description_raises_value_error(self):
+        """CQ-R2-2: Pydantic ValidationError must be wrapped as ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(yaml.dump({"status": "pending"}))
+            with pytest.raises(ValueError, match="Invalid task entry in"):
+                load_task_file(path)
+
+    def test_list_invalid_entry_raises_value_error(self):
+        """CQ-R2-2: ValidationError in list entries must be wrapped as ValueError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(yaml.dump({"tasks": [{"status": "pending"}]}))
+            with pytest.raises(ValueError, match="Invalid task entry 0 in"):
+                load_task_file(path)
+
+
+class TestSaveTaskFilePermissions:
+    def test_save_sets_file_mode_0o600(self):
+        """SEC-R2-1: saved file must have mode 0o600."""
+        import stat
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            tf = TaskFile(entries=[TaskEntry(description="Secure task")])
+            save_task_file(path, tf)
+            mode = stat.S_IMODE(path.stat().st_mode)
+            assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_save_sets_dir_mode_0o700(self):
+        """SEC-R2-1: parent directory must be tightened to 0o700."""
+        import stat
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            subdir = Path(tmpdir) / "subdir"
+            subdir.mkdir(mode=0o755)
+            path = subdir / "task.yaml"
+            tf = TaskFile(entries=[TaskEntry(description="Secure task")])
+            save_task_file(path, tf)
+            mode = stat.S_IMODE(subdir.stat().st_mode)
+            assert mode == 0o700, f"Expected 0o700, got {oct(mode)}"
+
+
+class TestSaveTaskFileSymlinkProtection:
+    def test_rejects_symlinked_parent(self):
+        """SEC-R4-1: write to path under a symlinked parent dir must raise."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_dir = Path(tmpdir) / "real"
+            real_dir.mkdir()
+            sym_dir = Path(tmpdir) / "sym"
+            sym_dir.symlink_to(real_dir)
+            path = sym_dir / "task.yaml"
+            tf = TaskFile(entries=[TaskEntry(description="test")])
+            with pytest.raises(ValueError, match="ancestor is a symlink"):
+                save_task_file(path, tf)
+
+    def test_rejects_symlinked_ancestor(self):
+        """SEC-R4-1: ancestor symlink (not just immediate parent) must be rejected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_dir = Path(tmpdir) / "real"
+            real_dir.mkdir()
+            tasks_dir = real_dir / "tasks"
+            tasks_dir.mkdir()
+            sym_ancestor = Path(tmpdir) / "project" / ".fdsx"
+            sym_ancestor.parent.mkdir()
+            sym_ancestor.symlink_to(real_dir)
+            path = sym_ancestor / "tasks" / "task.yaml"
+            tf = TaskFile(entries=[TaskEntry(description="test")])
+            with pytest.raises(ValueError, match="ancestor is a symlink"):
+                save_task_file(path, tf)
+
+    def test_rejects_symlinked_file(self):
+        """SEC-R3-1: write to a symlinked file path must raise."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            real_file = Path(tmpdir) / "real.yaml"
+            real_file.write_text("placeholder")
+            sym_file = Path(tmpdir) / "task.yaml"
+            sym_file.symlink_to(real_file)
+            tf = TaskFile(entries=[TaskEntry(description="test")])
+            with pytest.raises(ValueError, match="target is a symlink"):
+                save_task_file(sym_file, tf)
+
+
+class TestSaveTaskFileFlat:
+    def test_save_flat_single_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            tf = TaskFile(
+                entries=[TaskEntry(description="Fix the bug", status="pending")]
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            assert data["description"] == "Fix the bug"
+            assert data["status"] == "pending"
+
+    def test_save_excludes_none_values(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="Fix the bug", thread_id=None, error=None)
+                ]
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            assert "null" not in content
+            assert "None" not in content
+
+
+class TestSaveTaskFileMulti:
+    def test_save_multi_entry(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="Task 1"),
+                    TaskEntry(description="Task 2"),
+                ]
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            assert "tasks" in data
+            assert len(data["tasks"]) == 2
+
+
+class TestRoundTrip:
+    def test_single_entry_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            original = TaskFile(
+                entries=[
+                    TaskEntry(
+                        description="Fix bug", status="completed", thread_id="abc"
+                    )
+                ]
+            )
+            save_task_file(path, original)
+
+            loaded = load_task_file(path)
+            assert len(loaded.entries) == 1
+            assert loaded.entries[0].description == "Fix bug"
+            assert loaded.entries[0].status == "completed"
+
+    def test_multi_entry_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            original = TaskFile(
+                entries=[
+                    TaskEntry(description="Task 1", status="completed"),
+                    TaskEntry(description="Task 2", status="failed", error="segfault"),
+                ]
+            )
+            save_task_file(path, original)
+
+            loaded = load_task_file(path)
+            assert len(loaded.entries) == 2
+            assert loaded.entries[1].description == "Task 2"
+            assert loaded.entries[1].status == "failed"
+            assert loaded.entries[1].error == "segfault"
+
+    def test_single_entry_with_workflow_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            original = TaskFile(
+                entries=[
+                    TaskEntry(
+                        description="Fix the bug",
+                        status="pending",
+                        workflow="plan.yaml",
+                    )
+                ]
+            )
+            save_task_file(path, original)
+
+            loaded = load_task_file(path)
+            assert len(loaded.entries) == 1
+            assert loaded.entries[0].workflow == "plan.yaml"
+
+
+class TestSaveTaskFileSecurity:
+    def test_symlinked_ancestor_raises_before_mkdir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            safe_dir = Path(tmpdir) / "safe"
+            safe_dir.mkdir()
+            external_dir = Path(tmpdir) / "external"
+            external_dir.mkdir()
+            symlink_dir = safe_dir / ".fdsx"
+            symlink_dir.symlink_to(external_dir)
+
+            path = symlink_dir / "tasks.yaml"
+            tf = TaskFile(entries=[TaskEntry(description="Task 1")])
+
+            with pytest.raises(ValueError, match="ancestor is a symlink"):
+                save_task_file(path, tf)

--- a/tests/unit/test_terminal.py
+++ b/tests/unit/test_terminal.py
@@ -2,12 +2,121 @@ from io import StringIO
 from unittest.mock import patch
 
 from fdsx.display.terminal import (
+    _format_elapsed,
     display_branch_complete,
     display_branch_failed,
     display_branch_start,
+    display_completion_summary,
     display_parallel_results,
     display_wait_prompt,
 )
+
+
+class TestFormatElapsed:
+    """Tests for _format_elapsed time formatting helper."""
+
+    def test_seconds_only(self):
+        """Values under 60 seconds show only seconds."""
+        assert _format_elapsed(34.0) == "34s"
+
+    def test_zero_seconds(self):
+        """Zero seconds is formatted as '0s'."""
+        assert _format_elapsed(0.0) == "0s"
+
+    def test_exactly_one_minute(self):
+        """60 seconds is shown as '1m 0s'."""
+        assert _format_elapsed(60.0) == "1m 0s"
+
+    def test_minutes_and_seconds(self):
+        """Values under an hour show minutes and seconds."""
+        assert _format_elapsed(154.0) == "2m 34s"
+
+    def test_exactly_one_hour(self):
+        """3600 seconds is shown as '1h 0m 0s'."""
+        assert _format_elapsed(3600.0) == "1h 0m 0s"
+
+    def test_hours_minutes_seconds(self):
+        """Values over an hour show hours, minutes, and seconds."""
+        assert _format_elapsed(3754.0) == "1h 2m 34s"
+
+    def test_fractional_seconds_truncated(self):
+        """Fractional seconds are truncated (not rounded)."""
+        assert _format_elapsed(34.9) == "34s"
+
+
+class TestDisplayCompletionSummary:
+    """Tests for display_completion_summary output format."""
+
+    def test_success_message_contains_flow_name(self):
+        """Success message includes the flow name."""
+        captured = StringIO()
+        with patch("sys.stderr", captured):
+            display_completion_summary("MyFlow", 10.0)
+        assert "MyFlow" in captured.getvalue()
+
+    def test_success_message_format(self):
+        """Success message matches expected format with checkmark."""
+        captured = StringIO()
+        with patch("sys.stderr", captured):
+            display_completion_summary("MyFlow", 34.0)
+        output = captured.getvalue()
+        assert "✓" in output
+        assert "completed successfully" in output
+        assert "34s" in output
+
+    def test_success_writes_to_stderr_not_stdout(self):
+        """Completion summary is written to stderr, not stdout."""
+        stdout = StringIO()
+        stderr = StringIO()
+        with patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+            display_completion_summary("MyFlow", 5.0)
+        assert stdout.getvalue() == ""
+        assert stderr.getvalue() != ""
+
+    def test_failure_message_format(self):
+        """Failure message includes flow name, failed state, and error."""
+        captured = StringIO()
+        with patch("sys.stderr", captured):
+            display_completion_summary(
+                "MyFlow", 5.0, failed_state="ReviewState", error="exit code 1"
+            )
+        output = captured.getvalue()
+        assert "✗" in output
+        assert "MyFlow" in output
+        assert "ReviewState" in output
+        assert "exit code 1" in output
+
+    def test_failure_message_writes_to_stderr(self):
+        """Failure summary is written to stderr, not stdout."""
+        stdout = StringIO()
+        stderr = StringIO()
+        with patch("sys.stdout", stdout), patch("sys.stderr", stderr):
+            display_completion_summary("Flow", 2.0, failed_state="step1", error="err")
+        assert stdout.getvalue() == ""
+        assert stderr.getvalue() != ""
+
+    def test_success_elapsed_time_in_output(self):
+        """Success message includes the formatted elapsed time."""
+        captured = StringIO()
+        with patch("sys.stderr", captured):
+            display_completion_summary("Flow", 154.0)
+        assert "2m 34s" in captured.getvalue()
+
+    def test_flow_name_sanitized(self):
+        """Flow name with control characters is sanitized."""
+        captured = StringIO()
+        with patch("sys.stderr", captured):
+            display_completion_summary("My\x1b[31mFlow", 1.0)
+        output = captured.getvalue()
+        assert "\x1b" not in output
+        assert "MyFlow" in output
+
+    def test_failure_with_none_error_uses_fallback(self):
+        """When error is None, 'unknown error' is shown."""
+        captured = StringIO()
+        with patch("sys.stderr", captured):
+            display_completion_summary("Flow", 1.0, failed_state="step1", error=None)
+        assert "unknown error" in captured.getvalue()
 
 
 class TestDisplayWaitPrompt:

--- a/tests/unit/test_uuidv7.py
+++ b/tests/unit/test_uuidv7.py
@@ -1,0 +1,98 @@
+"""Tests for UUIDv7 run ID generation (Phase 1: FR-1.1–FR-1.6)."""
+
+import re
+import time
+
+import uuid_utils
+
+from fdsx.logging.recorder import THREAD_ID_PATTERN
+
+
+class TestUUIDv7Format:
+    """FR-1.1: Generated IDs are valid UUID format."""
+
+    def test_uuid7_is_valid_uuid_format(self) -> None:
+        """Generated ID must match standard UUID string format."""
+        uid = str(uuid_utils.uuid7())
+        uuid_pattern = re.compile(
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+        )
+        assert uuid_pattern.match(uid), f"Not a valid UUID format: {uid}"
+
+    def test_uuid7_version_nibble_is_7(self) -> None:
+        """FR-1.2: Version nibble (13th hex char) must be '7'."""
+        uid = str(uuid_utils.uuid7())
+        # UUID format: xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx
+        # M (version) is at index 14 (after removing dashes: position 12)
+        # With dashes: positions 0-7, dash, 9-12, dash, 14-17, dash, 19-22, dash, 24-35
+        version_nibble = uid[14]
+        assert version_nibble == "7", f"Expected version nibble '7', got '{version_nibble}' in {uid}"
+
+    def test_uuid7_variant_bits(self) -> None:
+        """FR-1.3: Variant bits (first nibble at position 19) must be '8', '9', 'a', or 'b'."""
+        uid = str(uuid_utils.uuid7())
+        variant_nibble = uid[19]
+        assert variant_nibble in ("8", "9", "a", "b"), (
+            f"Expected RFC 4122 variant nibble, got '{variant_nibble}' in {uid}"
+        )
+
+
+class TestUUIDv7ChronologicalSort:
+    """FR-1.4: UUIDv7 IDs sort chronologically (time-sortable property)."""
+
+    def test_sequential_uuids_sort_chronologically(self) -> None:
+        """UUIDv7 IDs generated sequentially must sort in generation order."""
+        ids = []
+        for _ in range(10):
+            ids.append(str(uuid_utils.uuid7()))
+            # Small sleep to ensure distinct millisecond timestamps
+            time.sleep(0.002)
+
+        sorted_ids = sorted(ids)
+        assert ids == sorted_ids, (
+            f"UUIDv7 IDs are not in chronological order.\n"
+            f"Generated: {ids}\n"
+            f"Sorted:    {sorted_ids}"
+        )
+
+    def test_two_uuids_in_order(self) -> None:
+        """Two UUIDv7s generated sequentially: first < second."""
+        uid1 = str(uuid_utils.uuid7())
+        time.sleep(0.002)
+        uid2 = str(uuid_utils.uuid7())
+        assert uid1 < uid2, f"Expected {uid1} < {uid2}"
+
+
+class TestUUIDv7ThreadIdPatternAcceptance:
+    """FR-1.5: Generated UUIDv7 IDs pass THREAD_ID_PATTERN validation."""
+
+    def test_uuid7_passes_thread_id_pattern(self) -> None:
+        """UUIDv7 string representation must pass existing THREAD_ID_PATTERN."""
+        uid = str(uuid_utils.uuid7())
+        # THREAD_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+        # UUIDs use hex chars [0-9a-f] and dashes '-' — both allowed
+        assert THREAD_ID_PATTERN.match(uid), (
+            f"UUIDv7 '{uid}' failed THREAD_ID_PATTERN validation"
+        )
+
+    def test_multiple_uuid7s_pass_thread_id_pattern(self) -> None:
+        """Multiple UUIDv7s all pass THREAD_ID_PATTERN."""
+        for _ in range(20):
+            uid = str(uuid_utils.uuid7())
+            assert THREAD_ID_PATTERN.match(uid), (
+                f"UUIDv7 '{uid}' failed THREAD_ID_PATTERN validation"
+            )
+
+    def test_uuid7_no_uppercase_hex(self) -> None:
+        """UUIDv7 string contains only lowercase hex digits and dashes."""
+        uid = str(uuid_utils.uuid7())
+        assert uid == uid.lower(), f"Expected lowercase UUID, got: {uid}"
+
+
+class TestUUIDv7Uniqueness:
+    """FR-1.6: Each generated ID is unique."""
+
+    def test_uuid7_generates_unique_ids(self) -> None:
+        """100 generated UUIDv7s must all be distinct."""
+        ids = {str(uuid_utils.uuid7()) for _ in range(100)}
+        assert len(ids) == 100, "Expected 100 unique UUIDv7 IDs"

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -161,6 +161,7 @@ class TestAnalyzeVariableReferences:
     def test_valid_flow_no_errors(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for variable analysis",
             start_at="start",
             states={
                 "start": TaskState(
@@ -185,6 +186,7 @@ class TestAnalyzeVariableReferences:
     def test_unreachable_variable_reference(self):
         flow = Flow(
             name="Test Flow",
+            description="Test flow for unreachable variable",
             start_at="start",
             states={
                 "start": TaskState(
@@ -215,6 +217,7 @@ class TestAnalyzeVariableReferences:
         # so we need a second state to demonstrate the fix.
         flow2 = Flow(
             name="Test Flow 2",
+            description="Test flow for input keys",
             start_at="start",
             states={
                 "start": TaskState(
@@ -245,6 +248,7 @@ class TestAnalyzeVariableReferences:
         """F3: different nested sub-paths on producer vs consumer should be flagged."""
         flow = Flow(
             name="Test Flow",
+            description="Test flow for nested paths",
             start_at="produce",
             states={
                 "produce": TaskState(
@@ -271,6 +275,7 @@ class TestAnalyzeVariableReferences:
         """F3: producing $.review satisfies reference to {review.decision} (ancestor)."""
         flow = Flow(
             name="Test Flow",
+            description="Test flow for ancestor path",
             start_at="produce",
             states={
                 "produce": TaskState(
@@ -296,6 +301,7 @@ class TestAnalyzeVariableReferences:
         """F3: producing $.review.summary satisfies reference to {review} (descendant proves parent exists)."""
         flow = Flow(
             name="Test Flow",
+            description="Test flow for descendant path",
             start_at="produce",
             states={
                 "produce": TaskState(
@@ -321,6 +327,7 @@ class TestAnalyzeVariableReferences:
         """Regression: analyze_variable_references must check parallel branch prompts."""
         flow = Flow(
             name="Test Flow",
+            description="Test flow for parallel branch",
             start_at="start",
             states={
                 "start": TaskState(
@@ -392,6 +399,7 @@ class TestAnalyzeVariableReferencesExtract:
 
         flow = Flow(
             name="Extraction Flow",
+            description="Test flow for extract result path",
             start_at="echo_state",
             states={
                 "echo_state": TaskState(
@@ -422,6 +430,7 @@ class TestAnalyzeVariableReferencesExtract:
         """F1: A reference to an extract.result_path that doesn't exist should be flagged."""
         flow = Flow(
             name="Extraction Flow",
+            description="Test flow for missing extract result path",
             start_at="echo_state",
             states={
                 "echo_state": TaskState(
@@ -452,6 +461,7 @@ class TestAnalyzeVariableReferencesExtract:
 
         flow = Flow(
             name="Parallel Extract Flow",
+            description="Test flow for parallel extract path",
             start_at="par",
             states={
                 "par": ParallelState(
@@ -488,6 +498,7 @@ class TestAnalyzeVariableReferencesExtract:
         """F1: Only the parallel state's own result_path is registered as top-level."""
         flow = Flow(
             name="Parallel Result Flow",
+            description="Test flow for parallel result path",
             start_at="par",
             states={
                 "par": ParallelState(

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -42,6 +42,31 @@ class TestResolveTemplate:
         result = resolve_template("Hello World!", {})
         assert result == "Hello World!"
 
+    def test_int_value(self):
+        result = resolve_template("Count: {count}", {"count": 42})
+        assert result == "Count: 42"
+
+    def test_bool_value(self):
+        result = resolve_template("Active: {active}", {"active": True})
+        assert result == "Active: True"
+
+    def test_list_value_rendered_as_json(self):
+        variables = {"items": ["apple", "banana"]}
+        result = resolve_template("Fruits: {items}", variables)
+        assert result == 'Fruits: [\n  "apple",\n  "banana"\n]'
+
+    def test_dict_value_rendered_as_json(self):
+        variables = {"config": {"timeout": 30, "debug": True}}
+        result = resolve_template("Config: {config}", variables)
+        assert result == 'Config: {\n  "timeout": 30,\n  "debug": true\n}'
+
+    def test_nested_dict_list_rendered_as_json(self):
+        variables = {"data": {"users": [{"name": "Alice"}, {"name": "Bob"}]}}
+        result = resolve_template("Data: {data}", variables)
+        assert '"name"' in result
+        assert "Alice" in result
+        assert "Bob" in result
+
 
 class TestResolveJsonPath:
     def test_simple_field(self):
@@ -155,6 +180,200 @@ class TestResolveTemplateShellSafe:
         # shlex.quote handles single quotes
         assert "it" in result
         assert "test" in result
+
+    def test_list_value_shell_safe(self):
+        """List values should be JSON-encoded and shell-quoted."""
+        variables = {"items": ["apple", "banana"]}
+        result = resolve_template_shell_safe("echo {items}", variables)
+        assert result == 'echo \'[\n  "apple",\n  "banana"\n]\'', (
+            f"Expected exact JSON+quote output, got: {result!r}"
+        )
+
+    def test_dict_value_shell_safe(self):
+        """Dict values should be JSON-encoded and shell-quoted."""
+        variables = {"config": {"timeout": 30}}
+        result = resolve_template_shell_safe("echo {config}", variables)
+        assert result == "echo '{\n  \"timeout\": 30\n}'", (
+            f"Expected exact JSON+quote output, got: {result!r}"
+        )
+
+
+class TestPassStateVariableRecognition:
+    """T003/T005: PassState parameters and aggregate must be recognized by analyze_variable_references."""
+
+    def test_pass_state_parameters_satisfy_downstream(self):
+        """T005: PassState.parameters keys should satisfy downstream variable references."""
+        from fdsx.models.flow import PassState
+
+        flow = Flow(
+            name="PassState Flow",
+            description="Test flow for PassState parameters",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.result",
+                    next="transform",
+                ),
+                "transform": PassState(
+                    type="pass",
+                    parameters={"doc_feedback": "{result}", "summary": "summary text"},
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {doc_feedback}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_pass_state_parameters_dollar_prefix(self):
+        """PassState parameter keys with $. prefix should be stripped."""
+        from fdsx.models.flow import PassState
+
+        flow = Flow(
+            name="PassState Dollar Prefix",
+            description="Test flow for $. prefix in parameters",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.raw",
+                    next="transform",
+                ),
+                "transform": PassState(
+                    type="pass",
+                    parameters={"$.review": "{raw}"},
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {review}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_pass_state_aggregate_satisfies_downstream(self):
+        """PassState.aggregate.result_path should satisfy downstream references."""
+        from fdsx.models.flow import AggregateRule, PassState
+
+        flow = Flow(
+            name="PassState Aggregate Flow",
+            description="Test flow for PassState aggregate",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.raw",
+                    next="aggregate",
+                ),
+                "aggregate": PassState(
+                    type="pass",
+                    aggregate=AggregateRule(
+                        source="$.results",
+                        field="decision",
+                        strategy="majority",
+                        match="APPROVED",
+                        no_match="REJECTED",
+                        result_path="$.decision",
+                    ),
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {decision}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_pass_state_undefined_variable_still_flagged(self):
+        """PassState without the right parameters should still flag undefined refs."""
+        from fdsx.models.flow import PassState
+
+        flow = Flow(
+            name="PassState Undefined",
+            description="PassState without the variable should still flag error",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.result",
+                    next="transform",
+                ),
+                "transform": PassState(
+                    type="pass",
+                    parameters={"other_key": "static"},
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {undefined_var}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 1
+        assert "undefined_var" in errors[0]
+
+    def test_pass_state_parameters_undefined_ref_in_value_flagged(self):
+        """PassState.parameters values with {var} refs to undefined variables must be flagged."""
+        from fdsx.models.flow import PassState
+
+        flow = Flow(
+            name="PassState Undefined Input",
+            description="PassState references undefined var in parameters value",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.result",
+                    next="transform",
+                ),
+                "transform": PassState(
+                    type="pass",
+                    parameters={"doc_feedback": "{nonexistent_var}"},
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {doc_feedback}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 1
+        assert "nonexistent_var" in errors[0]
 
 
 class TestAnalyzeVariableReferences:

--- a/tests/unit/test_workflow_cui.py
+++ b/tests/unit/test_workflow_cui.py
@@ -1,0 +1,303 @@
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.display.terminal import confirm_workflow_assignments_interactive
+from fdsx.models.task import TaskEntry, TaskFile
+
+
+class TestConfirmWorkflowAssignmentsInteractive:
+    """Tests for the interactive workflow confirmation CUI."""
+
+    def _make_task_files(self, *descriptions: str) -> list[tuple[Path, TaskFile]]:
+        """Helper to create task_files list from descriptions."""
+        return [
+            (
+                Path(f"00{i}-task.yaml"),
+                TaskFile(entries=[TaskEntry(description=desc)]),
+            )
+            for i, desc in enumerate(descriptions, start=1)
+        ]
+
+    def _make_workflows(self, *names: str) -> list[tuple[Path, str]]:
+        """Helper to create available_workflows list from names."""
+        return [(Path(name), f"Description for {name}") for name in names]
+
+    def test_confirm_returns_assignments_dict(self):
+        """'c' input returns the assignments dict."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        wf1 = Path("review.yaml")
+        wf2 = Path("implement.yaml")
+        assignments = {
+            (0, 0): wf1,
+            (1, 0): wf2,
+        }
+        display_keys = [(0, 0), (1, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="c"):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result is not None
+        assert result == assignments
+        assert result[(0, 0)] == wf1
+        assert result[(1, 0)] == wf2
+
+    def test_cancel_returns_none(self):
+        """'q' input returns None."""
+        task_files = self._make_task_files("Fix the bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="q"):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result is None
+
+    def test_non_tty_auto_confirm_returns_copy(self):
+        """When is_interactive() is False, returns immediately without calling input."""
+        task_files = self._make_task_files("Fix the bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=False):
+            with patch("builtins.input") as mock_input:
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        mock_input.assert_not_called()
+        assert result is not None
+        assert result == assignments
+        assert result is not assignments
+
+    def test_change_workflow_by_number(self):
+        """Entering a number changes that assignment and confirm returns updated dict."""
+        task_files = self._make_task_files("Fix the bug")
+        original_wf = Path("review.yaml")
+        new_wf = Path("implement.yaml")
+        assignments = {(0, 0): original_wf}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
+
+        input_seq = ["1", "2", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result is not None
+        assert result[(0, 0)] == new_wf
+
+    def test_change_workflow_cancel_sub_pick_returns_to_main(self):
+        """Cancelling workflow sub-pick ('c') returns to main prompt."""
+        task_files = self._make_task_files("Fix the bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
+
+        input_seq = ["1", "c", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result is not None
+        assert result[(0, 0)] == Path("review.yaml")
+
+    def test_invalid_number_reprompts(self):
+        """Invalid row number prints error and re-prompts."""
+        task_files = self._make_task_files("Fix the bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+        stream = StringIO()
+
+        input_seq = ["0", "99", "abc", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows, stream=stream
+                )
+
+        assert result is not None
+        assert "Invalid number" in stream.getvalue()
+
+    def test_invalid_workflow_pick_reprompts(self):
+        """Invalid workflow pick number prints error and re-prompts."""
+        task_files = self._make_task_files("Fix the bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
+        stream = StringIO()
+
+        input_seq = ["1", "99", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows, stream=stream
+                )
+
+        assert result is not None
+        assert "Invalid number" in stream.getvalue()
+
+    def test_empty_workflows_no_change_possible(self):
+        """When no alternative workflows, prints message and returns to main."""
+        task_files = self._make_task_files("Fix the bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows: list[tuple[Path, str]] = []
+        stream = StringIO()
+
+        input_seq = ["1", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows, stream=stream
+                )
+
+        assert result is not None
+        assert "No alternative workflows" in stream.getvalue()
+        assert result[(0, 0)] == Path("review.yaml")
+
+    def test_unassigned_entry_blocks_confirm(self):
+        """'c' with unassigned entries is rejected until all are assigned."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        wf1 = Path("review.yaml")
+        wf2 = Path("implement.yaml")
+        assignments = {
+            (0, 0): wf1,
+        }
+        display_keys = [(0, 0), (1, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
+        stream = StringIO()
+
+        input_seq = ["c", "2", "2", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows, stream=stream
+                )
+
+        assert result is not None
+        stderr_text = stream.getvalue()
+        assert "Cannot confirm" in stderr_text
+        assert "no workflow assigned" in stderr_text
+        assert result[(1, 0)] == wf2
+
+    def test_table_shows_correct_columns(self):
+        """Table output contains expected columns and task info."""
+        task_files = self._make_task_files("Fix the login bug")
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+        stream = StringIO()
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="c"):
+                confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows, stream=stream
+                )
+
+        stderr_text = stream.getvalue()
+        assert "WORKFLOW ASSIGNMENTS" in stderr_text
+        assert "FILE" in stderr_text
+        assert "ENTRY" in stderr_text
+        assert "WORKFLOW" in stderr_text
+        assert "TASK" in stderr_text
+        assert "review.yaml" in stderr_text
+        assert "Fix the login" in stderr_text
+        assert "task.yaml" in stderr_text
+
+    def test_confirm_does_not_persist_while_in_memory(self):
+        """The function returns a dict; caller is responsible for persistence."""
+        task_files = self._make_task_files("Fix the bug")
+        wf1 = Path("review.yaml")
+        wf2 = Path("implement.yaml")
+        assignments = {(0, 0): wf1}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
+
+        input_seq = ["1", "2", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result[(0, 0)] == wf2
+        assert assignments[(0, 0)] == wf1
+
+    def test_returns_none_preserves_original_assignments(self):
+        """Cancel returns None; original assignments dict is unchanged."""
+        task_files = self._make_task_files("Fix the bug")
+        wf = Path("review.yaml")
+        assignments = {(0, 0): wf}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="q"):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result is None
+        assert assignments[(0, 0)] == wf
+
+    def test_sanitizes_ansi_from_description(self):
+        """ANSI escape sequences in task description are stripped from output."""
+        task_files = [
+            (
+                Path("001-task.yaml"),
+                TaskFile(
+                    entries=[TaskEntry(description="\x1b[31mFix the bug\x1b[0m danger")]
+                ),
+            )
+        ]
+        assignments = {(0, 0): Path("review.yaml")}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+        stream = StringIO()
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="c"):
+                confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows, stream=stream
+                )
+
+        stderr_text = stream.getvalue()
+        assert "\x1b" not in stderr_text
+        assert "Fix the bug" in stderr_text
+
+    def test_workflow_change_persists_through_multiple_changes(self):
+        """Changing the same assignment twice keeps the last value."""
+        task_files = self._make_task_files("Fix the bug")
+        wf1 = Path("review.yaml")
+        wf2 = Path("implement.yaml")
+        wf3 = Path("test.yaml")
+        assignments = {(0, 0): wf1}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml", "test.yaml")
+
+        input_seq = ["1", "2", "1", "3", "c"]
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", side_effect=input_seq):
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        assert result is not None
+        assert result[(0, 0)] == wf3

--- a/tests/unit/test_workflow_cui.py
+++ b/tests/unit/test_workflow_cui.py
@@ -49,11 +49,14 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert result[(1, 0)] == wf2
 
     def test_cancel_returns_none(self):
-        """'q' input returns None."""
-        task_files = self._make_task_files("Fix the bug")
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
-        workflows = self._make_workflows("review.yaml")
+        """'q' input returns None (uses 2 tasks since single assigned auto-confirms)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        assignments = {
+            (0, 0): Path("review.yaml"),
+            (1, 0): Path("implement.yaml"),
+        }
+        display_keys = [(0, 0), (1, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
 
         with patch("fdsx.display.terminal.is_interactive", return_value=True):
             with patch("builtins.input", return_value="q"):
@@ -82,12 +85,12 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert result is not assignments
 
     def test_change_workflow_by_number(self):
-        """Entering a number changes that assignment and confirm returns updated dict."""
-        task_files = self._make_task_files("Fix the bug")
+        """Entering a number changes that assignment and confirm returns updated dict (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
         original_wf = Path("review.yaml")
         new_wf = Path("implement.yaml")
-        assignments = {(0, 0): original_wf}
-        display_keys = [(0, 0)]
+        assignments = {(0, 0): original_wf, (1, 0): original_wf}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml", "implement.yaml")
 
         input_seq = ["1", "2", "c"]
@@ -101,10 +104,10 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert result[(0, 0)] == new_wf
 
     def test_change_workflow_cancel_sub_pick_returns_to_main(self):
-        """Cancelling workflow sub-pick ('c') returns to main prompt."""
-        task_files = self._make_task_files("Fix the bug")
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
+        """Cancelling workflow sub-pick ('c') returns to main prompt (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        assignments = {(0, 0): Path("review.yaml"), (1, 0): Path("review.yaml")}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml", "implement.yaml")
 
         input_seq = ["1", "c", "c"]
@@ -118,10 +121,10 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert result[(0, 0)] == Path("review.yaml")
 
     def test_invalid_number_reprompts(self):
-        """Invalid row number prints error and re-prompts."""
-        task_files = self._make_task_files("Fix the bug")
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
+        """Invalid row number prints error and re-prompts (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        assignments = {(0, 0): Path("review.yaml"), (1, 0): Path("review.yaml")}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml")
         stream = StringIO()
 
@@ -136,10 +139,10 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert "Invalid number" in stream.getvalue()
 
     def test_invalid_workflow_pick_reprompts(self):
-        """Invalid workflow pick number prints error and re-prompts."""
-        task_files = self._make_task_files("Fix the bug")
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
+        """Invalid workflow pick number prints error and re-prompts (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        assignments = {(0, 0): Path("review.yaml"), (1, 0): Path("review.yaml")}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml", "implement.yaml")
         stream = StringIO()
 
@@ -154,10 +157,10 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert "Invalid number" in stream.getvalue()
 
     def test_empty_workflows_no_change_possible(self):
-        """When no alternative workflows, prints message and returns to main."""
-        task_files = self._make_task_files("Fix the bug")
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
+        """When no alternative workflows, prints message and returns to main (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
+        assignments = {(0, 0): Path("review.yaml"), (1, 0): Path("review.yaml")}
+        display_keys = [(0, 0), (1, 0)]
         workflows: list[tuple[Path, str]] = []
         stream = StringIO()
 
@@ -198,11 +201,14 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert result[(1, 0)] == wf2
 
     def test_table_shows_correct_columns(self):
-        """Table output contains expected columns and task info."""
-        task_files = self._make_task_files("Fix the login bug")
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
-        workflows = self._make_workflows("review.yaml")
+        """Table output contains expected columns and task info (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the login bug", "Write tests")
+        assignments = {
+            (0, 0): Path("review.yaml"),
+            (1, 0): Path("implement.yaml"),
+        }
+        display_keys = [(0, 0), (1, 0)]
+        workflows = self._make_workflows("review.yaml", "implement.yaml")
         stream = StringIO()
 
         with patch("fdsx.display.terminal.is_interactive", return_value=True):
@@ -223,11 +229,11 @@ class TestConfirmWorkflowAssignmentsInteractive:
 
     def test_confirm_does_not_persist_while_in_memory(self):
         """The function returns a dict; caller is responsible for persistence."""
-        task_files = self._make_task_files("Fix the bug")
+        task_files = self._make_task_files("Fix the bug", "Write tests")
         wf1 = Path("review.yaml")
         wf2 = Path("implement.yaml")
-        assignments = {(0, 0): wf1}
-        display_keys = [(0, 0)]
+        assignments = {(0, 0): wf1, (1, 0): wf1}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml", "implement.yaml")
 
         input_seq = ["1", "2", "c"]
@@ -241,11 +247,11 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert assignments[(0, 0)] == wf1
 
     def test_returns_none_preserves_original_assignments(self):
-        """Cancel returns None; original assignments dict is unchanged."""
-        task_files = self._make_task_files("Fix the bug")
+        """Cancel returns None; original assignments dict is unchanged (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
         wf = Path("review.yaml")
-        assignments = {(0, 0): wf}
-        display_keys = [(0, 0)]
+        assignments = {(0, 0): wf, (1, 0): wf}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml")
 
         with patch("fdsx.display.terminal.is_interactive", return_value=True):
@@ -258,17 +264,21 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert assignments[(0, 0)] == wf
 
     def test_sanitizes_ansi_from_description(self):
-        """ANSI escape sequences in task description are stripped from output."""
+        """ANSI escape sequences in task description are stripped from output (uses 2 tasks)."""
         task_files = [
             (
                 Path("001-task.yaml"),
                 TaskFile(
                     entries=[TaskEntry(description="\x1b[31mFix the bug\x1b[0m danger")]
                 ),
-            )
+            ),
+            (
+                Path("002-task.yaml"),
+                TaskFile(entries=[TaskEntry(description="Write tests")]),
+            ),
         ]
-        assignments = {(0, 0): Path("review.yaml")}
-        display_keys = [(0, 0)]
+        assignments = {(0, 0): Path("review.yaml"), (1, 0): Path("review.yaml")}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml")
         stream = StringIO()
 
@@ -283,13 +293,13 @@ class TestConfirmWorkflowAssignmentsInteractive:
         assert "Fix the bug" in stderr_text
 
     def test_workflow_change_persists_through_multiple_changes(self):
-        """Changing the same assignment twice keeps the last value."""
-        task_files = self._make_task_files("Fix the bug")
+        """Changing the same assignment twice keeps the last value (uses 2 tasks)."""
+        task_files = self._make_task_files("Fix the bug", "Write tests")
         wf1 = Path("review.yaml")
         wf2 = Path("implement.yaml")
         wf3 = Path("test.yaml")
-        assignments = {(0, 0): wf1}
-        display_keys = [(0, 0)]
+        assignments = {(0, 0): wf1, (1, 0): wf1}
+        display_keys = [(0, 0), (1, 0)]
         workflows = self._make_workflows("review.yaml", "implement.yaml", "test.yaml")
 
         input_seq = ["1", "2", "1", "3", "c"]
@@ -301,3 +311,39 @@ class TestConfirmWorkflowAssignmentsInteractive:
 
         assert result is not None
         assert result[(0, 0)] == wf3
+
+    def test_single_task_auto_confirm_no_input_called(self):
+        """A single assigned task auto-confirms without calling input (T028 edge case)."""
+        task_files = self._make_task_files("Fix the bug")
+        wf = Path("review.yaml")
+        assignments = {(0, 0): wf}
+        display_keys = [(0, 0)]
+        workflows = self._make_workflows("review.yaml")
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input") as mock_input:
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        mock_input.assert_not_called()
+        assert result is not None
+        assert result == assignments
+
+    def test_single_unassigned_task_shows_cui(self):
+        """A single unassigned task still requires CUI interaction."""
+        task_files = self._make_task_files("Fix the bug")
+        display_keys = [(0, 0)]
+        assignments: dict[tuple[int, int], Path] = {}
+        workflows = self._make_workflows("review.yaml")
+
+        with patch("fdsx.display.terminal.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="c") as mock_input:
+                result = confirm_workflow_assignments_interactive(
+                    display_keys, assignments, task_files, workflows
+                )
+
+        mock_input.assert_called()
+        assert result is None, (
+            "Unassigned single task should block on 'c' until assigned"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -210,6 +210,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
     { name = "typer" },
+    { name = "uuid-utils" },
 ]
 
 [package.optional-dependencies]
@@ -232,6 +233,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "structlog", specifier = ">=24" },
     { name = "typer", specifier = ">=0.9" },
+    { name = "uuid-utils", specifier = ">=0.9" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary

### Phase 1: UUIDv7 Run IDs (T001–T004)
- Replaced UUIDv4 with UUIDv7 for time-sortable run IDs across all generation points

### Phase 2: Claude Provider JSON Streaming (T005–T009)
- **Stream parser**: Added `_make_stream_callback()` to `src/fdsx/providers/claude.py` — a closure that parses each NDJSON line from Claude's `stream-json` output and dispatches `text_delta`, `thinking_delta`, and `tool_use` events to the `output_callback`
- **Streaming wiring**: When `output_callback` is provided, `execute()` now adds `--output-format stream-json --verbose --include-partial-messages` flags and returns `ProviderResult.stdout` from the `result` event (with fallback to accumulated text deltas on crash)
- **Fixture & tests**: 10-line NDJSON fixture, 22 unit tests, and 8 integration tests with mocked subprocess

### Phase 3: Codex Provider JSONL Streaming (T010–T014)
- **Stream parser**: Added `_make_stream_callback()` to `src/fdsx/providers/codex.py` — a closure that parses each JSONL line from Codex's `--json` output and dispatches `agent_message`, `reasoning`, `command_execution`, `file_change`, `mcp_tool_call`, `error`, and `turn.failed` events
- **Streaming wiring**: When `output_callback` is provided, `execute()` appends `--json` flag and reconstructs `ProviderResult.stdout` from concatenated agent_message texts (FR-4.7)
- **Fixture & tests**: 12-line JSONL fixture, 33 unit tests (9 test classes), and 11 integration tests with mocked subprocess fixture replay

### Phase 4: StreamLogger Quiet Mode (T015–T019)
- **StreamLogger**: Added `quiet: bool = False` parameter; guarded `print()` calls with `if not self.quiet` to suppress stderr streaming output
- **CLI wiring**: Added `--quiet` typer option to `run` command, wired through `engine.run_flow()` → `compiler.compile_flow()` → `StreamLogger`
- **Tests**: 5 unit tests for quiet mode behavior + 4 integration tests for end-to-end `--quiet` flag
- Completion summary remains unaffected (FR-5.4) — `display_completion_summary()` runs independently of StreamLogger

### Phase 5: Verification & Polish (T020–T021)
- **Bug fix**: `--quiet` flag was silently ignored in `--tasks` (batch) and `--tasks-dir` execution modes — added `quiet: bool = False` parameter to `run_batch()` and `run_tasks_dir()` and wired it through from the CLI
- **Mock fixes**: Updated 13 mock function signatures across 3 test files to accept `**kwargs` for forward-compatibility
- **New tests**: Added `TestBatchQuietFlagPropagation` and `TestRunTasksDirQuietFlagPropagation` test classes

### Stdin Fallback
- Added stdin fallback for CLI providers to handle oversized prompts (E2BIG errors)

### File-Based Variable Passing: result_file (Phases 1–3)
- **Phase 1 (Model + Helper)**: Added `write_result_to_file()` helper in `variables.py` and `result_file` field to `TaskState`/`ParallelState` models with validation
- **Phase 2 (Engine + Static Analysis)**: Added `_meta.run_dir` propagation in engine and `result_file` recognition in static analysis (`get_result_paths()`)
- **Phase 3 (Compiler Wiring)**: Wired `result_file` in `_create_task_node()` and `_create_collector_node()` — calls `write_result_to_file()` and stores the path via `set_jsonpath`. Registered `result_file` keys in `_build_state_schema()` and `_extract_result_paths()`. 6 new unit tests covering file-only, both, and no-file modes.

### Fix Split Emptiness Check (Phase 1: T001–T003)
- **Emptiness check fix**: Modified `src/fdsx/cli/main.py` to filter out `completed/` subdirectory when checking if tasks dir is empty — `fdsx split` now succeeds without `--force` when only `completed/` exists
- **5 integration tests**: split with only completed dir, completed dir preservation on normal split, task numbering continuation from completed, pending yaml still blocks, and `--force` preserving completed dir
- **Task progress**: Marked T001–T003 as done in `specs/20260322050008-fix-split-task-granularity/tasks.md`

## Test plan

- [x] All 22 Claude streaming unit tests pass
- [x] All 8 Claude streaming integration tests pass
- [x] All 33 Codex streaming unit tests pass
- [x] All 11 Codex streaming integration tests pass
- [x] All 5 quiet mode unit tests pass
- [x] All 4 quiet mode integration tests pass
- [x] Batch quiet flag propagation tests pass (2 new tests)
- [x] Tasks-dir quiet flag propagation tests pass (2 new tests)
- [x] All 36 result_file unit tests pass (Phases 1–3)
- [x] All 16 split integration tests pass (including 5 new emptiness check tests)
- [x] Pyright type check passes with 0 errors
- [x] Full test suite: no new regressions
- [ ] Manual verification with real Claude CLI (optional)
- [ ] Manual verification with real Codex CLI (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)