### PR TITLE
feat: add GitHub Actions publish workflow for PyPI release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,108 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      testpypi:
+        description: "Publish to TestPyPI"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install dev deps
+        run: pip install -e ".[dev]"
+      - name: ruff check
+        run: ruff check .
+      - name: ruff format check
+        run: ruff format --check .
+      - name: mypy
+        run: mypy src/fdsx
+      - name: pytest
+        run: pytest
+
+  build:
+    name: build
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: install build
+        run: pip install build
+      - name: build
+        run: python -m build
+      - name: upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-to-testpypi:
+    name: publish-to-testpypi
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.testpypi
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/fdsx/
+    permissions:
+      id-token: write
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-to-pypi:
+    name: publish-to-pypi
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/project/fdsx/
+    permissions:
+      id-token: write
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 kenfdev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,19 @@
+graft src
+include pyproject.toml
+include README.md
+include LICENSE
+
+prune .claude
+prune .takt
+prune .specify
+prune .worktree
+prune .fdsx
+prune specs
+
+exclude .gitignore
+exclude .worktreeinclude
+exclude docker-compose.yml
+exclude uv.lock
+
+global-exclude *.pyc
+global-exclude __pycache__

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fdsx — Flow-Driven Stateful eXecution
 
+[![PyPI version](https://img.shields.io/pypi/v/fdsx.svg)](https://pypi.org/project/fdsx/)
+
 A lightweight framework for building and executing complex AI agent workflows using declarative YAML definitions.
 
 ## Overview
@@ -17,6 +19,12 @@ fdsx enables you to define AI agent workflows in YAML, combining the durability 
 
 ```bash
 pip install fdsx
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv tool install fdsx
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,24 @@
 [project]
 name = "fdsx"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Declarative AI agent workflow execution framework"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
 authors = [
-    {name = "fdsx Contributors"}
+    {name = "kenfdev"}
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
     "Topic :: Software Development :: Libraries :: Application Frameworks",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
@@ -30,11 +34,11 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/fdsx/fdsx"
-Repository = "https://github.com/fdsx/fdsx"
+Homepage = "https://github.com/kenfdev/fdsx"
+Repository = "https://github.com/kenfdev/fdsx"
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
@@ -50,6 +54,8 @@ fdsx = "fdsx.cli.main:app"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools_scm]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -47,6 +46,7 @@ dev = [
     "pytest-asyncio>=0.23",
     "ruff>=0.4",
     "mypy>=1.10",
+    "types-PyYAML>=6",
 ]
 
 [project.scripts]
@@ -56,6 +56,7 @@ fdsx = "fdsx.cli.main:app"
 where = ["src"]
 
 [tool.setuptools_scm]
+local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -231,7 +231,11 @@ class CheckpointManager:
                 started_at = ""
                 config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
                 try:
-                    checkpoint_tuple = checkpointer.get_tuple(config) if checkpointer is not None else None
+                    checkpoint_tuple = (
+                        checkpointer.get_tuple(config)
+                        if checkpointer is not None
+                        else None
+                    )
                     if checkpoint_tuple is not None:
                         checkpoint_data = checkpoint_tuple.checkpoint
                         meta = _extract_meta_from_checkpoint(checkpoint_data)
@@ -274,6 +278,7 @@ class CheckpointManager:
                 if flow_name == thread_id or not started_at:
                     try:
                         import json
+
                         run_log_path = runs_dir / thread_id / RUN_FILENAME
                         if run_log_path.is_file():
                             with open(run_log_path, "r") as f:

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -4,14 +4,39 @@ from pathlib import Path
 import typer
 import uuid_utils
 
+from fdsx import __version__
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core import engine
-from fdsx.core.batch import COMPLETED_SUBDIR, TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.batch import (
+    COMPLETED_SUBDIR,
+    TASKS_DIR,
+    split_tasks_to_groups,
+    write_task_files,
+)
 from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
 from fdsx.display.terminal import Spinner, _sanitize_output, display_resume_command
 
 app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework")
+
+
+def version_callback(value: bool | None) -> None:
+    if value:
+        typer.echo(f"fdsx {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool | None = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
+) -> None:
+    pass
 
 
 @app.command()

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -8,7 +8,12 @@ from typing import Any
 from fdsx.core.config import TaskSplitterConfig
 from fdsx.display.terminal import _sanitize_output
 from fdsx.models.flow import Flow
-from fdsx.models.task import TaskEntry, TaskFile, save_task_file
+from fdsx.models.task import (
+    TaskEntry,
+    TaskFile,
+    _ensure_no_symlink_ancestors,
+    save_task_file,
+)
 from fdsx.providers.base import get_provider
 
 
@@ -335,11 +340,9 @@ def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Pat
     Raises:
         ValueError: If tasks_dir is a symlink or other security checks fail
     """
-    current = tasks_dir
-    while current != current.parent:
-        if current.exists() and current.is_symlink():
-            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
-        current = current.parent
+    # Reject user-controlled symlink ancestors before creating the tasks dir,
+    # while allowing known platform temp aliases like /var and /tmp on macOS.
+    _ensure_no_symlink_ancestors(tasks_dir, include_self=True)
 
     tasks_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
@@ -376,20 +379,15 @@ def move_task_to_completed(file_path: Path) -> None:
     """
     completed_dir = file_path.parent / COMPLETED_SUBDIR
 
-    # Security check: no symlinks in the ancestor path
-    current = completed_dir
-    while current != current.parent:
-        if current.exists() and current.is_symlink():
-            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
-        current = current.parent
+    # Reject user-controlled symlink ancestors in the destination path while
+    # allowing known platform temp aliases like /var and /tmp on macOS.
+    _ensure_no_symlink_ancestors(completed_dir, include_self=True)
 
     completed_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
     dest = completed_dir / file_path.name
     if dest.exists():
-        raise FileExistsError(
-            f"Destination already exists in completed/: {dest}"
-        )
+        raise FileExistsError(f"Destination already exists in completed/: {dest}")
 
     shutil.move(str(file_path), str(dest))
 

--- a/src/fdsx/core/compiler.py
+++ b/src/fdsx/core/compiler.py
@@ -226,7 +226,9 @@ def compile_flow(
 
     # Derive the .fdsx base directory for hook data files from log_dir.
     # log_dir = .fdsx/runs/<thread-id>/logs/ → parent×3 = .fdsx/
-    fdsx_base_dir: Path | None = log_dir.parent.parent.parent if log_dir is not None else None
+    fdsx_base_dir: Path | None = (
+        log_dir.parent.parent.parent if log_dir is not None else None
+    )
 
     # Resolve config-level hooks (merged global+project hooks are in fdsx_config.hooks)
     config_hooks = config.hooks if config is not None else None
@@ -252,17 +254,33 @@ def compile_flow(
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
             on_start, on_complete = _collect_state_hooks(state)
-            node = _create_task_node(state_name, state, flow, recorder, config, log_dir, quiet)
+            node = _create_task_node(
+                state_name, state, flow, recorder, config, log_dir, quiet
+            )
             graph.add_node(
                 state_name,
-                _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    node,
+                    state_name,
+                    on_start,
+                    on_complete,
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
             on_start, on_complete = _collect_state_hooks(state)
             node = _create_choice_node(state_name, state, flow, recorder)
             graph.add_node(
                 state_name,
-                _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    node,
+                    state_name,
+                    on_start,
+                    on_complete,
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
         elif isinstance(state, ParallelState):
             on_start, on_complete = _collect_state_hooks(state)
@@ -270,23 +288,46 @@ def compile_flow(
             dispatch_node = _create_dispatch_node(state_name, state, recorder)
             graph.add_node(
                 state_name,
-                _wrap_with_hooks(dispatch_node, state_name, on_start, [], recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    dispatch_node,
+                    state_name,
+                    on_start,
+                    [],
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
             graph.add_node(
                 f"_branch_{state_name}",
-                _create_branch_executor(state_name, state, flow, recorder, config, log_dir, quiet),
+                _create_branch_executor(
+                    state_name, state, flow, recorder, config, log_dir, quiet
+                ),
             )  # type: ignore[call-overload]
             collector_node = _create_collector_node(state_name, state, flow, recorder)
             graph.add_node(
                 f"_collect_{state_name}",
-                _wrap_with_hooks(collector_node, state_name, [], on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    collector_node,
+                    state_name,
+                    [],
+                    on_complete,
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
         elif state.type == "pass":
             on_start, on_complete = _collect_state_hooks(state)
             node = _create_pass_node(state_name, state, flow, recorder)
             graph.add_node(
                 state_name,
-                _wrap_with_hooks(node, state_name, on_start, on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    node,
+                    state_name,
+                    on_start,
+                    on_complete,
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
         elif state.type == "wait":
             on_start, on_complete = _collect_state_hooks(state)
@@ -295,12 +336,26 @@ def compile_flow(
             notify_node = _create_wait_notify_node(state_name, state, recorder)
             graph.add_node(
                 state_name,
-                _wrap_with_hooks(notify_node, state_name, on_start, [], recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    notify_node,
+                    state_name,
+                    on_start,
+                    [],
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
             interrupt_node = _create_wait_interrupt_node(state_name, state, recorder)
             graph.add_node(
                 f"_{state_name}_int",
-                _wrap_with_hooks(interrupt_node, state_name, [], on_complete, recorder=recorder, fdsx_base_dir=fdsx_base_dir),
+                _wrap_with_hooks(
+                    interrupt_node,
+                    state_name,
+                    [],
+                    on_complete,
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
             )  # type: ignore[call-overload]
             graph.add_edge(state_name, f"_{state_name}_int")
 
@@ -459,7 +514,9 @@ def _wrap_with_hooks(
             )
 
         node_error: BaseException | None = None
-        result: dict[str, Any] = state_dict  # fallback data written to output.json on failure
+        result: dict[str, Any] = (
+            state_dict  # fallback data written to output.json on failure
+        )
         try:
             result = node_fn(state_dict)
         except BaseException as exc:
@@ -509,7 +566,9 @@ def _create_task_node(
     quiet: bool = False,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Task state."""
-    merged_options = _merge_provider_options(config, flow, state.provider, state.provider_options)
+    merged_options = _merge_provider_options(
+        config, flow, state.provider, state.provider_options
+    )
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         from fdsx.core.extraction import extract_value
@@ -617,7 +676,9 @@ def _create_task_node(
             run_dir = state_dict.get("_meta", {}).get("run_dir", "")
             if run_dir:
                 varname = state.result_file[2:]  # strip "$."
-                file_path = write_result_to_file(varname, result.stdout.strip(), Path(run_dir))
+                file_path = write_result_to_file(
+                    varname, result.stdout.strip(), Path(run_dir)
+                )
                 new_state = set_jsonpath(state.result_file, new_state, file_path)
                 variables_set = [*variables_set, state.result_file]
 
@@ -706,7 +767,9 @@ def _create_branch_executor(
         prompt = branch.prompt_template or ""
         resolved_prompt = resolve_template(prompt, state_dict)
 
-        merged_options = _merge_provider_options(config, flow, branch.provider, branch.provider_options)
+        merged_options = _merge_provider_options(
+            config, flow, branch.provider, branch.provider_options
+        )
         provider = get_provider(branch.provider, merged_options)
 
         max_retries = branch.retry if branch.retry is not None else 3

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -100,7 +100,9 @@ def run_flow(
         flow_version=flow.version,
     )
 
-    fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
+    fdsx_config = load_config(
+        project_dir=base_dir.parent if base_dir is not None else None
+    )
 
     _runs_base = base_dir if base_dir is not None else Path.cwd() / FDSX_DIR_NAME
     run_dir = _runs_base / RUNS_DIR_NAME / thread_id
@@ -477,7 +479,9 @@ def resume_flow(
             flow_version=flow_version,
         )
 
-        fdsx_config = load_config(project_dir=base_dir.parent if base_dir is not None else None)
+        fdsx_config = load_config(
+            project_dir=base_dir.parent if base_dir is not None else None
+        )
 
         resume_run_dir = base_dir / RUNS_DIR_NAME / thread_id
         resume_log_dir = resume_run_dir / LOGS_DIR_NAME
@@ -505,9 +509,7 @@ def resume_flow(
         }
 
         state_info = compiled.graph.get_state(resume_config)
-        existing_meta = (
-            state_info.values.get("_meta", {}) if state_info.values else {}
-        )
+        existing_meta = state_info.values.get("_meta", {}) if state_info.values else {}
         if "run_dir" not in existing_meta:
             updated_meta = {**existing_meta, "run_dir": str(resume_run_dir)}
             compiled.graph.update_state(resume_config, {"_meta": updated_meta})
@@ -770,20 +772,17 @@ def run_tasks_dir(
                 try:
                     resolved_wf = wf_path.resolve()
                     wf_dir_resolved = workflows_dir.resolve()
-                    if not str(resolved_wf).startswith(
-                        str(wf_dir_resolved) + "/"
-                    ) and resolved_wf != wf_dir_resolved:
+                    if (
+                        not str(resolved_wf).startswith(str(wf_dir_resolved) + "/")
+                        and resolved_wf != wf_dir_resolved
+                    ):
                         raise ValueError(
                             f"Workflow path escapes workflows directory: {entry.workflow}"
                         )
                 except OSError:
-                    raise ValueError(
-                        f"Cannot resolve workflow path: {entry.workflow}"
-                    )
+                    raise ValueError(f"Cannot resolve workflow path: {entry.workflow}")
                 if wf_path.is_symlink():
-                    raise ValueError(
-                        f"Workflow path must not be a symlink: {wf_path}"
-                    )
+                    raise ValueError(f"Workflow path must not be a symlink: {wf_path}")
                 if wf_path.is_dir():
                     wf_file = wf_path / "workflow.yaml"
                     if not wf_file.exists():

--- a/src/fdsx/core/hooks.py
+++ b/src/fdsx/core/hooks.py
@@ -142,7 +142,10 @@ def write_hook_data(
     base_runs_dir = (fdsx_dir / RUNS_DIR_NAME).resolve()
     expected_hooks_base = (base_runs_dir / thread_id / HOOKS_DIR_NAME).resolve()
     hooks_dir = (expected_hooks_base / state_name).resolve()
-    if not str(hooks_dir).startswith(str(expected_hooks_base) + os.sep) and hooks_dir != expected_hooks_base:
+    if (
+        not str(hooks_dir).startswith(str(expected_hooks_base) + os.sep)
+        and hooks_dir != expected_hooks_base
+    ):
         raise ValueError(
             "Invalid thread_id or state_name: path resolved outside runs directory"
         )

--- a/src/fdsx/core/selector.py
+++ b/src/fdsx/core/selector.py
@@ -269,13 +269,13 @@ def select_workflow(
     # match inside "review-code").
     matches: list[Path] = []
     for wf_path, _, display_name in workflows:
-        pattern = r'(?:^|\s)' + re.escape(display_name) + r'(?:$|\s)'
+        pattern = r"(?:^|\s)" + re.escape(display_name) + r"(?:$|\s)"
         if re.search(pattern, selected_name):
             if wf_path not in matches:
                 matches.append(wf_path)
     if not matches:
         for wf_path, _, display_name in workflows:
-            pattern = r'(?:^|\s)' + re.escape(wf_path.name) + r'(?:$|\s)'
+            pattern = r"(?:^|\s)" + re.escape(wf_path.name) + r"(?:$|\s)"
             if re.search(pattern, selected_name):
                 if wf_path not in matches:
                     matches.append(wf_path)
@@ -406,7 +406,9 @@ def resolve_workflow_for_task(
             selected_display_name = dn
             break
 
-    approved = confirm_workflow_selection(selected, task_description, display_name=selected_display_name)
+    approved = confirm_workflow_selection(
+        selected, task_description, display_name=selected_display_name
+    )
     if approved:
         return selected
 

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -520,9 +520,7 @@ def confirm_workflow_assignments_interactive(
             entry = task_file.entries[entry_idx]
             wf_path = assignments.get(key)
             wf_name = (
-                wf_display_map.get(wf_path, wf_path.name)
-                if wf_path
-                else "(unassigned)"
+                wf_display_map.get(wf_path, wf_path.name) if wf_path else "(unassigned)"
             )
 
             file_name = file_path.name[:29]
@@ -663,12 +661,12 @@ def display_resume_command(
     stream.write(border + "\n")
     if mode == "single-flow":
         stream.write(f"|{padding}|\n")
-        stream.write(f"|  To resume this flow, run:\n")
+        stream.write("|  To resume this flow, run:\n")
         stream.write(f"|  $ {command}\n")
         stream.write(f"|{padding}|\n")
     else:
         stream.write(f"|{padding}|\n")
-        stream.write(f"|  To continue processing, run:\n")
+        stream.write("|  To continue processing, run:\n")
         stream.write(f"|  $ {command}\n")
         stream.write(f"|{padding}|\n")
     stream.write(border + "\n")

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -244,8 +244,7 @@ def _validate_result_file(v: str | None) -> str | None:
         return v
     if not v.startswith("$."):
         raise ValueError(
-            f"result_file must start with '$.' (got '{v}'). "
-            "Example: '$.plan_ref'"
+            f"result_file must start with '$.' (got '{v}'). Example: '$.plan_ref'"
         )
     remainder = v[2:]
     if not remainder or not remainder.strip():

--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -59,15 +59,13 @@ class TaskEntry(BaseModel):
     def validate_workflow_filename(cls, v: str | None) -> str | None:
         if v is None:
             return v
+        if "\\" in v or v in {".", ".."}:
+            raise ValueError(f"workflow must be a relative path without .., got '{v}'")
         parts = Path(v).parts
         if ".." in parts or v.startswith("/") or v.startswith("\\"):
-            raise ValueError(
-                f"workflow must be a relative path without .., got '{v}'"
-            )
+            raise ValueError(f"workflow must be a relative path without .., got '{v}'")
         if len(parts) > 2:
-            raise ValueError(
-                f"workflow nesting too deep (max 1 level), got '{v}'"
-            )
+            raise ValueError(f"workflow nesting too deep (max 1 level), got '{v}'")
         return v
 
 
@@ -83,6 +81,25 @@ class TaskFile(BaseModel):
         default_factory=list,
         description="List of task entries in this file",
     )
+
+
+_ALLOWED_SYSTEM_SYMLINK_ANCESTORS = {
+    Path("/var"),
+    Path("/tmp"),
+}
+
+
+def _ensure_no_symlink_ancestors(path: Path, *, include_self: bool) -> None:
+    """Reject user-controlled symlink ancestors while allowing known system aliases."""
+    current = path.absolute() if include_self else path.absolute().parent
+    while current != current.parent:
+        if (
+            current.exists()
+            and current.is_symlink()
+            and current not in _ALLOWED_SYSTEM_SYMLINK_ANCESTORS
+        ):
+            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
+        current = current.parent
 
 
 def load_task_file(path: Path) -> TaskFile:
@@ -108,9 +125,7 @@ def load_task_file(path: Path) -> TaskFile:
         fd = os.open(str(path), open_flags)
     except OSError as e:
         if e.errno == errno.ELOOP:
-            raise ValueError(
-                f"Refusing to read task file: {path} is a symlink"
-            ) from e
+            raise ValueError(f"Refusing to read task file: {path} is a symlink") from e
         raise
     try:
         data = os.read(fd, os.fstat(fd).st_size)
@@ -169,13 +184,9 @@ def save_task_file(path: Path, task_file: TaskFile) -> None:
         path: Destination path.
         task_file: TaskFile to serialize.
     """
-    # Walk every existing ancestor to reject any symlinked directory before
-    # creating any directories. Non-existent ancestors cannot be symlinks.
-    current = path.parent
-    while current != current.parent:
-        if current.exists() and current.is_symlink():
-            raise ValueError(f"Refusing to write: ancestor is a symlink: {current}")
-        current = current.parent
+    # Reject user-controlled symlink ancestors before creating any directories.
+    # Allow the platform temp aliases used on macOS (/var, /tmp).
+    _ensure_no_symlink_ancestors(path, include_self=False)
 
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
 

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -62,6 +63,7 @@ def _run_subprocess(
     stdin_data: str | None = None,
     shell: bool = False,
     completion_event: threading.Event | None = None,
+    env: dict[str, str] | None = None,
 ) -> ProviderResult:
     """Shared subprocess execution helper for all providers.
 
@@ -78,6 +80,8 @@ def _run_subprocess(
             subprocess stream protocol. When set, initiates an escalating
             termination cascade: wait 5s for voluntary exit → SIGTERM →
             wait 5s → SIGKILL. Collected data is preserved in the result.
+        env: Optional extra environment variables. Merged with os.environ
+            so the subprocess inherits the full environment.
 
     Returns:
         ProviderResult with exit code and output.
@@ -98,6 +102,7 @@ def _run_subprocess(
         cmd = args
 
     try:
+        proc_env = {**os.environ, **env} if env else None
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE if stdin_data is not None else None,
@@ -105,6 +110,7 @@ def _run_subprocess(
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
+            env=proc_env,
         )
 
         killed_by_timeout = False

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -5,7 +5,12 @@ from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
+from fdsx.providers.base import (
+    ARG_MAX_STDIN_THRESHOLD,
+    ProviderBase,
+    ProviderResult,
+    _run_subprocess,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +19,12 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 # CLI flags added to enable stream-json output when output_callback is provided
-_STREAM_FORMAT_FLAGS = ["--output-format", "stream-json", "--verbose", "--include-partial-messages"]
+_STREAM_FORMAT_FLAGS = [
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--include-partial-messages",
+]
 
 # NDJSON event type strings
 _EVENT_CONTENT_BLOCK_START = "content_block_start"
@@ -35,7 +45,12 @@ class ClaudeOptions(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    permission_mode: Literal["default", "acceptEdits", "bypassPermissions", "dontAsk", "plan", "auto"] | None = None
+    permission_mode: (
+        Literal[
+            "default", "acceptEdits", "bypassPermissions", "dontAsk", "plan", "auto"
+        ]
+        | None
+    ) = None
     dangerously_skip_permissions: bool = False
     allowed_tools: list[str] = []
     disallowed_tools: list[str] = []
@@ -58,7 +73,9 @@ class ClaudeProvider(ProviderBase):
     """Claude provider - executes Claude CLI."""
 
     def __init__(self, options: ClaudeOptions | None = None) -> None:
-        self.options: ClaudeOptions = options if options is not None else ClaudeOptions()
+        self.options: ClaudeOptions = (
+            options if options is not None else ClaudeOptions()
+        )
 
     def _make_stream_callback(
         self,
@@ -232,7 +249,9 @@ class ClaudeProvider(ProviderBase):
         if output_callback is not None:
             args.extend(_STREAM_FORMAT_FLAGS)
             completion_event = threading.Event()
-            stream_callback, get_result, flush = self._make_stream_callback(output_callback, completion_event)
+            stream_callback, get_result, flush = self._make_stream_callback(
+                output_callback, completion_event
+            )
             result = _run_subprocess(
                 args=args,
                 timeout=timeout,

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -4,7 +4,12 @@ from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
+from fdsx.providers.base import (
+    ARG_MAX_STDIN_THRESHOLD,
+    ProviderBase,
+    ProviderResult,
+    _run_subprocess,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +132,9 @@ class CodexProvider(ProviderBase):
                 logger.warning("turn.failed event received: %s", event.get("error", ""))
 
             elif event_type == _EVENT_ERROR:
-                logger.warning("Codex error event: %s", event.get("message", str(event)))
+                logger.warning(
+                    "Codex error event: %s", event.get("message", str(event))
+                )
 
         def get_result() -> str | None:
             if agent_message_parts:

--- a/src/fdsx/providers/opencode.py
+++ b/src/fdsx/providers/opencode.py
@@ -1,8 +1,14 @@
-from typing import Callable
+import json
+from typing import Any, Callable
 
 from pydantic import BaseModel, ConfigDict
 
-from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderBase, ProviderResult, _run_subprocess
+from fdsx.providers.base import (
+    ARG_MAX_STDIN_THRESHOLD,
+    ProviderBase,
+    ProviderResult,
+    _run_subprocess,
+)
 
 
 class OpenCodeOptions(BaseModel):
@@ -10,16 +16,27 @@ class OpenCodeOptions(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    permission: str | dict[str, Any] | None = None
+
     def to_cli_flags(self) -> list[str]:
         """Translate options to OpenCode CLI flags (none currently defined)."""
         return []
+
+    def to_env(self) -> dict[str, str]:
+        """Build extra environment variables for the OpenCode subprocess."""
+        if self.permission is None:
+            return {}
+        config = {"permission": self.permission}
+        return {"OPENCODE_CONFIG_CONTENT": json.dumps(config)}
 
 
 class OpenCodeProvider(ProviderBase):
     """OpenCode provider - executes OpenCode CLI."""
 
     def __init__(self, options: OpenCodeOptions | None = None) -> None:
-        self.options: OpenCodeOptions = options if options is not None else OpenCodeOptions()
+        self.options: OpenCodeOptions = (
+            options if options is not None else OpenCodeOptions()
+        )
 
     def execute(
         self,
@@ -54,10 +71,13 @@ class OpenCodeProvider(ProviderBase):
             args.append(prompt)
             stdin_data = None
 
+        env = self.options.to_env() or None
+
         return _run_subprocess(
             args=args,
             timeout=timeout,
             output_callback=output_callback,
             stderr_callback=stderr_callback,
             stdin_data=stdin_data,
+            env=env,
         )

--- a/tests/integration/cli_test_utils.py
+++ b/tests/integration/cli_test_utils.py
@@ -1,0 +1,43 @@
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Sequence
+
+
+FIXTURES_DIR = Path(__file__).resolve().parent.parent / "fixtures"
+
+
+def fixture_path(*parts: str) -> str:
+    """Return an absolute path under tests/fixtures/."""
+    return str(FIXTURES_DIR.joinpath(*parts).resolve())
+
+
+def run_fdsx(
+    args: Sequence[str],
+    *,
+    cwd: str | Path | None = None,
+    input: str | None = None,
+    timeout: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the CLI from an isolated working directory unless one is supplied."""
+    command = [sys.executable, "-m", "fdsx.cli.main", *args]
+    if cwd is not None:
+        return subprocess.run(
+            command,
+            cwd=cwd,
+            input=input,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        return subprocess.run(
+            command,
+            cwd=tmp_dir,
+            input=input,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -1,5 +1,3 @@
-import subprocess
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -8,6 +6,7 @@ import pytest
 
 from fdsx.core import engine
 from fdsx.core.config import FdsxConfig, TaskSplitterConfig
+from tests.integration.cli_test_utils import fixture_path, run_fdsx
 
 
 class TestBatchExecution:
@@ -23,9 +22,14 @@ class TestBatchExecution:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
                 with patch("fdsx.core.engine.display_task_list", return_value=True):
-                    with patch("fdsx.core.engine.run_flow", return_value={"result": "ok"}):
+                    with patch(
+                        "fdsx.core.engine.run_flow", return_value={"result": "ok"}
+                    ):
                         with tempfile.TemporaryDirectory() as tmpdir:
                             base_dir = Path(tmpdir)
                             results = engine.run_batch(flow_path, tasks_file, base_dir)
@@ -52,7 +56,10 @@ class TestBatchExecution:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
                 with patch("fdsx.core.engine.display_task_list", return_value=False):
                     with tempfile.TemporaryDirectory() as tmpdir:
                         base_dir = Path(tmpdir)
@@ -65,27 +72,24 @@ class TestBatchExecution:
         flow_path = Path("tests/fixtures/batch_flow.yaml")
         tasks_file = Path("tests/fixtures/sample_tasks.md")
 
-        with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=None)):
+        with patch(
+            "fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=None)
+        ):
             with tempfile.TemporaryDirectory() as tmpdir:
                 base_dir = Path(tmpdir)
                 with pytest.raises(engine.FlowValidationError, match="task_splitter"):
                     engine.run_batch(flow_path, tasks_file, base_dir)
 
     def test_mutual_exclusion_validation(self):
-        result = subprocess.run(
+        result = run_fdsx(
             [
-                sys.executable,
-                "-m",
-                "fdsx.cli.main",
                 "run",
-                "tests/fixtures/batch_flow.yaml",
+                fixture_path("batch_flow.yaml"),
                 "--input",
                 "foo=bar",
                 "--tasks",
-                "tests/fixtures/sample_tasks.md",
-            ],
-            capture_output=True,
-            text=True,
+                fixture_path("sample_tasks.md"),
+            ]
         )
 
         assert result.returncode == 2
@@ -113,13 +117,20 @@ class TestBatchIntegrationWithMockedInput:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
                 with patch("fdsx.core.engine.display_task_list", return_value=True):
                     with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                         with tempfile.TemporaryDirectory() as tmpdir:
                             base_dir = Path(tmpdir)
-                            with patch("fdsx.core.engine.input", side_effect=["y", "y"]):
-                                results = engine.run_batch(flow_path, tasks_file, base_dir)
+                            with patch(
+                                "fdsx.core.engine.input", side_effect=["y", "y"]
+                            ):
+                                results = engine.run_batch(
+                                    flow_path, tasks_file, base_dir
+                                )
 
         assert len(results) == 3
 
@@ -143,13 +154,18 @@ class TestBatchIntegrationWithMockedInput:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
                 with patch("fdsx.core.engine.display_task_list", return_value=True):
                     with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                         with tempfile.TemporaryDirectory() as tmpdir:
                             base_dir = Path(tmpdir)
                             with patch("fdsx.core.engine.input", side_effect=["n"]):
-                                results = engine.run_batch(flow_path, tasks_file, base_dir)
+                                results = engine.run_batch(
+                                    flow_path, tasks_file, base_dir
+                                )
 
         assert len(results) == 2
 
@@ -167,12 +183,17 @@ class TestBatchQuietFlagPropagation:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
                 with patch("fdsx.core.engine.display_task_list", return_value=True):
                     with patch("fdsx.core.engine.run_flow") as mock_run_flow:
                         with tempfile.TemporaryDirectory() as tmpdir:
                             base_dir = Path(tmpdir)
-                            engine.run_batch(flow_path, tasks_file, base_dir, quiet=True)
+                            engine.run_batch(
+                                flow_path, tasks_file, base_dir, quiet=True
+                            )
 
         assert mock_run_flow.called
         for call_args in mock_run_flow.call_args_list:
@@ -190,7 +211,10 @@ class TestBatchQuietFlagPropagation:
         )
 
         with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
-            with patch("fdsx.core.engine.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
                 with patch("fdsx.core.engine.display_task_list", return_value=True):
                     with patch("fdsx.core.engine.run_flow") as mock_run_flow:
                         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/integration/test_choice_flow.py
+++ b/tests/integration/test_choice_flow.py
@@ -5,40 +5,40 @@ from fdsx.core.loader import load_flow
 
 
 class TestChoiceFlow:
-    def test_choice_flow_matches_first_rule(self):
+    def test_choice_flow_matches_first_rule(self, tmp_path):
         path = Path("tests/fixtures/choice_flow.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "status" in result
 
-    def test_choice_flow_explicit_status(self):
+    def test_choice_flow_explicit_status(self, tmp_path):
         path = Path("tests/fixtures/choice_flow.yaml")
 
-        result = run_flow(path, inputs={"initial_status": "ready"})
+        result = run_flow(path, inputs={"initial_status": "ready"}, base_dir=tmp_path)
 
         assert "status" in result
 
-    def test_choice_flow_strips_stdout_newline(self):
+    def test_choice_flow_strips_stdout_newline(self, tmp_path):
         path = Path("tests/fixtures/choice_flow.yaml")
 
-        result = run_flow(path, inputs={"initial_status": "ready"})
+        result = run_flow(path, inputs={"initial_status": "ready"}, base_dir=tmp_path)
 
         assert result["status"] == "ready"
         assert "proceed_result" in result
         assert result["proceed_result"] == "Proceeding with execution"
 
-    def test_choice_flow_default_branch(self):
+    def test_choice_flow_default_branch(self, tmp_path):
         """Test that the default branch is taken when no rule matches."""
         path = Path("tests/fixtures/choice_flow_default.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "status" in result
         assert result["status"] == "unknown_status"

--- a/tests/integration/test_claude_streaming.py
+++ b/tests/integration/test_claude_streaming.py
@@ -11,7 +11,6 @@ fixture to verify:
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from fdsx.providers.base import ProviderResult
 from fdsx.providers.claude import ClaudeProvider, _STREAM_FORMAT_FLAGS
@@ -24,14 +23,27 @@ FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "claude_stream.ndjson
 
 # Expected values derived from the fixture file
 FIXTURE_RESULT_TEXT = "Hello! Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"
-FIXTURE_TEXT_DELTAS = ["Hello", "! Here are 3 items:\n\n", "1. Apple\n2. Banana\n3. Cherry"]
+FIXTURE_TEXT_DELTAS = [
+    "Hello",
+    "! Here are 3 items:\n\n",
+    "1. Apple\n2. Banana\n3. Cherry",
+]
 # After line buffering, fragments are combined and split at newlines
-FIXTURE_BUFFERED_LINES = ["Hello! Here are 3 items:", "1. Apple", "2. Banana", "3. Cherry"]
+FIXTURE_BUFFERED_LINES = [
+    "Hello! Here are 3 items:",
+    "1. Apple",
+    "2. Banana",
+    "3. Cherry",
+]
 
 
 def _load_fixture_lines() -> list[str]:
     """Return non-empty NDJSON lines from the fixture file."""
-    return [line.rstrip("\n") for line in FIXTURE_PATH.read_text().splitlines() if line.strip()]
+    return [
+        line.rstrip("\n")
+        for line in FIXTURE_PATH.read_text().splitlines()
+        if line.strip()
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -39,7 +51,9 @@ def _load_fixture_lines() -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _fake_run_subprocess_factory(fixture_lines: list[str], exit_code: int = 0) -> MagicMock:
+def _fake_run_subprocess_factory(
+    fixture_lines: list[str], exit_code: int = 0
+) -> MagicMock:
     """Return a mock for _run_subprocess that replays fixture lines via output_callback."""
 
     def fake_run_subprocess(**kwargs: object) -> ProviderResult:
@@ -74,7 +88,9 @@ class TestClaudeStreamingEndToEnd:
         """ProviderResult.stdout must match the result event text, not raw NDJSON."""
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.claude._run_subprocess", mock_run):
-            result = self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+            result = self.provider.execute(
+                "Say hello and list 3 items", output_callback=lambda _: None
+            )
 
         assert result.stdout == FIXTURE_RESULT_TEXT
 
@@ -83,7 +99,9 @@ class TestClaudeStreamingEndToEnd:
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.claude._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=received.append
+            )
 
         # Fragments are buffered and emitted as complete lines
         assert received == FIXTURE_BUFFERED_LINES
@@ -93,7 +111,9 @@ class TestClaudeStreamingEndToEnd:
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.claude._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=received.append
+            )
 
         for item in received:
             assert not item.strip().startswith("{"), (
@@ -104,7 +124,9 @@ class TestClaudeStreamingEndToEnd:
         """_run_subprocess must be called with stream-json CLI flags."""
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.claude._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=lambda _: None
+            )
 
         mock_run.assert_called_once()
         called_args: list[str] = mock_run.call_args.kwargs["args"]
@@ -114,13 +136,17 @@ class TestClaudeStreamingEndToEnd:
     def test_no_streaming_flags_without_callback(self) -> None:
         """Without output_callback, _run_subprocess must NOT receive stream-json flags."""
         fake_result = ProviderResult(exit_code=0, stdout="plain response", stderr="")
-        with patch("fdsx.providers.claude._run_subprocess", return_value=fake_result) as mock_run:
+        with patch(
+            "fdsx.providers.claude._run_subprocess", return_value=fake_result
+        ) as mock_run:
             result = self.provider.execute("Say hello")
 
         mock_run.assert_called_once()
         called_args: list[str] = mock_run.call_args.kwargs["args"]
         for flag in _STREAM_FORMAT_FLAGS:
-            assert flag not in called_args, f"Unexpected streaming flag found in args: {flag!r}"
+            assert flag not in called_args, (
+                f"Unexpected streaming flag found in args: {flag!r}"
+            )
         assert result.stdout == "plain response"
 
     def test_exit_code_preserved(self) -> None:
@@ -135,8 +161,10 @@ class TestClaudeStreamingEndToEnd:
         """When no result event in stream, stdout falls back to concatenated text_delta."""
         # Only feed text_delta lines (no result event)
         delta_only_lines = [
-            line for line in self.fixture_lines
-            if '"type":"content_block_delta"' in line or '"type": "content_block_delta"' in line
+            line
+            for line in self.fixture_lines
+            if '"type":"content_block_delta"' in line
+            or '"type": "content_block_delta"' in line
         ]
         mock_run = _fake_run_subprocess_factory(delta_only_lines)
         with patch("fdsx.providers.claude._run_subprocess", mock_run):

--- a/tests/integration/test_cli_e2e.py
+++ b/tests/integration/test_cli_e2e.py
@@ -1,48 +1,21 @@
-import subprocess
-
-
-def get_fdsx_command():
-    """Get the fdsx command using uv to exercise the entry point."""
-    return ["uv", "run", "fdsx"]
+from tests.integration.cli_test_utils import fixture_path, run_fdsx
 
 
 class TestCLIE2E:
     def test_validate_valid_flow(self):
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "validate",
-                "tests/fixtures/simple_flow.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["validate", fixture_path("simple_flow.yaml")])
         assert result.returncode == 0
 
     def test_validate_invalid_flow(self):
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "validate",
-                "tests/fixtures/invalid_flows/missing_start_at.yaml",
-            ],
-            capture_output=True,
-            text=True,
+        result = run_fdsx(
+            ["validate", fixture_path("invalid_flows", "missing_start_at.yaml")]
         )
         assert result.returncode == 2
         assert result.stderr, "Expected error message on stderr"
         assert len(result.stderr.strip()) > 0
 
     def test_run_simple_flow(self):
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/simple_flow.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["run", fixture_path("simple_flow.yaml")])
         assert result.returncode == 0
         # FR-1.3: No JSON on stdout
         assert result.stdout == ""
@@ -50,16 +23,8 @@ class TestCLIE2E:
         assert "completed successfully" in result.stderr
 
     def test_run_with_input(self):
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/simple_flow.yaml",
-                "--input",
-                "task=hello",
-            ],
-            capture_output=True,
-            text=True,
+        result = run_fdsx(
+            ["run", fixture_path("simple_flow.yaml"), "--input", "task=hello"]
         )
         assert result.returncode == 0
         # FR-1.3: No JSON on stdout
@@ -69,16 +34,8 @@ class TestCLIE2E:
 
     def test_run_with_input_uses_value(self):
         """R2-F4: --input value must be consumed; workflow completes successfully."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/input_flow.yaml",
-                "--input",
-                "task=world",
-            ],
-            capture_output=True,
-            text=True,
+        result = run_fdsx(
+            ["run", fixture_path("input_flow.yaml"), "--input", "task=world"]
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
         # FR-1.3: No JSON on stdout
@@ -87,13 +44,7 @@ class TestCLIE2E:
         assert "completed successfully" in result.stderr
 
     def test_run_with_invalid_flow_returns_exit_code_2(self):
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/invalid_flows/missing_start_at.yaml",
-            ],
-            capture_output=True,
-            text=True,
+        result = run_fdsx(
+            ["run", fixture_path("invalid_flows", "missing_start_at.yaml")]
         )
         assert result.returncode == 2

--- a/tests/integration/test_cli_e2e_phase2.py
+++ b/tests/integration/test_cli_e2e_phase2.py
@@ -1,9 +1,4 @@
-import subprocess
-
-
-def get_fdsx_command():
-    """Get the fdsx command using uv to exercise the entry point."""
-    return ["uv", "run", "fdsx"]
+from tests.integration.cli_test_utils import fixture_path, run_fdsx
 
 
 class TestCLIE2EPhase2:
@@ -11,28 +6,12 @@ class TestCLIE2EPhase2:
 
     def test_parallel_review_yaml_validates(self):
         """Test parallel_review.yaml validates successfully."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "validate",
-                "tests/fixtures/parallel_review.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["validate", fixture_path("parallel_review.yaml")])
         assert result.returncode == 0
 
     def test_parallel_review_yaml_runs(self):
         """Test parallel_review.yaml runs successfully via CLI."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/parallel_review.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["run", fixture_path("parallel_review.yaml")])
         assert result.returncode == 0, f"stderr: {result.stderr}"
         # FR-1.3: No JSON on stdout
         assert result.stdout == ""
@@ -41,28 +20,12 @@ class TestCLIE2EPhase2:
 
     def test_extraction_flow_yaml_validates(self):
         """Test extraction_flow.yaml validates successfully."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "validate",
-                "tests/fixtures/extraction_flow.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["validate", fixture_path("extraction_flow.yaml")])
         assert result.returncode == 0
 
     def test_extraction_flow_yaml_runs(self):
         """Test extraction_flow.yaml runs successfully via CLI."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/extraction_flow.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["run", fixture_path("extraction_flow.yaml")])
         assert result.returncode == 0, f"stderr: {result.stderr}"
         # FR-1.3: No JSON on stdout
         assert result.stdout == ""
@@ -71,28 +34,12 @@ class TestCLIE2EPhase2:
 
     def test_loop_flow_yaml_validates(self):
         """Test loop_flow.yaml validates successfully."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "validate",
-                "tests/fixtures/loop_flow.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["validate", fixture_path("loop_flow.yaml")])
         assert result.returncode == 0
 
     def test_loop_flow_yaml_runs(self):
         """Test loop_flow.yaml runs successfully via CLI with loop behavior."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/loop_flow.yaml",
-            ],
-            capture_output=True,
-            text=True,
-        )
+        result = run_fdsx(["run", fixture_path("loop_flow.yaml")])
         assert result.returncode == 0, f"stderr: {result.stderr}"
         # FR-1.3: No JSON on stdout
         assert result.stdout == ""

--- a/tests/integration/test_cli_e2e_phase3.py
+++ b/tests/integration/test_cli_e2e_phase3.py
@@ -1,11 +1,7 @@
-import subprocess
 import tempfile
 from pathlib import Path
 
-
-def get_fdsx_command():
-    """Get the fdsx command using uv to exercise the entry point."""
-    return ["uv", "run", "fdsx"]
+from tests.integration.cli_test_utils import fixture_path, run_fdsx
 
 
 class TestCLIE2EPhase3:
@@ -13,15 +9,9 @@ class TestCLIE2EPhase3:
 
     def test_wait_state_flow_with_stdin_selection(self):
         """Test fdsx run with Wait state flow - provide input via stdin."""
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
-                "run",
-                "tests/fixtures/wait_approval.yaml",
-            ],
+        result = run_fdsx(
+            ["run", fixture_path("wait_approval.yaml")],
             input="1\n",
-            capture_output=True,
-            text=True,
             timeout=30,
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -33,16 +23,14 @@ class TestCLIE2EPhase3:
     def test_resume_interrupted_flow(self):
         """Test fdsx resume --thread-id with previously interrupted flow."""
         with tempfile.TemporaryDirectory() as tmp_dir:
-            flow_path = str(Path("tests/fixtures/wait_approval.yaml").resolve())
+            flow_path = fixture_path("wait_approval.yaml")
             thread_id = "test-resume-interrupted"
             base_dir = str(Path(tmp_dir) / ".fdsx")
 
-            first_run = subprocess.run(
-                get_fdsx_command() + ["run", flow_path, "--thread-id", thread_id],
+            first_run = run_fdsx(
+                ["run", flow_path, "--thread-id", thread_id],
                 input="",
                 cwd=tmp_dir,
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert first_run.returncode == 1, (
@@ -50,9 +38,8 @@ class TestCLIE2EPhase3:
             )
             assert "Checkpoint saved" in first_run.stderr
 
-            resume_result = subprocess.run(
-                get_fdsx_command()
-                + [
+            resume_result = run_fdsx(
+                [
                     "resume",
                     "--thread-id",
                     thread_id,
@@ -61,8 +48,6 @@ class TestCLIE2EPhase3:
                 ],
                 input="1\n",
                 cwd=tmp_dir,
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert resume_result.returncode == 0, f"stderr: {resume_result.stderr}"
@@ -76,17 +61,14 @@ class TestCLIE2EPhase3:
         with tempfile.TemporaryDirectory() as tmp_dir:
             base_dir = Path(tmp_dir) / ".fdsx"
 
-            result = subprocess.run(
-                get_fdsx_command()
-                + [
+            result = run_fdsx(
+                [
                     "resume",
                     "--thread-id",
                     "nonexistent-thread-id-12345",
                     "--base-dir",
                     str(base_dir),
                 ],
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert result.returncode == 2, (
@@ -99,33 +81,27 @@ class TestCLIE2EPhase3:
         with tempfile.TemporaryDirectory() as tmp_dir:
             base_dir = Path(tmp_dir) / ".fdsx"
             thread_id = "test-list-thread"
-            flow_path = Path("tests/fixtures/simple_flow.yaml").resolve()
+            flow_path = fixture_path("simple_flow.yaml")
 
-            run_result = subprocess.run(
-                get_fdsx_command()
-                + [
+            run_result = run_fdsx(
+                [
                     "run",
-                    str(flow_path),
+                    flow_path,
                     "--thread-id",
                     thread_id,
                 ],
                 cwd=tmp_dir,
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert run_result.returncode == 0, f"stderr: {run_result.stderr}"
 
-            list_result = subprocess.run(
-                get_fdsx_command()
-                + [
+            list_result = run_fdsx(
+                [
                     "list",
                     "--base-dir",
                     str(base_dir),
                 ],
                 cwd=tmp_dir,
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert list_result.returncode == 0, f"stderr: {list_result.stderr}"
@@ -141,16 +117,13 @@ class TestCLIE2EPhase3:
         with tempfile.TemporaryDirectory() as tmp_dir:
             base_dir = Path(tmp_dir) / ".fdsx"
 
-            result = subprocess.run(
-                get_fdsx_command()
-                + [
+            result = run_fdsx(
+                [
                     "list",
                     "--base-dir",
                     str(base_dir),
                 ],
                 cwd=tmp_dir,
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -179,12 +152,7 @@ class TestCLIE2EPhase3:
                 "    end: true\n"
             )
 
-            result = subprocess.run(
-                get_fdsx_command() + ["validate", str(flow_path)],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+            result = run_fdsx(["validate", str(flow_path)], timeout=30)
             assert result.returncode == 0, (
                 f"Expected exit 0 (prompt_file loaded from disk), got {result.returncode}. "
                 f"stderr: {result.stderr}"
@@ -211,11 +179,9 @@ class TestCLIE2EPhase3:
                 "    end: true\n"
             )
 
-            result = subprocess.run(
-                get_fdsx_command() + ["run", str(flow_path)],
+            result = run_fdsx(
+                ["run", str(flow_path)],
                 cwd=tmp_dir,
-                capture_output=True,
-                text=True,
                 timeout=30,
             )
             assert result.returncode == 2, (

--- a/tests/integration/test_cli_e2e_phase4.py
+++ b/tests/integration/test_cli_e2e_phase4.py
@@ -1,7 +1,5 @@
 """End-to-end CLI tests for Phase 4 batch task scenarios."""
 
-import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
@@ -11,11 +9,7 @@ from typer.testing import CliRunner
 
 from fdsx.cli.main import app
 from fdsx.providers.base import ProviderResult
-
-
-def get_fdsx_command():
-    """Get the fdsx command invoking the CLI module directly."""
-    return [sys.executable, "-m", "fdsx.cli.main"]
+from tests.integration.cli_test_utils import fixture_path, run_fdsx
 
 
 class TestBatchCLIE2E:
@@ -55,21 +49,15 @@ class TestBatchCLIE2E:
 
     def test_input_tasks_mutual_exclusion(self):
         """Test --input and --tasks together → exit code 2, mutual exclusion error."""
-        flow_path = str(Path("tests/fixtures/batch_flow.yaml").resolve())
-        tasks_path = str(Path("tests/fixtures/sample_tasks.md").resolve())
-
-        result = subprocess.run(
-            get_fdsx_command()
-            + [
+        result = run_fdsx(
+            [
                 "run",
-                flow_path,
+                fixture_path("batch_flow.yaml"),
                 "--input",
                 "task=foo",
                 "--tasks",
-                tasks_path,
+                fixture_path("sample_tasks.md"),
             ],
-            capture_output=True,
-            text=True,
             timeout=30,
         )
 
@@ -99,17 +87,14 @@ class TestBatchCLIE2E:
             tasks_path = Path(tmpdir) / "tasks.md"
             tasks_path.write_text("Task 1\nTask 2\n")
 
-            result = subprocess.run(
-                get_fdsx_command()
-                + [
+            result = run_fdsx(
+                [
                     "run",
                     str(flow_path),
                     "--tasks",
                     str(tasks_path),
                 ],
                 input="y\n",
-                capture_output=True,
-                text=True,
                 timeout=30,
                 cwd=tmpdir,
             )

--- a/tests/integration/test_codex_streaming.py
+++ b/tests/integration/test_codex_streaming.py
@@ -23,12 +23,19 @@ FIXTURE_PATH = Path(__file__).parent.parent / "fixtures" / "codex_stream.jsonl"
 
 # Expected values derived from the fixture file (two agent_message events joined with "\n")
 FIXTURE_RESULT_TEXT = "Hello! \nHere are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"
-FIXTURE_AGENT_MESSAGE_TEXTS = ["Hello! ", "Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry"]
+FIXTURE_AGENT_MESSAGE_TEXTS = [
+    "Hello! ",
+    "Here are 3 items:\n\n1. Apple\n2. Banana\n3. Cherry",
+]
 
 
 def _load_fixture_lines() -> list[str]:
     """Return non-empty JSONL lines from the fixture file."""
-    return [line.rstrip("\n") for line in FIXTURE_PATH.read_text().splitlines() if line.strip()]
+    return [
+        line.rstrip("\n")
+        for line in FIXTURE_PATH.read_text().splitlines()
+        if line.strip()
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +43,9 @@ def _load_fixture_lines() -> list[str]:
 # ---------------------------------------------------------------------------
 
 
-def _fake_run_subprocess_factory(fixture_lines: list[str], exit_code: int = 0) -> MagicMock:
+def _fake_run_subprocess_factory(
+    fixture_lines: list[str], exit_code: int = 0
+) -> MagicMock:
     """Return a mock for _run_subprocess that replays fixture lines via output_callback."""
 
     def fake_run_subprocess(**kwargs: object) -> ProviderResult:
@@ -71,7 +80,9 @@ class TestCodexStreamingEndToEnd:
         """ProviderResult.stdout must match concatenated agent_message texts, not raw JSONL."""
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):
-            result = self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+            result = self.provider.execute(
+                "Say hello and list 3 items", output_callback=lambda _: None
+            )
 
         assert result.stdout == FIXTURE_RESULT_TEXT
 
@@ -80,17 +91,23 @@ class TestCodexStreamingEndToEnd:
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=received.append
+            )
 
         for text in FIXTURE_AGENT_MESSAGE_TEXTS:
-            assert text in received, f"Expected agent_message text not received: {text!r}"
+            assert text in received, (
+                f"Expected agent_message text not received: {text!r}"
+            )
 
     def test_output_callback_receives_tool_events(self) -> None:
         """output_callback must be called for command_execution, file_change, mcp_tool_call."""
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=received.append
+            )
 
         assert "[tool: echo hello]" in received
         assert "[tool: file_change]" in received
@@ -101,7 +118,9 @@ class TestCodexStreamingEndToEnd:
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=received.append
+            )
 
         assert "[thinking] I need to say hello in a friendly way." in received
 
@@ -110,7 +129,9 @@ class TestCodexStreamingEndToEnd:
         received: list[str] = []
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=received.append)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=received.append
+            )
 
         for item in received:
             assert not item.strip().startswith("{"), (
@@ -121,7 +142,9 @@ class TestCodexStreamingEndToEnd:
         """_run_subprocess must be called with all _STREAM_FORMAT_FLAGS when output_callback is provided."""
         mock_run = _fake_run_subprocess_factory(self.fixture_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):
-            self.provider.execute("Say hello and list 3 items", output_callback=lambda _: None)
+            self.provider.execute(
+                "Say hello and list 3 items", output_callback=lambda _: None
+            )
 
         mock_run.assert_called_once()
         called_args: list[str] = mock_run.call_args.kwargs["args"]
@@ -131,13 +154,17 @@ class TestCodexStreamingEndToEnd:
     def test_no_streaming_flag_without_callback(self) -> None:
         """Without output_callback, _run_subprocess must NOT receive any _STREAM_FORMAT_FLAGS."""
         fake_result = ProviderResult(exit_code=0, stdout="plain response", stderr="")
-        with patch("fdsx.providers.codex._run_subprocess", return_value=fake_result) as mock_run:
+        with patch(
+            "fdsx.providers.codex._run_subprocess", return_value=fake_result
+        ) as mock_run:
             result = self.provider.execute("Say hello")
 
         mock_run.assert_called_once()
         called_args: list[str] = mock_run.call_args.kwargs["args"]
         for flag in _STREAM_FORMAT_FLAGS:
-            assert flag not in called_args, f"Unexpected {flag!r} found in args: {called_args}"
+            assert flag not in called_args, (
+                f"Unexpected {flag!r} found in args: {called_args}"
+            )
         assert result.stdout == "plain response"
 
     def test_exit_code_preserved(self) -> None:
@@ -165,8 +192,7 @@ class TestCodexStreamingEndToEnd:
         """When no agent_message completed events, stdout comes from raw _run_subprocess result."""
         # Feed only non-agent_message lines
         non_message_lines = [
-            line for line in self.fixture_lines
-            if '"agent_message"' not in line
+            line for line in self.fixture_lines if '"agent_message"' not in line
         ]
         mock_run = _fake_run_subprocess_factory(non_message_lines)
         with patch("fdsx.providers.codex._run_subprocess", mock_run):

--- a/tests/integration/test_e2e_phase6.py
+++ b/tests/integration/test_e2e_phase6.py
@@ -205,7 +205,8 @@ class TestEdgeCases:
         assert results[0]["status"] == "completed"
         assert results[0]["category"] == "new"
 
-        loaded = load_task_file(tasks_dir / "001-single.yaml")
+        # After all entries complete, the file is moved to completed/
+        loaded = load_task_file(tasks_dir / "completed" / "001-single.yaml")
         assert loaded.entries[0].status == "completed"
 
     def test_mix_valid_and_invalid_yaml_files(self, tmp_path):
@@ -343,7 +344,9 @@ class TestFullPipelineE2E:
                 assert r["category"] == "retried"
                 assert r["status"] == "completed"
 
-        task_file_final = load_task_file(task_file_path)
+        # After all entries complete on resume, the file is moved to completed/
+        completed_path = task_file_path.parent / "completed" / task_file_path.name
+        task_file_final = load_task_file(completed_path)
         assert task_file_final.entries[0].status == "completed"
         assert task_file_final.entries[0].description == "Implement feature A"
         assert task_file_final.entries[1].status == "completed"
@@ -390,7 +393,9 @@ class TestFullPipelineE2E:
         )
 
         for f in created_files:
-            loaded = load_task_file(f)
+            # After all entries complete, files are moved to completed/
+            completed_f = f.parent / "completed" / f.name
+            loaded = load_task_file(completed_f)
             for entry in loaded.entries:
                 assert entry.status == "completed", (
                     f"Entry '{entry.description}' should be completed"
@@ -495,7 +500,7 @@ class TestFullPipelineE2E:
                 with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
                     with patch("fdsx.core.engine.display_tasks_dir_summary"):
                         with patch("fdsx.core.engine.input", side_effect=["n"]):
-                            results = engine.run_tasks_dir(
+                            engine.run_tasks_dir(
                                 None,
                                 tasks_dir,
                                 base_dir=project_root / ".fdsx",
@@ -558,7 +563,9 @@ class TestFullPipelineE2E:
                 assert r["category"] == "retried"
                 assert r["status"] == "completed"
 
-        final_task_file = load_task_file(created_files[0])
+        # After all entries complete on resume, the file is moved to completed/
+        completed_path = created_files[0].parent / "completed" / created_files[0].name
+        final_task_file = load_task_file(completed_path)
         assert final_task_file.entries[0].status == "completed"
         assert final_task_file.entries[1].status == "completed"
 

--- a/tests/integration/test_e2e_scenarios.py
+++ b/tests/integration/test_e2e_scenarios.py
@@ -93,6 +93,7 @@ class TestScenario1LinearFlow:
     @staticmethod
     def _read_run_log(base_dir: Path, thread_id: str) -> dict:
         from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+
         log_path = base_dir / RUNS_DIR_NAME / thread_id / RUN_FILENAME
         assert log_path.exists(), f"Run log not found at {log_path}"
         with open(log_path, "r") as f:
@@ -176,7 +177,9 @@ class TestScenario3WaitWebhook:
             mock_webhook.return_value = True
 
             with patch("builtins.input", return_value="1"):
-                result = engine.run_flow(path, thread_id="test-scenario3", base_dir=tmp_path)
+                result = engine.run_flow(
+                    path, thread_id="test-scenario3", base_dir=tmp_path
+                )
 
             assert mock_webhook.call_count == 1
             assert "plan_output" in result

--- a/tests/integration/test_e2e_scenarios.py
+++ b/tests/integration/test_e2e_scenarios.py
@@ -111,7 +111,7 @@ class TestScenario2ParallelVote:
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = engine.run_flow(path, thread_id="test-scenario2")
+        result = engine.run_flow(path, thread_id="test-scenario2", base_dir=tmp_path)
 
         assert "reviews" in result
         assert len(result["reviews"]) == 3
@@ -176,7 +176,7 @@ class TestScenario3WaitWebhook:
             mock_webhook.return_value = True
 
             with patch("builtins.input", return_value="1"):
-                result = engine.run_flow(path, thread_id="test-scenario3")
+                result = engine.run_flow(path, thread_id="test-scenario3", base_dir=tmp_path)
 
             assert mock_webhook.call_count == 1
             assert "plan_output" in result
@@ -344,7 +344,7 @@ class TestScenario5ExtractionChoice:
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = engine.run_flow(path, thread_id="test-scenario5")
+        result = engine.run_flow(path, thread_id="test-scenario5", base_dir=tmp_path)
 
         assert "raw_output" in result
         assert "decision" in result

--- a/tests/integration/test_extraction_flow.py
+++ b/tests/integration/test_extraction_flow.py
@@ -6,53 +6,53 @@ from fdsx.models.flow import Branch, ExtractRule, Flow, ParallelState
 
 
 class TestExtractionFlow:
-    def test_keyword_extraction_choice_routing(self):
+    def test_keyword_extraction_choice_routing(self, tmp_path):
         """Test keyword extraction and correct Choice routing."""
         path = Path("tests/fixtures/extraction_flow.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "decision" in result
         assert result["decision"] == "APPROVED"
         assert "approved_result" in result
 
-    def test_regex_extraction_choice_routing(self):
+    def test_regex_extraction_choice_routing(self, tmp_path):
         """Test regex extraction from structured output."""
         path = Path("tests/fixtures/regex_extraction_flow.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "extracted_status" in result
         assert result["extracted_status"] == "success"
         assert "success_result" in result
 
-    def test_json_extraction_choice_routing(self):
+    def test_json_extraction_choice_routing(self, tmp_path):
         """Test JSON extraction from raw JSON output."""
         path = Path("tests/fixtures/json_extraction_flow.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "extracted_status" in result
         assert result["extracted_status"] == "approved"
         assert "approved_result" in result
 
-    def test_json_codeblock_extraction_choice_routing(self):
+    def test_json_codeblock_extraction_choice_routing(self, tmp_path):
         """Test JSON extraction from ```json code block output (T024)."""
         path = Path("tests/fixtures/json_codeblock_extraction_flow.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "extracted_status" in result
         assert result["extracted_status"] == "approved"

--- a/tests/integration/test_hook_streaming_interaction.py
+++ b/tests/integration/test_hook_streaming_interaction.py
@@ -30,7 +30,9 @@ from fdsx.models.flow import HookEntry
 # ---------------------------------------------------------------------------
 
 
-def _make_recorder(thread_id: str = "test-thread", flow_name: str = "TestFlow") -> MagicMock:
+def _make_recorder(
+    thread_id: str = "test-thread", flow_name: str = "TestFlow"
+) -> MagicMock:
     recorder = MagicMock()
     recorder.thread_id = thread_id
     recorder.flow_name = flow_name
@@ -86,15 +88,17 @@ class TestHookFiringOrderWithStreaming:
                 wrapped({"input": "value"})
 
         # on_start fires before node executes
-        assert execution_order.index("hook_starting") < execution_order.index("node_started"), (
-            "on_start hook must fire before node execution starts"
-        )
+        assert execution_order.index("hook_starting") < execution_order.index(
+            "node_started"
+        ), "on_start hook must fire before node execution starts"
         # node executes before on_complete fires
-        assert execution_order.index("node_completed") < execution_order.index("hook_completed"), (
-            "on_complete hook must fire after node execution completes"
-        )
+        assert execution_order.index("node_completed") < execution_order.index(
+            "hook_completed"
+        ), "on_complete hook must fire after node execution completes"
 
-    def test_streaming_log_file_and_hook_data_files_coexist(self, tmp_path: Path) -> None:
+    def test_streaming_log_file_and_hook_data_files_coexist(
+        self, tmp_path: Path
+    ) -> None:
         """StreamLogger log files and hook data JSON files exist in the correct directories.
 
         - Log files: .fdsx/runs/<thread-id>/logs/<state-name>.log
@@ -152,7 +156,9 @@ class TestHookFiringOrderWithStreaming:
         assert input_path.parent.parent.name == HOOKS_DIR_NAME
         assert input_path.parent.parent.parent.name == thread_id
 
-    def test_hook_fires_correctly_with_streaming_task_state(self, tmp_path: Path) -> None:
+    def test_hook_fires_correctly_with_streaming_task_state(
+        self, tmp_path: Path
+    ) -> None:
         """Full integration: hooks fire around a system provider task that produces output.
 
         Uses compile_flow with a real system provider task so that:
@@ -187,19 +193,25 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "hook-stream-full-tid"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="Hook Streaming Integration")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="Hook Streaming Integration"
+        )
         log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
 
         hook_calls: list[dict] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
             hook_calls.append({"state_name": state_name, "status": status})
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": thread_id}}
                 list(
@@ -248,14 +260,18 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "stream-terminal-tid"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="Hook + Streaming Terminal")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="Hook + Streaming Terminal"
+        )
         log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks"):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": thread_id}}
                 list(
@@ -301,14 +317,18 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "log-hook-tid"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="Log + Hook Coexistence")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="Log + Hook Coexistence"
+        )
         log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks"):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": thread_id}}
                 list(
@@ -512,19 +532,25 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "multi-state-hook-tid"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="Multi State Hook Stream")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="Multi State Hook Stream"
+        )
         log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
 
         hook_calls: list[dict] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
             hook_calls.append({"state_name": state_name, "status": status})
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": thread_id}}
                 list(
@@ -539,10 +565,26 @@ states:
         assert "step2" in state_names_that_fired, "step2 hooks should have fired"
 
         # Both starting and completed for each state
-        step1_starting = [c for c in hook_calls if c["state_name"] == "step1" and c["status"] == "starting"]
-        step1_completed = [c for c in hook_calls if c["state_name"] == "step1" and c["status"] == "completed"]
-        step2_starting = [c for c in hook_calls if c["state_name"] == "step2" and c["status"] == "starting"]
-        step2_completed = [c for c in hook_calls if c["state_name"] == "step2" and c["status"] == "completed"]
+        step1_starting = [
+            c
+            for c in hook_calls
+            if c["state_name"] == "step1" and c["status"] == "starting"
+        ]
+        step1_completed = [
+            c
+            for c in hook_calls
+            if c["state_name"] == "step1" and c["status"] == "completed"
+        ]
+        step2_starting = [
+            c
+            for c in hook_calls
+            if c["state_name"] == "step2" and c["status"] == "starting"
+        ]
+        step2_completed = [
+            c
+            for c in hook_calls
+            if c["state_name"] == "step2" and c["status"] == "completed"
+        ]
 
         assert len(step1_starting) == 1, "step1 on_start should fire once"
         assert len(step1_completed) == 1, "step1 on_complete should fire once"
@@ -581,14 +623,18 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "per-state-log-tid"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="Per State Logs With Hooks")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="Per State Logs With Hooks"
+        )
         log_dir = tmp_path / RUNS_DIR_NAME / thread_id / LOGS_DIR_NAME
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks"):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": thread_id}}
                 list(

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -30,7 +30,9 @@ from fdsx.models.flow import HookConfig, HookEntry
 # ---------------------------------------------------------------------------
 
 
-def _make_recorder(thread_id: str = "test-thread", flow_name: str = "TestFlow") -> MagicMock:
+def _make_recorder(
+    thread_id: str = "test-thread", flow_name: str = "TestFlow"
+) -> MagicMock:
     recorder = MagicMock()
     recorder.thread_id = thread_id
     recorder.flow_name = flow_name
@@ -353,7 +355,9 @@ class TestWrapWithHooksAbortBehavior:
 class TestWrapWithHooksNodeFailure:
     """on_complete hooks fire with status='failed' when the node raises, then the error re-raises."""
 
-    def test_on_complete_fires_with_failed_status_when_node_raises(self, tmp_path: Path) -> None:
+    def test_on_complete_fires_with_failed_status_when_node_raises(
+        self, tmp_path: Path
+    ) -> None:
         """on_complete hooks fire with status='failed' when node raises RuntimeError."""
 
         def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -380,7 +384,9 @@ class TestWrapWithHooksNodeFailure:
         exec_kwargs = mock_exec.call_args[1]
         assert exec_kwargs["status"] == "failed"
 
-    def test_node_error_is_reraised_after_on_complete_hooks(self, tmp_path: Path) -> None:
+    def test_node_error_is_reraised_after_on_complete_hooks(
+        self, tmp_path: Path
+    ) -> None:
         """The original exception is re-raised after on_complete hooks run."""
         original_error = ValueError("original error")
 
@@ -406,7 +412,9 @@ class TestWrapWithHooksNodeFailure:
 
         assert exc_info.value is original_error
 
-    def test_output_json_written_with_input_state_on_failure(self, tmp_path: Path) -> None:
+    def test_output_json_written_with_input_state_on_failure(
+        self, tmp_path: Path
+    ) -> None:
         """When node fails, output.json is written with the input state_dict (fallback)."""
 
         def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -434,7 +442,9 @@ class TestWrapWithHooksNodeFailure:
                 with pytest.raises(RuntimeError):
                     wrapped({"original": "state"})
 
-        output_write = next(c for c in write_data_calls if c["filename"] == OUTPUT_FILENAME)
+        output_write = next(
+            c for c in write_data_calls if c["filename"] == OUTPUT_FILENAME
+        )
         assert output_write["data"] == {"original": "state"}, (
             "output.json should contain the input state_dict as fallback on failure"
         )
@@ -537,18 +547,24 @@ states:
 
         hook_calls: list[dict] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
-            hook_calls.append({
-                "state_name": state_name,
-                "status": status,
-                "count": len(hooks),
-            })
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
+            hook_calls.append(
+                {
+                    "state_name": state_name,
+                    "status": status,
+                    "count": len(hooks),
+                }
+            )
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(
                     flow,
                     recorder=recorder,
@@ -556,7 +572,11 @@ states:
                 )
                 # Run the graph
                 config_dict = {"configurable": {"thread_id": "hooks-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
         starting_calls = [c for c in hook_calls if c["status"] == "starting"]
         completed_calls = [c for c in hook_calls if c["status"] == "completed"]
@@ -595,20 +615,32 @@ states:
 
         hook_calls: list[dict] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
             hook_calls.append({"status": status, "count": len(hooks)})
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": "flow-hook-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
-        assert any(c["status"] == "starting" for c in hook_calls), "on_start should fire"
-        assert any(c["status"] == "completed" for c in hook_calls), "on_complete should fire"
+        assert any(c["status"] == "starting" for c in hook_calls), (
+            "on_start should fire"
+        )
+        assert any(c["status"] == "completed" for c in hook_calls), (
+            "on_complete should fire"
+        )
 
     def test_config_level_hooks_merge_with_flow_and_state(self, tmp_path: Path) -> None:
         """Config-level hooks are included via collect_hooks merge."""
@@ -635,22 +667,34 @@ states:
             hooks=HookConfig(on_start=[HookEntry(command="echo global_start")])
         )
 
-        recorder = _make_recorder(thread_id="config-hook-tid", flow_name="Config Hook Test")
+        recorder = _make_recorder(
+            thread_id="config-hook-tid", flow_name="Config Hook Test"
+        )
         log_dir = tmp_path / ".fdsx" / "runs" / "config-hook-tid" / "logs"
 
         hook_calls: list[list] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
             hook_calls.append([h.command for h in hooks])
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
-                compiled = compile_flow(flow, recorder=recorder, config=fdsx_config, log_dir=log_dir)
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
+                compiled = compile_flow(
+                    flow, recorder=recorder, config=fdsx_config, log_dir=log_dir
+                )
                 config_dict = {"configurable": {"thread_id": "config-hook-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
         # Config-level hook should appear in the on_start call
         all_commands = [cmd for call_cmds in hook_calls for cmd in call_cmds]
@@ -693,7 +737,9 @@ states:
 
         captured_hooks: list[list[str]] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
             if status == "starting":
                 captured_hooks.append([h.command for h in hooks])
 
@@ -701,10 +747,18 @@ states:
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
-                compiled = compile_flow(flow, recorder=recorder, config=fdsx_config, log_dir=log_dir)
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
+                compiled = compile_flow(
+                    flow, recorder=recorder, config=fdsx_config, log_dir=log_dir
+                )
                 config_dict = {"configurable": {"thread_id": "merge-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
         assert len(captured_hooks) == 1
         cmds = captured_hooks[0]
@@ -738,7 +792,11 @@ states:
         with patch("fdsx.core.compiler.execute_hooks") as mock_exec:
             compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
             config_dict = {"configurable": {"thread_id": "no-hook-tid"}}
-            list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+            list(
+                compiled.graph.stream(
+                    {"_meta": {}}, config=config_dict, stream_mode="values"
+                )
+            )
 
         mock_exec.assert_not_called()
 
@@ -769,22 +827,38 @@ states:
 
         hook_calls: list[dict] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
             hook_calls.append({"state_name": state_name, "status": status})
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": "pass-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
-        assert any(c["status"] == "starting" and c["state_name"] == "passme" for c in hook_calls)
-        assert any(c["status"] == "completed" and c["state_name"] == "passme" for c in hook_calls)
+        assert any(
+            c["status"] == "starting" and c["state_name"] == "passme"
+            for c in hook_calls
+        )
+        assert any(
+            c["status"] == "completed" and c["state_name"] == "passme"
+            for c in hook_calls
+        )
 
-    def test_parallel_state_hooks_wrap_dispatch_and_collector(self, tmp_path: Path) -> None:
+    def test_parallel_state_hooks_wrap_dispatch_and_collector(
+        self, tmp_path: Path
+    ) -> None:
         """ParallelState: on_start fires in dispatch, on_complete fires in collector."""
         flow_yaml = """
 name: Parallel Hook Flow
@@ -819,17 +893,27 @@ states:
 
         hook_calls: list[dict] = []
 
-        def fake_execute_hooks(hooks, *, state_name, status, data_path, thread_id, flow_name):
-            hook_calls.append({"state_name": state_name, "status": status, "count": len(hooks)})
+        def fake_execute_hooks(
+            hooks, *, state_name, status, data_path, thread_id, flow_name
+        ):
+            hook_calls.append(
+                {"state_name": state_name, "status": status, "count": len(hooks)}
+            )
 
         def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
             return tmp_path / filename
 
         with patch("fdsx.core.compiler.execute_hooks", side_effect=fake_execute_hooks):
-            with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+            with patch(
+                "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+            ):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": "par-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
         starting_calls = [c for c in hook_calls if c["status"] == "starting"]
         completed_calls = [c for c in hook_calls if c["status"] == "completed"]
@@ -873,11 +957,17 @@ states:
             write_calls.append({"base_dir": base_dir})
             return tmp_path / filename
 
-        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+        with patch(
+            "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+        ):
             with patch("fdsx.core.compiler.execute_hooks"):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
                 config_dict = {"configurable": {"thread_id": "test-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
         assert len(write_calls) > 0
         assert write_calls[0]["base_dir"] == fdsx_root, (
@@ -914,11 +1004,17 @@ states:
             write_calls.append({"base_dir": base_dir})
             return tmp_path / filename
 
-        with patch("fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data):
+        with patch(
+            "fdsx.core.compiler.write_hook_data", side_effect=fake_write_hook_data
+        ):
             with patch("fdsx.core.compiler.execute_hooks"):
                 compiled = compile_flow(flow, recorder=recorder, log_dir=None)
                 config_dict = {"configurable": {"thread_id": "none-logdir-tid"}}
-                list(compiled.graph.stream({"_meta": {}}, config=config_dict, stream_mode="values"))
+                list(
+                    compiled.graph.stream(
+                        {"_meta": {}}, config=config_dict, stream_mode="values"
+                    )
+                )
 
         assert len(write_calls) > 0
         assert write_calls[0]["base_dir"] is None

--- a/tests/integration/test_large_command.py
+++ b/tests/integration/test_large_command.py
@@ -50,7 +50,9 @@ class TestLargeCommandIntegration:
         # Simulate a large state value being interpolated into the command.
         large_value = "review_output_line\n" * 7000  # ~130KB+ when embedded
         # Embed the large value as a heredoc-style variable, then process it
-        large_cmd = f"large_state='{large_value}'; echo \"$large_state\" | wc -l | tr -d ' '"
+        large_cmd = (
+            f"large_state='{large_value}'; echo \"$large_state\" | wc -l | tr -d ' '"
+        )
 
         if len(large_cmd.encode("utf-8")) < ARG_MAX_STDIN_THRESHOLD:
             # If the constructed command doesn't hit the threshold, pad it

--- a/tests/integration/test_linear_flow.py
+++ b/tests/integration/test_linear_flow.py
@@ -6,7 +6,7 @@ from fdsx.core.loader import load_flow
 
 
 class TestLinearFlow:
-    def test_end_to_end_linear_flow(self):
+    def test_end_to_end_linear_flow(self, tmp_path):
         path = Path("tests/fixtures/simple_flow.yaml")
 
         flow, errors = load_flow(path)
@@ -16,7 +16,7 @@ class TestLinearFlow:
         compiled = compile_flow(flow)
         assert compiled is not None
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "plan" in result
         assert "implementation" in result
@@ -25,18 +25,18 @@ class TestLinearFlow:
         assert "Implementation:" in result["implementation"]
         assert "Review:" in result["review"]
 
-    def test_linear_flow_with_inputs(self):
+    def test_linear_flow_with_inputs(self, tmp_path):
         path = Path("tests/fixtures/simple_flow.yaml")
 
-        result = run_flow(path, inputs={"task": "test task"})
+        result = run_flow(path, inputs={"task": "test task"}, base_dir=tmp_path)
 
         assert "plan" in result
         assert "implementation" in result
 
-    def test_linear_flow_thread_id(self):
+    def test_linear_flow_thread_id(self, tmp_path):
         path = Path("tests/fixtures/simple_flow.yaml")
 
         thread_id = "test-thread-123"
-        result = run_flow(path, thread_id=thread_id)
+        result = run_flow(path, thread_id=thread_id, base_dir=tmp_path)
 
         assert "plan" in result

--- a/tests/integration/test_loop_enforcement.py
+++ b/tests/integration/test_loop_enforcement.py
@@ -4,10 +4,10 @@ from fdsx.core.engine import run_flow
 
 
 class TestLoopEnforcement:
-    def test_max_loop_prevents_infinite_cycle(self):
+    def test_max_loop_prevents_infinite_cycle(self, tmp_path):
         """R2-F5: flow.max_loop must bound execution via LangGraph recursion_limit."""
         path = Path("tests/fixtures/loop_flow.yaml")
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
         assert isinstance(result, dict)
         # Loop control must return partial results rather than empty dict or an exception
         assert result != {}, "Loop control must return partial state, not empty dict"

--- a/tests/integration/test_loop_flow.py
+++ b/tests/integration/test_loop_flow.py
@@ -5,7 +5,7 @@ from fdsx.core.loader import load_flow
 
 
 class TestLoopFlow:
-    def test_loop_stops_at_max_iterations(self):
+    def test_loop_stops_at_max_iterations(self, tmp_path):
         """Test that loop stops gracefully after max_loop iterations."""
         path = Path("tests/fixtures/loop_flow.yaml")
 
@@ -14,17 +14,17 @@ class TestLoopFlow:
 
         assert flow.max_loop == 3
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         # Must return a dict (not raise), and must not be empty — partial results preserved
         assert isinstance(result, dict)
         assert result != {}, "Loop control must return partial state, not empty dict"
 
-    def test_loop_returns_partial_results(self):
+    def test_loop_returns_partial_results(self, tmp_path):
         """Test that loop returns results from the last iteration when max_loop is reached."""
         path = Path("tests/fixtures/loop_flow.yaml")
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert isinstance(result, dict)
         # The fixture loops plan→implement→review→decide and never reaches done,
@@ -36,11 +36,11 @@ class TestLoopFlow:
             f"Expected at least one of {partial_keys} in result, got: {list(result.keys())}"
         )
 
-    def test_state_variables_retained_across_iterations(self):
+    def test_state_variables_retained_across_iterations(self, tmp_path):
         """Test that state variables from earlier loop iterations are available in later ones."""
         path = Path("tests/fixtures/loop_flow.yaml")
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         # plan_output, impl_output, and review_output were all set in the loop body.
         # They must all survive to the final captured state (the last iteration overwrites them,

--- a/tests/integration/test_loop_flow.py
+++ b/tests/integration/test_loop_flow.py
@@ -45,6 +45,12 @@ class TestLoopFlow:
         # plan_output, impl_output, and review_output were all set in the loop body.
         # They must all survive to the final captured state (the last iteration overwrites them,
         # so all three should be present in partial results).
-        assert "plan_output" in result, "plan_output must be retained in partial results"
-        assert "impl_output" in result, "impl_output must be retained in partial results"
-        assert "review_output" in result, "review_output must be retained in partial results"
+        assert "plan_output" in result, (
+            "plan_output must be retained in partial results"
+        )
+        assert "impl_output" in result, (
+            "impl_output must be retained in partial results"
+        )
+        assert "review_output" in result, (
+            "review_output must be retained in partial results"
+        )

--- a/tests/integration/test_parallel_flow.py
+++ b/tests/integration/test_parallel_flow.py
@@ -8,14 +8,14 @@ from fdsx.logging.recorder import LOGS_DIR_NAME, RUNS_DIR_NAME
 
 
 class TestParallelFlow:
-    def test_parallel_review_majority_aggregation(self):
+    def test_parallel_review_majority_aggregation(self, tmp_path):
         """Test parallel review with majority aggregation and choice routing."""
         path = Path("tests/fixtures/parallel_review.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "reviews" in result
         assert len(result["reviews"]) == 3
@@ -27,11 +27,11 @@ class TestParallelFlow:
         assert "decision" in result
         assert result["decision"] == "APPROVED"
 
-    def test_parallel_branch_results_have_output_field(self):
+    def test_parallel_branch_results_have_output_field(self, tmp_path):
         """Verify branch results array contains output field."""
         path = Path("tests/fixtures/parallel_review.yaml")
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "reviews" in result
         assert len(result["reviews"]) == 3
@@ -40,14 +40,14 @@ class TestParallelFlow:
 
 
 class TestParallelMinSuccess:
-    def test_min_success_tolerates_partial_failure(self):
+    def test_min_success_tolerates_partial_failure(self, tmp_path):
         """Test that min_success allows flow to continue with partial branch failures."""
         path = Path("tests/fixtures/parallel_min_success.yaml")
 
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-        result = run_flow(path)
+        result = run_flow(path, base_dir=tmp_path)
 
         assert "results" in result
         assert len(result["results"]) == 3

--- a/tests/integration/test_provider_options.py
+++ b/tests/integration/test_provider_options.py
@@ -89,7 +89,9 @@ class TestClaudeWithPermissionMode:
             captured_args.append(list(args))
             return FAKE_SUCCESS
 
-        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="hello", model="claude-sonnet")
 
         assert len(captured_args) == 1
@@ -108,7 +110,9 @@ class TestClaudeWithPermissionMode:
             captured_args.append(list(args))
             return FAKE_SUCCESS
 
-        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="hello", model="claude-sonnet")
 
         args = captured_args[0]
@@ -126,7 +130,9 @@ class TestClaudeWithPermissionMode:
             captured_args.append(list(args))
             return FAKE_SUCCESS
 
-        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="hello")
 
         assert "--dangerously-skip-permissions" in captured_args[0]
@@ -210,7 +216,9 @@ class TestTaskLevelOverride:
             flow_providers={"claude": {"permission_mode": "plan"}},
             task_provider_options={"permission_mode": "bypassPermissions"},
         )
-        merged = _merge_provider_options(config, flow, "claude", flow.states["step1"].provider_options)  # type: ignore[union-attr]
+        merged = _merge_provider_options(
+            config, flow, "claude", flow.states["step1"].provider_options
+        )  # type: ignore[union-attr]
 
         assert merged is not None
         assert merged["permission_mode"] == "bypassPermissions"
@@ -293,7 +301,9 @@ class TestParallelBranchesWithMixedProviders:
             captured_args.append(list(args))
             return FAKE_SUCCESS
 
-        with patch("fdsx.providers.codex._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.codex._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="do work", model="codex-mini")
 
         args = captured_args[0]
@@ -311,7 +321,9 @@ class TestParallelBranchesWithMixedProviders:
             captured_args.append(list(args))
             return FAKE_SUCCESS
 
-        with patch("fdsx.providers.opencode._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.opencode._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="do work", model="opencode-model")
 
         # Prompt must still be the last arg

--- a/tests/integration/test_quiet_mode.py
+++ b/tests/integration/test_quiet_mode.py
@@ -17,10 +17,13 @@ from fdsx.cli.main import app
 class TestQuietModeE2E:
     """End-to-end integration tests for --quiet flag (FR-5.1, FR-5.4)."""
 
-    def test_quiet_suppresses_state_streaming_output(self):
+    def test_quiet_suppresses_state_streaming_output(self, tmp_path, monkeypatch):
         """--quiet suppresses [state_name] prefixed lines on stderr."""
+        flow_path = str(
+            Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
+        )
+        monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        flow_path = str(Path("tests/fixtures/simple_flow.yaml").resolve())
 
         result = runner.invoke(app, ["run", flow_path, "--quiet"])
 
@@ -32,10 +35,13 @@ class TestQuietModeE2E:
         assert "[implement]" not in result.output
         assert "[review]" not in result.output
 
-    def test_quiet_completion_summary_still_printed(self):
+    def test_quiet_completion_summary_still_printed(self, tmp_path, monkeypatch):
         """--quiet does not suppress the completion summary."""
+        flow_path = str(
+            Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
+        )
+        monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        flow_path = str(Path("tests/fixtures/simple_flow.yaml").resolve())
 
         result = runner.invoke(app, ["run", flow_path, "--quiet"])
 
@@ -45,10 +51,13 @@ class TestQuietModeE2E:
         # Completion summary should still appear (from display_completion_summary)
         assert "completed successfully" in result.output
 
-    def test_non_quiet_produces_streaming_output(self):
+    def test_non_quiet_produces_streaming_output(self, tmp_path, monkeypatch):
         """Without --quiet, streaming output is produced (baseline)."""
+        flow_path = str(
+            Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
+        )
+        monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        flow_path = str(Path("tests/fixtures/simple_flow.yaml").resolve())
 
         result = runner.invoke(app, ["run", flow_path])
 
@@ -66,7 +75,9 @@ class TestQuietModeE2E:
         """--quiet still writes per-state log files (FR-5.3)."""
         monkeypatch.chdir(tmp_path)
 
-        src_fixture = Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
+        src_fixture = (
+            Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
+        )
         flow_file = tmp_path / "simple_flow.yaml"
         shutil.copy(src_fixture, flow_file)
 

--- a/tests/integration/test_result_file.py
+++ b/tests/integration/test_result_file.py
@@ -48,7 +48,7 @@ class TestTaskResultFileIntegration:
             "  consume_state:\n"
             "    type: task\n"
             "    provider: system\n"
-            "    command: \"cat {output_ref}\"\n"
+            '    command: "cat {output_ref}"\n'
             "    result_path: $.final\n"
             "    end: true\n",
             encoding="utf-8",
@@ -60,7 +60,9 @@ class TestTaskResultFileIntegration:
         run_dir = tmp_path / RUNS_DIR_NAME / thread_id
         expected_file = run_dir / RESULT_FILE_DATA_DIR / "output_ref.md"
 
-        assert "output_ref" in result, f"result_file variable missing from result: {result}"
+        assert "output_ref" in result, (
+            f"result_file variable missing from result: {result}"
+        )
         assert Path(result["output_ref"]).is_absolute(), (
             f"output_ref should be absolute path, got: {result['output_ref']}"
         )
@@ -134,12 +136,12 @@ class TestParallelResultFileIntegration:
         assert isinstance(parsed, list), (
             f"Expected JSON list in {expected_file}, got: {type(parsed)}"
         )
-        assert len(parsed) == 2, (
-            f"Expected 2 branch results, got: {len(parsed)}"
-        )
+        assert len(parsed) == 2, f"Expected 2 branch results, got: {len(parsed)}"
         for entry in parsed:
             assert "output" in entry, f"Missing 'output' key in branch result: {entry}"
-            assert "exit_code" in entry, f"Missing 'exit_code' key in branch result: {entry}"
+            assert "exit_code" in entry, (
+                f"Missing 'exit_code' key in branch result: {entry}"
+            )
         assert result["reviews_ref"] == str(expected_file.resolve()), (
             f"reviews_ref path mismatch: {result['reviews_ref']} != {expected_file.resolve()}"
         )
@@ -167,5 +169,7 @@ class TestResultFileRegression:
             f"but found: {data_dir}"
         )
         assert "plan" in result, f"Expected 'plan' in result: {result}"
-        assert "implementation" in result, f"Expected 'implementation' in result: {result}"
+        assert "implementation" in result, (
+            f"Expected 'implementation' in result: {result}"
+        )
         assert "review" in result, f"Expected 'review' in result: {result}"

--- a/tests/integration/test_resume_interrupt.py
+++ b/tests/integration/test_resume_interrupt.py
@@ -1,12 +1,8 @@
 import yaml
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from fdsx.cli.main import app
-from fdsx.core import engine
-from fdsx.core.config import FdsxConfig
 from fdsx.models.task import TaskEntry, TaskFile, save_task_file
 
 

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -1,16 +1,19 @@
-import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import yaml
 
-from fdsx.core.batch import COMPLETED_SUBDIR, TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.batch import (
+    COMPLETED_SUBDIR,
+    TASKS_DIR,
+    split_tasks_to_groups,
+    write_task_files,
+)
 from fdsx.core.config import FdsxConfig, TaskSplitterConfig
 from fdsx.models.task import TaskEntry
 
 
 class TestSplitIntegration:
-    def test_split_end_to_end_with_mock_provider(self):
+    def test_split_end_to_end_with_mock_provider(self, tmp_path):
         """End-to-end test: split task content via mock provider and write files."""
         mock_provider = MagicMock()
         mock_provider.execute.return_value = MagicMock(
@@ -32,23 +35,22 @@ class TestSplitIntegration:
         assert len(result_groups[1]) == 1
         assert len(result_groups[2]) == 1
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tasks_dir = Path(tmpdir) / TASKS_DIR
-            created_files = write_task_files(result_groups, tasks_dir)
+        tasks_dir = tmp_path / TASKS_DIR
+        created_files = write_task_files(result_groups, tasks_dir)
 
-            assert len(created_files) == 3
-            assert (tasks_dir / "001-implement-feature-a.yaml").exists()
-            assert (tasks_dir / "002-write-tests-for-feature-a.yaml").exists()
-            assert (tasks_dir / "003-write-tests-for-feature-b.yaml").exists()
+        assert len(created_files) == 3
+        assert (tasks_dir / "001-implement-feature-a.yaml").exists()
+        assert (tasks_dir / "002-write-tests-for-feature-a.yaml").exists()
+        assert (tasks_dir / "003-write-tests-for-feature-b.yaml").exists()
 
-            for f in created_files:
-                assert f.exists()
-                assert f.stat().st_mode & 0o777 == 0o600
+        for f in created_files:
+            assert f.exists()
+            assert f.stat().st_mode & 0o777 == 0o600
 
-            content = (tasks_dir / "001-implement-feature-a.yaml").read_text()
-            data = yaml.safe_load(content)
-            assert len(data["tasks"]) == 2
-            assert data["tasks"][0]["description"] == "Implement feature A"
+        content = (tasks_dir / "001-implement-feature-a.yaml").read_text()
+        data = yaml.safe_load(content)
+        assert len(data["tasks"]) == 2
+        assert data["tasks"][0]["description"] == "Implement feature A"
 
     def test_split_with_empty_result(self):
         """Test handling of empty result from provider."""
@@ -66,7 +68,7 @@ class TestSplitIntegration:
 
         assert groups == []
 
-    def test_split_with_single_task(self):
+    def test_split_with_single_task(self, tmp_path):
         """Test handling of single task result."""
         mock_provider = MagicMock()
         mock_provider.execute.return_value = MagicMock(
@@ -84,31 +86,29 @@ class TestSplitIntegration:
         assert len(groups[0]) == 1
         assert groups[0][0].description == "Single task"
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tasks_dir = Path(tmpdir) / TASKS_DIR
-            created_files = write_task_files(groups, tasks_dir)
+        tasks_dir = tmp_path / TASKS_DIR
+        created_files = write_task_files(groups, tasks_dir)
 
-            assert len(created_files) == 1
-            content = (tasks_dir / "001-single-task.yaml").read_text()
-            data = yaml.safe_load(content)
-            assert "description" in data
-            assert data["description"] == "Single task"
+        assert len(created_files) == 1
+        content = (tasks_dir / "001-single-task.yaml").read_text()
+        data = yaml.safe_load(content)
+        assert "description" in data
+        assert data["description"] == "Single task"
 
-    def test_split_writes_yaml_with_task_status(self):
+    def test_split_writes_yaml_with_task_status(self, tmp_path):
         """Verify that written YAML files contain correct status field."""
         groups = [
             [TaskEntry(description="Task with default status")],
         ]
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tasks_dir = Path(tmpdir) / TASKS_DIR
-            write_task_files(groups, tasks_dir)
+        tasks_dir = tmp_path / TASKS_DIR
+        write_task_files(groups, tasks_dir)
 
-            content = (tasks_dir / "001-task-with-default-status.yaml").read_text()
-            data = yaml.safe_load(content)
+        content = (tasks_dir / "001-task-with-default-status.yaml").read_text()
+        data = yaml.safe_load(content)
 
-            assert "status" in data
-            assert data["status"] == "pending"
+        assert "status" in data
+        assert data["status"] == "pending"
 
 
 class TestSplitCliIntegration:
@@ -342,7 +342,9 @@ class TestSplitCliIntegration:
         tasks_dir = tmp_path / TASKS_DIR
         completed_dir = tasks_dir / COMPLETED_SUBDIR
         completed_dir.mkdir(parents=True, exist_ok=True)
-        (completed_dir / "001-old-task.yaml").write_text("description: Old task\nstatus: done")
+        (completed_dir / "001-old-task.yaml").write_text(
+            "description: Old task\nstatus: done"
+        )
 
         task_file = tmp_path / "tasks.md"
         task_file.write_text("New feature")
@@ -356,13 +358,19 @@ class TestSplitCliIntegration:
 
         monkeypatch.chdir(tmp_path)
 
-        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
             with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
                 runner = CliRunner()
-                result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+                result = runner.invoke(
+                    app, ["split", str(task_file)], catch_exceptions=False
+                )
 
         assert result.exit_code == 0
         import json as _json
+
         paths = _json.loads(result.stdout)
         assert len(paths) == 1
 
@@ -392,10 +400,15 @@ class TestSplitCliIntegration:
 
         monkeypatch.chdir(tmp_path)
 
-        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
             with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
                 runner = CliRunner()
-                result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+                result = runner.invoke(
+                    app, ["split", str(task_file)], catch_exceptions=False
+                )
 
         assert result.exit_code == 0
         assert completed_dir.exists()
@@ -413,8 +426,12 @@ class TestSplitCliIntegration:
         tasks_dir = tmp_path / TASKS_DIR
         completed_dir = tasks_dir / COMPLETED_SUBDIR
         completed_dir.mkdir(parents=True, exist_ok=True)
-        (completed_dir / "001-first.yaml").write_text("description: First\nstatus: done")
-        (completed_dir / "002-second.yaml").write_text("description: Second\nstatus: done")
+        (completed_dir / "001-first.yaml").write_text(
+            "description: First\nstatus: done"
+        )
+        (completed_dir / "002-second.yaml").write_text(
+            "description: Second\nstatus: done"
+        )
 
         task_file = tmp_path / "tasks.md"
         task_file.write_text("Third task")
@@ -428,18 +445,21 @@ class TestSplitCliIntegration:
 
         monkeypatch.chdir(tmp_path)
 
-        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
             with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
                 runner = CliRunner()
-                result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+                result = runner.invoke(
+                    app, ["split", str(task_file)], catch_exceptions=False
+                )
 
         assert result.exit_code == 0
         assert (tasks_dir / "003-third-task.yaml").exists()
 
     # T001: Split without --force still fails when a pending .yaml exists outside completed/
-    def test_split_command_still_blocks_with_pending_yaml(
-        self, tmp_path, monkeypatch
-    ):
+    def test_split_command_still_blocks_with_pending_yaml(self, tmp_path, monkeypatch):
         """Split without --force fails when a pending .yaml file exists directly in tasks dir."""
         from typer.testing import CliRunner
         from fdsx.cli.main import app
@@ -449,22 +469,29 @@ class TestSplitCliIntegration:
         completed_dir.mkdir(parents=True, exist_ok=True)
         (completed_dir / "001-done.yaml").write_text("description: Done\nstatus: done")
         # Pending task directly in tasks dir — should block split
-        (tasks_dir / "002-pending.yaml").write_text("description: Pending\nstatus: pending")
+        (tasks_dir / "002-pending.yaml").write_text(
+            "description: Pending\nstatus: pending"
+        )
 
         task_file = tmp_path / "tasks.md"
         task_file.write_text("New feature")
 
         monkeypatch.chdir(tmp_path)
 
-        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
             runner = CliRunner()
-            result = runner.invoke(app, ["split", str(task_file)], catch_exceptions=False)
+            result = runner.invoke(
+                app, ["split", str(task_file)], catch_exceptions=False
+            )
 
         assert result.exit_code == 2
         assert "not empty" in result.stderr
 
     # T006: Prompt produces feature-level tasks with numbered sub-steps
-    def test_split_produces_feature_level_tasks(self):
+    def test_split_produces_feature_level_tasks(self, tmp_path):
         """Verify split accepts feature-level task descriptions with numbered sub-steps."""
         import json as _json
 
@@ -499,17 +526,14 @@ class TestSplitCliIntegration:
         assert "2." in description
         assert "3." in description
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tasks_dir = Path(tmpdir) / TASKS_DIR
-            created_files = write_task_files(groups, tasks_dir)
+        tasks_dir = tmp_path / TASKS_DIR
+        created_files = write_task_files(groups, tasks_dir)
 
-            # Produces fewer files than micro-task split (1 vs many)
-            assert len(created_files) == 1
+        # Produces fewer files than micro-task split (1 vs many)
+        assert len(created_files) == 1
 
     # T003: --force removes pending .yaml files but preserves completed/ dir
-    def test_split_command_force_preserves_completed_dir(
-        self, tmp_path, monkeypatch
-    ):
+    def test_split_command_force_preserves_completed_dir(self, tmp_path, monkeypatch):
         """--force clears pending .yaml files but preserves completed/ and its contents."""
         from typer.testing import CliRunner
         from fdsx.cli.main import app
@@ -534,7 +558,10 @@ class TestSplitCliIntegration:
 
         monkeypatch.chdir(tmp_path)
 
-        with patch("fdsx.cli.main.load_config", return_value=FdsxConfig(task_splitter=TaskSplitterConfig())):
+        with patch(
+            "fdsx.cli.main.load_config",
+            return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+        ):
             with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
                 runner = CliRunner()
                 result = runner.invoke(

--- a/tests/integration/test_subprocess_completion.py
+++ b/tests/integration/test_subprocess_completion.py
@@ -40,10 +40,12 @@ def _make_result_ndjson(result_value: str = "ok") -> str:
 
 def _make_content_block_delta_ndjson(text: str) -> str:
     """Return a stream-json NDJSON line for a content_block_delta event."""
-    return json.dumps({
-        "type": "content_block_delta",
-        "delta": {"type": "text_delta", "text": text},
-    })
+    return json.dumps(
+        {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": text},
+        }
+    )
 
 
 def _make_ndjson_callback(
@@ -120,7 +122,9 @@ class TestHangingProvider:
     def test_hanging_provider_result_data_preserved(self):
         """All NDJSON lines emitted before the hang are delivered to the callback."""
         completion_event = threading.Event()
-        output_callback, all_lines, result_values = _make_ndjson_callback(completion_event)
+        output_callback, all_lines, result_values = _make_ndjson_callback(
+            completion_event
+        )
 
         delta1 = _make_content_block_delta_ndjson("hello ")
         delta2 = _make_content_block_delta_ndjson("world")
@@ -164,8 +168,7 @@ class TestCleanExitProvider:
 
         result_line = _make_result_ndjson("clean exit result")
         script = (
-            "import sys\n"
-            f"print({result_line!r}, flush=True)\n"
+            f"import sys\nprint({result_line!r}, flush=True)\n"
             # Process exits immediately after printing
         )
 
@@ -192,11 +195,7 @@ class TestCleanExitProvider:
         output_callback, _, _ = _make_ndjson_callback(completion_event)
 
         result_line = _make_result_ndjson("done")
-        script = (
-            "import sys\n"
-            f"print({result_line!r}, flush=True)\n"
-            "sys.exit(42)\n"
-        )
+        script = f"import sys\nprint({result_line!r}, flush=True)\nsys.exit(42)\n"
 
         result = _run_subprocess(
             args=[_PYTHON, "-c", script],

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -928,9 +928,7 @@ class TestRunTasksDirQuietFlagPropagation:
 
             with patch("fdsx.core.engine.run_flow") as mock_run_flow:
                 with patch("fdsx.core.engine.display_tasks_dir_summary"):
-                    engine.run_tasks_dir(
-                        flow_path, tasks_dir, auto_workflow=True
-                    )
+                    engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
 
             assert mock_run_flow.called
             for call_args in mock_run_flow.call_args_list:

--- a/tests/integration/test_wait_resume.py
+++ b/tests/integration/test_wait_resume.py
@@ -13,44 +13,44 @@ class TestWaitFlow:
         flow, errors = load_flow(path)
         assert flow is not None, f"Failed to load: {errors}"
 
-    def test_wait_state_prompt_with_approve_selection(self):
+    def test_wait_state_prompt_with_approve_selection(self, tmp_path):
         """Test Wait → Choice routing: select approve → verify flow takes approve branch."""
         path = Path("tests/fixtures/wait_approval.yaml")
 
         # Mock stdin to provide "1" (approve)
         with patch("builtins.input", return_value="1"):
-            result = run_flow(path)
+            result = run_flow(path, base_dir=tmp_path)
 
         assert "plan_output" in result
         assert "approval_decision" in result
         assert result["approval_decision"] == "approve"
         assert "implementation_output" in result
 
-    def test_wait_state_prompt_with_reject_selection(self):
+    def test_wait_state_prompt_with_reject_selection(self, tmp_path):
         """Test Wait → Choice routing: select reject → verify flow takes reject branch."""
         path = Path("tests/fixtures/wait_approval.yaml")
 
         # Mock stdin to provide "2" (reject)
         with patch("builtins.input", return_value="2"):
-            result = run_flow(path)
+            result = run_flow(path, base_dir=tmp_path)
 
         assert "plan_output" in result
         assert "approval_decision" in result
         assert result["approval_decision"] == "reject"
         assert "rejected_output" in result
 
-    def test_wait_state_prompt_with_invalid_input_then_valid(self):
+    def test_wait_state_prompt_with_invalid_input_then_valid(self, tmp_path):
         """Test Wait state re-prompt on invalid input."""
         path = Path("tests/fixtures/wait_approval.yaml")
 
         # Mock stdin to provide invalid input first, then "1" (approve)
         with patch("builtins.input", side_effect=["invalid", "5", "1"]):
-            result = run_flow(path)
+            result = run_flow(path, base_dir=tmp_path)
 
         assert "approval_decision" in result
         assert result["approval_decision"] == "approve"
 
-    def test_wait_webhook_notification_sent(self):
+    def test_wait_webhook_notification_sent(self, tmp_path):
         """Test webhook notification: verify POST is sent when notify is configured."""
         path = Path("tests/fixtures/wait_webhook.yaml")
 
@@ -58,7 +58,7 @@ class TestWaitFlow:
             mock_webhook.return_value = True
 
             with patch("builtins.input", return_value="1"):
-                result = run_flow(path)
+                result = run_flow(path, base_dir=tmp_path)
 
             # Verify webhook was called
             assert mock_webhook.called
@@ -68,7 +68,7 @@ class TestWaitFlow:
             assert "plan_output" in result
             assert result["approval_decision"] == "approve"
 
-    def test_wait_webhook_sent_exactly_once_on_approve(self):
+    def test_wait_webhook_sent_exactly_once_on_approve(self, tmp_path):
         """Regression: webhook must fire exactly once, not on every resume cycle.
 
         Before the fix, send_notification() was called before interrupt() in the same
@@ -82,14 +82,14 @@ class TestWaitFlow:
             mock_webhook.return_value = True
 
             with patch("builtins.input", return_value="1"):
-                result = run_flow(path)
+                result = run_flow(path, base_dir=tmp_path)
 
         assert result["approval_decision"] == "approve"
         assert mock_webhook.call_count == 1, (
             f"Expected webhook called exactly once, got {mock_webhook.call_count}"
         )
 
-    def test_wait_webhook_failure_does_not_block_flow(self):
+    def test_wait_webhook_failure_does_not_block_flow(self, tmp_path):
         """Test webhook failure: verify flow continues normally (warning logged, prompt still shown)."""
         path = Path("tests/fixtures/wait_webhook.yaml")
 
@@ -98,7 +98,7 @@ class TestWaitFlow:
             mock_webhook.return_value = False
 
             with patch("builtins.input", return_value="1"):
-                result = run_flow(path)
+                result = run_flow(path, base_dir=tmp_path)
 
             # Verify webhook was called
             assert mock_webhook.called

--- a/tests/integration/test_workflow_persistence.py
+++ b/tests/integration/test_workflow_persistence.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 
 from fdsx.core import engine
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
@@ -31,7 +30,8 @@ class TestWorkflowPersistence:
                             flow_path, tasks_dir, auto_workflow=False
                         )
 
-            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            # After all entries complete, the file is moved to completed/
+            loaded = load_task_file(tasks_dir / "completed" / "001-test.yaml")
             assert loaded.entries[0].workflow is not None
             assert results[0]["status"] == "completed"
 
@@ -53,7 +53,7 @@ class TestWorkflowPersistence:
                             "fdsx.display.terminal.confirm_workflow_assignments_interactive",
                             return_value=None,
                         ):
-                            results = engine.run_tasks_dir(
+                            engine.run_tasks_dir(
                                 flow_path, tasks_dir, auto_workflow=False
                             )
 
@@ -126,7 +126,8 @@ class TestWorkflowPersistence:
                 "Selector should not be called when workflow is already persisted"
             )
 
-            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            # After all entries complete, the file is moved to completed/
+            loaded = load_task_file(tasks_dir / "completed" / "001-test.yaml")
             assert loaded.entries[0].workflow == "review.yaml"
             assert loaded.entries[0].status == "completed"
 
@@ -148,12 +149,13 @@ class TestWorkflowPersistence:
                             "fdsx.display.terminal.confirm_workflow_assignments_interactive"
                         ) as mock_cui:
                             mock_cui.return_value = {(0, 0): Path("review.yaml")}
-                            results = engine.run_tasks_dir(
+                            engine.run_tasks_dir(
                                 flow_path, tasks_dir, auto_workflow=False
                             )
 
             mock_cui.assert_called_once()
-            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            # After all entries complete, the file is moved to completed/
+            loaded = load_task_file(tasks_dir / "completed" / "001-test.yaml")
             assert loaded.entries[0].workflow == "review.yaml"
 
     def test_workflow_persists_with_correct_filename_format(self):
@@ -170,11 +172,10 @@ class TestWorkflowPersistence:
                     with patch(
                         "fdsx.display.terminal.is_interactive", return_value=False
                     ):
-                        results = engine.run_tasks_dir(
-                            flow_path, tasks_dir, auto_workflow=False
-                        )
+                        engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=False)
 
-            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            # After all entries complete, the file is moved to completed/
+            loaded = load_task_file(tasks_dir / "completed" / "001-test.yaml")
             wf = loaded.entries[0].workflow
             assert wf is not None
             assert "/" not in wf
@@ -203,7 +204,7 @@ class TestWorkflowPersistence:
                     ):
                         engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=False)
 
-            loaded = load_task_file(tasks_dir / "001-multi.yaml")
+            loaded = load_task_file(tasks_dir / "completed" / "001-multi.yaml")
             for entry in loaded.entries:
                 assert entry.workflow is not None
                 assert entry.status == "completed"

--- a/tests/unit/test_backoff.py
+++ b/tests/unit/test_backoff.py
@@ -22,6 +22,7 @@ class TestExponentialBackoff:
         state.result_path = "result"
 
         flow = MagicMock(spec=Flow)
+        flow.providers = None
 
         call_count = 0
         sleep_times = []
@@ -67,6 +68,7 @@ class TestExponentialBackoff:
         state.result_path = "result"
 
         flow = MagicMock(spec=Flow)
+        flow.providers = None
 
         call_count = 0
         sleep_times = []
@@ -111,6 +113,7 @@ class TestExponentialBackoff:
         state.result_path = "result"
 
         flow = MagicMock(spec=Flow)
+        flow.providers = None
 
         call_count = 0
         sleep_times = []
@@ -156,6 +159,7 @@ class TestExponentialBackoff:
         state.result_path = "result"
 
         flow = MagicMock(spec=Flow)
+        flow.providers = None
 
         call_count = 0
         sleep_times = []
@@ -204,6 +208,7 @@ class TestExponentialBackoff:
         parallel_state.branches = [branch]
 
         flow = MagicMock(spec=Flow)
+        flow.providers = None
 
         call_count = 0
         sleep_times = []

--- a/tests/unit/test_checkpoint.py
+++ b/tests/unit/test_checkpoint.py
@@ -157,7 +157,9 @@ class TestCheckpointManager:
         entry = next(t for t in threads if t["thread_id"] == "run-log-only-thread")
         assert entry["flow_name"] == "my_flow"
 
-    def test_list_threads_no_duplicate_for_run_log_and_checkpoint(self, manager, temp_dir):
+    def test_list_threads_no_duplicate_for_run_log_and_checkpoint(
+        self, manager, temp_dir
+    ):
         """T003: a thread present in both DB and run log must appear only once."""
         import json
         import sqlite3
@@ -196,11 +198,13 @@ class TestCheckpointManager:
         threads = manager.list_threads()
 
         dual_entries = [t for t in threads if t["thread_id"] == "dual-thread"]
-        assert len(dual_entries) == 1, "Thread must appear exactly once even if in both DB and run log"
+        assert len(dual_entries) == 1, (
+            "Thread must appear exactly once even if in both DB and run log"
+        )
 
     def test_list_threads_ignores_dirs_without_run_json(self, manager, temp_dir):
         """T003: directories in runs/ without a run.json file must not appear."""
-        from fdsx.logging.recorder import RUNS_DIR_NAME, RUN_FILENAME
+        from fdsx.logging.recorder import RUNS_DIR_NAME
 
         runs_dir = manager.base_dir / RUNS_DIR_NAME
         # A directory without run.json

--- a/tests/unit/test_claude_stream_parser.py
+++ b/tests/unit/test_claude_stream_parser.py
@@ -36,15 +36,37 @@ def _make_provider() -> ClaudeProvider:
 
 
 def _build_text_delta_line(text: str, index: int = 0) -> str:
-    return json.dumps({"type": _EVENT_CONTENT_BLOCK_DELTA, "index": index, "delta": {"type": _DELTA_TYPE_TEXT, "text": text}})
+    return json.dumps(
+        {
+            "type": _EVENT_CONTENT_BLOCK_DELTA,
+            "index": index,
+            "delta": {"type": _DELTA_TYPE_TEXT, "text": text},
+        }
+    )
 
 
 def _build_thinking_delta_line(thinking: str, index: int = 0) -> str:
-    return json.dumps({"type": _EVENT_CONTENT_BLOCK_DELTA, "index": index, "delta": {"type": _DELTA_TYPE_THINKING, "thinking": thinking}})
+    return json.dumps(
+        {
+            "type": _EVENT_CONTENT_BLOCK_DELTA,
+            "index": index,
+            "delta": {"type": _DELTA_TYPE_THINKING, "thinking": thinking},
+        }
+    )
 
 
 def _build_tool_use_start_line(tool_name: str, index: int = 1) -> str:
-    return json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": index, "content_block": {"type": _CONTENT_TYPE_TOOL_USE, "id": "tu_001", "name": tool_name}})
+    return json.dumps(
+        {
+            "type": _EVENT_CONTENT_BLOCK_START,
+            "index": index,
+            "content_block": {
+                "type": _CONTENT_TYPE_TOOL_USE,
+                "id": "tu_001",
+                "name": tool_name,
+            },
+        }
+    )
 
 
 def _build_content_block_stop_line(index: int = 0) -> str:
@@ -52,7 +74,14 @@ def _build_content_block_stop_line(index: int = 0) -> str:
 
 
 def _build_result_line(result_text: str) -> str:
-    return json.dumps({"type": _EVENT_RESULT, "subtype": "success", "is_error": False, "result": result_text})
+    return json.dumps(
+        {
+            "type": _EVENT_RESULT,
+            "subtype": "success",
+            "is_error": False,
+            "result": result_text,
+        }
+    )
 
 
 def _wrap_in_stream_event(inner_json: str) -> str:
@@ -166,7 +195,13 @@ class TestToolUseContentBlockStart:
         provider = _make_provider()
         cb, _, _ = provider._make_stream_callback(received.append)
 
-        line = json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": 0, "content_block": {"type": _CONTENT_TYPE_TOOL_USE}})
+        line = json.dumps(
+            {
+                "type": _EVENT_CONTENT_BLOCK_START,
+                "index": 0,
+                "content_block": {"type": _CONTENT_TYPE_TOOL_USE},
+            }
+        )
         cb(line)
 
         assert received == ["[tool: unknown]"]
@@ -177,7 +212,13 @@ class TestToolUseContentBlockStart:
         provider = _make_provider()
         cb, _, _ = provider._make_stream_callback(received.append)
 
-        line = json.dumps({"type": _EVENT_CONTENT_BLOCK_START, "index": 0, "content_block": {"type": "text", "text": ""}})
+        line = json.dumps(
+            {
+                "type": _EVENT_CONTENT_BLOCK_START,
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }
+        )
         cb(line)
 
         assert received == []
@@ -210,7 +251,9 @@ class TestResultEvent:
         provider = _make_provider()
         cb, get_result, _ = provider._make_stream_callback(lambda _: None)
 
-        line = json.dumps({"type": _EVENT_RESULT, "subtype": "error", "result": "error message text"})
+        line = json.dumps(
+            {"type": _EVENT_RESULT, "subtype": "error", "result": "error message text"}
+        )
         cb(line)
 
         assert get_result() == "error message text"

--- a/tests/unit/test_cli_version.py
+++ b/tests/unit/test_cli_version.py
@@ -1,0 +1,18 @@
+import re
+
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+
+
+class TestCliVersion:
+    def test_version_flag_outputs_version_and_exits(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(app, ["--version"])
+
+        assert result.exit_code == 0, (
+            f"Expected exit 0, got {result.exit_code}. output: {result.output}"
+        )
+        assert re.fullmatch(r"fdsx \d+\.\d+\.\d+[^\n]*\n", result.output), (
+            f"Expected output matching 'fdsx X.Y.Z', got: {result.output!r}"
+        )

--- a/tests/unit/test_codex_stream_parser.py
+++ b/tests/unit/test_codex_stream_parser.py
@@ -172,7 +172,12 @@ class TestCommandExecution:
         provider = _make_provider()
         cb, _ = provider._make_stream_callback(received.append)
 
-        line = json.dumps({"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": _ITEM_TYPE_COMMAND_EXECUTION}})
+        line = json.dumps(
+            {
+                "type": _EVENT_ITEM_STARTED,
+                "item": {"id": "x", "type": _ITEM_TYPE_COMMAND_EXECUTION},
+            }
+        )
         cb(line)
 
         assert received == ["[tool: unknown]"]
@@ -183,7 +188,11 @@ class TestCommandExecution:
         provider = _make_provider()
         cb, _ = provider._make_stream_callback(received.append)
 
-        cb(_build_item_completed(_ITEM_TYPE_COMMAND_EXECUTION, command="echo hello", output="hello"))
+        cb(
+            _build_item_completed(
+                _ITEM_TYPE_COMMAND_EXECUTION, command="echo hello", output="hello"
+            )
+        )
 
         assert received == []
 
@@ -241,7 +250,12 @@ class TestMcpToolCall:
         provider = _make_provider()
         cb, _ = provider._make_stream_callback(received.append)
 
-        line = json.dumps({"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": _ITEM_TYPE_MCP_TOOL_CALL}})
+        line = json.dumps(
+            {
+                "type": _EVENT_ITEM_STARTED,
+                "item": {"id": "x", "type": _ITEM_TYPE_MCP_TOOL_CALL},
+            }
+        )
         cb(line)
 
         assert received == ["[tool: unknown]"]
@@ -252,7 +266,11 @@ class TestMcpToolCall:
         provider = _make_provider()
         cb, _ = provider._make_stream_callback(received.append)
 
-        cb(_build_item_completed(_ITEM_TYPE_MCP_TOOL_CALL, name="web_search", result=""))
+        cb(
+            _build_item_completed(
+                _ITEM_TYPE_MCP_TOOL_CALL, name="web_search", result=""
+            )
+        )
 
         assert received == []
 
@@ -439,7 +457,9 @@ class TestUnknownEventsIgnored:
         provider = _make_provider()
         cb, _ = provider._make_stream_callback(received.append)
 
-        line = json.dumps({"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": "future_item"}})
+        line = json.dumps(
+            {"type": _EVENT_ITEM_STARTED, "item": {"id": "x", "type": "future_item"}}
+        )
         cb(line)
 
         assert received == []
@@ -450,7 +470,9 @@ class TestUnknownEventsIgnored:
         provider = _make_provider()
         cb, get_result = provider._make_stream_callback(received.append)
 
-        line = json.dumps({"type": _EVENT_ITEM_COMPLETED, "item": {"id": "x", "type": "future_item"}})
+        line = json.dumps(
+            {"type": _EVENT_ITEM_COMPLETED, "item": {"id": "x", "type": "future_item"}}
+        )
         cb(line)
 
         assert received == []

--- a/tests/unit/test_compiler_merge.py
+++ b/tests/unit/test_compiler_merge.py
@@ -1,7 +1,5 @@
 """Unit tests for _merge_provider_options() in compiler (T016)."""
 
-import pytest
-
 from fdsx.core.compiler import _merge_provider_options
 from fdsx.core.config import FdsxConfig, ProviderConfigs
 from fdsx.models.flow import Flow, TaskState
@@ -94,7 +92,9 @@ class TestMergeProviderOptionsWorkflowOverrides:
     def test_workflow_overrides_config(self):
         """Workflow-level options override config-level options for same key."""
         config = _make_config({"permission_mode": "acceptEdits"})
-        flow = _make_simple_flow(providers={"claude": {"permission_mode": "bypassPermissions"}})
+        flow = _make_simple_flow(
+            providers={"claude": {"permission_mode": "bypassPermissions"}}
+        )
 
         result = _merge_provider_options(config, flow, "claude", None)
 
@@ -104,7 +104,9 @@ class TestMergeProviderOptionsWorkflowOverrides:
     def test_workflow_only_no_config(self):
         """Workflow-level options are used even when config has no providers."""
         config = FdsxConfig()
-        flow = _make_simple_flow(providers={"claude": {"dangerously_skip_permissions": True}})
+        flow = _make_simple_flow(
+            providers={"claude": {"dangerously_skip_permissions": True}}
+        )
 
         result = _merge_provider_options(config, flow, "claude", None)
 
@@ -114,7 +116,9 @@ class TestMergeProviderOptionsWorkflowOverrides:
     def test_workflow_adds_to_config(self):
         """Workflow can set different keys from config (both keys appear in result)."""
         config = _make_config({"permission_mode": "acceptEdits"})
-        flow = _make_simple_flow(providers={"claude": {"dangerously_skip_permissions": True}})
+        flow = _make_simple_flow(
+            providers={"claude": {"dangerously_skip_permissions": True}}
+        )
 
         result = _merge_provider_options(config, flow, "claude", None)
 
@@ -150,7 +154,9 @@ class TestMergeProviderOptionsTaskOverrides:
     def test_task_overrides_workflow(self):
         """Task-level options override workflow-level options for same key."""
         config = FdsxConfig()
-        flow = _make_simple_flow(providers={"claude": {"permission_mode": "acceptEdits"}})
+        flow = _make_simple_flow(
+            providers={"claude": {"permission_mode": "acceptEdits"}}
+        )
         task_opts = {"permission_mode": "bypassPermissions"}
 
         result = _merge_provider_options(config, flow, "claude", task_opts)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -361,9 +361,7 @@ class TestFdsxConfigProviders:
     def test_extra_claude_field_rejected(self):
         """Unknown fields inside a provider's options are rejected."""
         with pytest.raises(ValidationError):
-            FdsxConfig.model_validate(
-                {"providers": {"claude": {"unknown_flag": True}}}
-            )
+            FdsxConfig.model_validate({"providers": {"claude": {"unknown_flag": True}}})
 
     def test_backward_compat_without_providers(self):
         """Existing configs without a providers section still parse correctly."""
@@ -398,7 +396,9 @@ class TestLoadConfigWithProviders:
             config_dir.mkdir()
             global_file = config_dir / "config.yaml"
             global_file.write_text(
-                yaml.dump({"providers": {"claude": {"permission_mode": "bypassPermissions"}}})
+                yaml.dump(
+                    {"providers": {"claude": {"permission_mode": "bypassPermissions"}}}
+                )
             )
 
             project_dir = Path(tmpdir)
@@ -406,7 +406,9 @@ class TestLoadConfigWithProviders:
             fdsx_dir.mkdir()
             project_file = fdsx_dir / "config.yaml"
             project_file.write_text(
-                yaml.dump({"providers": {"claude": {"dangerously_skip_permissions": True}}})
+                yaml.dump(
+                    {"providers": {"claude": {"dangerously_skip_permissions": True}}}
+                )
             )
 
             original_xdg = os.environ.get("XDG_CONFIG_HOME")
@@ -441,7 +443,9 @@ class TestLoadConfigWithProviders:
             fdsx_dir.mkdir()
             project_file = fdsx_dir / "config.yaml"
             project_file.write_text(
-                yaml.dump({"providers": {"claude": {"permission_mode": "bypassPermissions"}}})
+                yaml.dump(
+                    {"providers": {"claude": {"permission_mode": "bypassPermissions"}}}
+                )
             )
 
             original_xdg = os.environ.get("XDG_CONFIG_HOME")
@@ -525,9 +529,7 @@ class TestFdsxConfigHooks:
     def test_hooks_empty_command_rejected(self):
         """T018: Empty command in hook entry must be rejected."""
         with pytest.raises(ValidationError):
-            FdsxConfig.model_validate(
-                {"hooks": {"on_start": [{"command": ""}]}}
-            )
+            FdsxConfig.model_validate({"hooks": {"on_start": [{"command": ""}]}})
 
 
 class TestDeepMergeHookListConcatenation:
@@ -545,7 +547,9 @@ class TestDeepMergeHookListConcatenation:
     def test_on_complete_lists_are_concatenated(self):
         """T018: on_complete lists from base and override are concatenated."""
         base = {"hooks": {"on_start": [], "on_complete": [{"command": "cleanup.sh"}]}}
-        override = {"hooks": {"on_start": [], "on_complete": [{"command": "notify.sh"}]}}
+        override = {
+            "hooks": {"on_start": [], "on_complete": [{"command": "notify.sh"}]}
+        }
         result = _deep_merge(base, override)
         assert len(result["hooks"]["on_complete"]) == 2
         assert result["hooks"]["on_complete"][0]["command"] == "cleanup.sh"

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta, timezone
 from io import StringIO
-from pathlib import Path
 from unittest.mock import patch
 
 from fdsx.core.engine import (

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -185,9 +185,7 @@ class TestExecuteHooks:
         return_codes = [1, 0]
 
         with patch("subprocess.run") as mock_run:
-            mock_run.side_effect = [
-                MagicMock(returncode=rc) for rc in return_codes
-            ]
+            mock_run.side_effect = [MagicMock(returncode=rc) for rc in return_codes]
             execute_hooks(
                 hooks,
                 state_name="S",
@@ -218,7 +216,6 @@ class TestExecuteHooks:
 
     def test_multiple_hooks_run_in_order(self, tmp_path: Path) -> None:
         """Multiple hooks run in list order."""
-        calls: list[str] = []
         hooks = [
             self._make_hook("hook-a"),
             self._make_hook("hook-b"),
@@ -286,7 +283,12 @@ class TestWriteHookData:
         )
 
         expected = (
-            tmp_path / RUNS_DIR_NAME / "thread-001" / HOOKS_DIR_NAME / "Planner" / INPUT_FILENAME
+            tmp_path
+            / RUNS_DIR_NAME
+            / "thread-001"
+            / HOOKS_DIR_NAME
+            / "Planner"
+            / INPUT_FILENAME
         )
         assert file_path == expected
         assert file_path.exists()
@@ -303,7 +305,12 @@ class TestWriteHookData:
         )
 
         expected = (
-            tmp_path / RUNS_DIR_NAME / "thread-002" / HOOKS_DIR_NAME / "Executor" / OUTPUT_FILENAME
+            tmp_path
+            / RUNS_DIR_NAME
+            / "thread-002"
+            / HOOKS_DIR_NAME
+            / "Executor"
+            / OUTPUT_FILENAME
         )
         assert file_path == expected
 
@@ -386,7 +393,9 @@ class TestWriteHookData:
             loaded = json.load(f)
         assert loaded == second_data
 
-    def test_default_base_dir_uses_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_base_dir_uses_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """When base_dir is None, path is rooted at CWD/.fdsx/."""
         monkeypatch.chdir(tmp_path)
         file_path = write_hook_data(
@@ -396,7 +405,15 @@ class TestWriteHookData:
             thread_id="t",
         )
 
-        expected_root = tmp_path / ".fdsx" / RUNS_DIR_NAME / "t" / HOOKS_DIR_NAME / "S" / INPUT_FILENAME
+        expected_root = (
+            tmp_path
+            / ".fdsx"
+            / RUNS_DIR_NAME
+            / "t"
+            / HOOKS_DIR_NAME
+            / "S"
+            / INPUT_FILENAME
+        )
         assert file_path == expected_root
 
     def test_returns_path_object(self, tmp_path: Path) -> None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -768,7 +768,9 @@ class TestHooksFieldOnStates:
         """T017: ChoiceState.hooks is None when not specified."""
         state = ChoiceState(
             type="choice",
-            choices=[ChoiceRule(variable="$.x", operator="equals", value="a", next="b")],
+            choices=[
+                ChoiceRule(variable="$.x", operator="equals", value="a", next="b")
+            ],
         )
         assert state.hooks is None
 
@@ -776,7 +778,9 @@ class TestHooksFieldOnStates:
         """T017: ChoiceState accepts a HookConfig."""
         state = ChoiceState(
             type="choice",
-            choices=[ChoiceRule(variable="$.x", operator="equals", value="a", next="b")],
+            choices=[
+                ChoiceRule(variable="$.x", operator="equals", value="a", next="b")
+            ],
             hooks=HookConfig(on_complete=[HookEntry(command="echo done")]),
         )
         assert state.hooks is not None
@@ -793,7 +797,9 @@ class TestHooksFieldOnStates:
             branches=[],
             result_path="$.r",
             end=True,
-            hooks=HookConfig(on_start=[HookEntry(command="init.sh", on_failure="abort")]),
+            hooks=HookConfig(
+                on_start=[HookEntry(command="init.sh", on_failure="abort")]
+            ),
         )
         assert state.hooks is not None
 

--- a/tests/unit/test_provider_options.py
+++ b/tests/unit/test_provider_options.py
@@ -23,7 +23,14 @@ class TestClaudeOptions:
 
     def test_claude_options_permission_mode_valid(self):
         """Valid permission_mode literals must be accepted."""
-        for mode in ("default", "acceptEdits", "bypassPermissions", "dontAsk", "plan", "auto"):
+        for mode in (
+            "default",
+            "acceptEdits",
+            "bypassPermissions",
+            "dontAsk",
+            "plan",
+            "auto",
+        ):
             opts = ClaudeOptions(permission_mode=mode)
             assert opts.permission_mode == mode
 
@@ -50,7 +57,12 @@ class TestClaudeOptions:
     def test_claude_options_to_cli_flags_allowed_tools(self):
         """allowed_tools maps to repeated --allowedTools <tool>."""
         opts = ClaudeOptions(allowed_tools=["Bash", "Read"])
-        assert opts.to_cli_flags() == ["--allowedTools", "Bash", "--allowedTools", "Read"]
+        assert opts.to_cli_flags() == [
+            "--allowedTools",
+            "Bash",
+            "--allowedTools",
+            "Read",
+        ]
 
     def test_claude_options_to_cli_flags_disallowed_tools(self):
         """disallowed_tools maps to repeated --disallowedTools <tool>."""
@@ -76,10 +88,13 @@ class TestClaudeOptions:
             disallowed_tools=["Write"],
         )
         assert opts.to_cli_flags() == [
-            "--permission-mode", "bypassPermissions",
+            "--permission-mode",
+            "bypassPermissions",
             "--dangerously-skip-permissions",
-            "--allowedTools", "Bash",
-            "--disallowedTools", "Write",
+            "--allowedTools",
+            "Bash",
+            "--disallowedTools",
+            "Write",
         ]
 
 
@@ -160,8 +175,10 @@ class TestCodexOptions:
             dangerously_bypass_approvals_and_sandbox=True,
         )
         assert opts.to_cli_flags() == [
-            "--sandbox", "workspace-write",
-            "--approval-policy", "on-request",
+            "--sandbox",
+            "workspace-write",
+            "--approval-policy",
+            "on-request",
             "--full-auto",
             "--dangerously-bypass-approvals-and-sandbox",
         ]

--- a/tests/unit/test_provider_stdin_fallback.py
+++ b/tests/unit/test_provider_stdin_fallback.py
@@ -40,7 +40,9 @@ class TestClaudeStdinFallback:
     def test_small_prompt_uses_args(self) -> None:
         """T01: prompt < threshold → prompt in args, stdin_data=None."""
         provider = ClaudeProvider()
-        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(SMALL_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -50,7 +52,9 @@ class TestClaudeStdinFallback:
     def test_large_prompt_uses_stdin(self) -> None:
         """T02: prompt above threshold → prompt NOT in args, stdin_data=prompt."""
         provider = ClaudeProvider()
-        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(ABOVE_THRESHOLD_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -61,7 +65,9 @@ class TestClaudeStdinFallback:
         """T03: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt."""
         options = ClaudeOptions(dangerously_skip_permissions=True)
         provider = ClaudeProvider(options)
-        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(ABOVE_THRESHOLD_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -72,7 +78,9 @@ class TestClaudeStdinFallback:
     def test_prompt_at_threshold_uses_stdin(self) -> None:
         """T10: prompt exactly at threshold → uses stdin (boundary case)."""
         provider = ClaudeProvider()
-        with patch("fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.claude._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(LARGE_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -86,7 +94,9 @@ class TestCodexStdinFallback:
     def test_small_prompt_uses_args(self) -> None:
         """T04: prompt < threshold → prompt in args, stdin_data=None."""
         provider = CodexProvider()
-        with patch("fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(SMALL_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -96,7 +106,9 @@ class TestCodexStdinFallback:
     def test_large_prompt_uses_stdin(self) -> None:
         """T05: prompt >= threshold → prompt NOT in args, stdin_data=prompt."""
         provider = CodexProvider()
-        with patch("fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(ABOVE_THRESHOLD_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -107,7 +119,9 @@ class TestCodexStdinFallback:
         """T06: prompt >= threshold + flags → flags in args, prompt NOT in args, stdin_data=prompt."""
         options = CodexOptions(full_auto=True)
         provider = CodexProvider(options)
-        with patch("fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.codex._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(ABOVE_THRESHOLD_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -122,7 +136,9 @@ class TestOpenCodeStdinFallback:
     def test_small_prompt_uses_args(self) -> None:
         """T07: prompt < threshold → prompt in args, stdin_data=None."""
         provider = OpenCodeProvider()
-        with patch("fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(SMALL_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -132,7 +148,9 @@ class TestOpenCodeStdinFallback:
     def test_large_prompt_uses_stdin(self) -> None:
         """T08: prompt >= threshold → prompt NOT in args, stdin_data=prompt."""
         provider = OpenCodeProvider()
-        with patch("fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(ABOVE_THRESHOLD_PROMPT)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs
@@ -143,7 +161,9 @@ class TestOpenCodeStdinFallback:
         """T09: prompt >= threshold + model flag → `-m model` in args, prompt NOT in args, stdin_data=prompt."""
         model = "gpt-4o"
         provider = OpenCodeProvider()
-        with patch("fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS) as mock_run:
+        with patch(
+            "fdsx.providers.opencode._run_subprocess", return_value=FAKE_SUCCESS
+        ) as mock_run:
             provider.execute(ABOVE_THRESHOLD_PROMPT, model=model)
         mock_run.assert_called_once()
         kwargs = mock_run.call_args.kwargs

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -178,7 +178,8 @@ class TestRunRecorder:
 
             file_path = recorder.save(base_dir=Path(tmpdir))
 
-            assert file_path == Path(tmpdir) / "runs" / "test-123" / RUN_FILENAME
+            expected = (Path(tmpdir) / "runs" / "test-123" / RUN_FILENAME).resolve()
+            assert file_path == expected
             assert file_path.exists()
 
             with open(file_path, "r") as f:
@@ -276,7 +277,9 @@ class TestRunRecorder:
                 recorder.finalize({"key": "value"}, "completed")
                 file_path = recorder.save()
 
-                expected = Path(tmpdir) / ".fdsx" / "runs" / "test-nobase" / RUN_FILENAME
+                expected = (
+                    Path(tmpdir) / ".fdsx" / "runs" / "test-nobase" / RUN_FILENAME
+                ).resolve()
                 assert file_path == expected
                 assert file_path.exists()
             finally:

--- a/tests/unit/test_result_file.py
+++ b/tests/unit/test_result_file.py
@@ -14,6 +14,7 @@ Phase 3:
 """
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -246,27 +247,30 @@ class TestMetaRunDir:
 
         captured: list[dict] = []
         mock_graph = MagicMock()
-        mock_graph.stream.side_effect = lambda state, **kw: (
-            captured.append(state) or []
-        )
+        mock_graph.stream.side_effect = lambda state, **kw: captured.append(state) or []
         mock_graph.get_state.return_value = MagicMock(tasks=[], values={})
         mock_compiled = MagicMock()
         mock_compiled.graph = mock_graph
         mock_compiled.result_paths = []
 
-        with (
-            patch("fdsx.core.engine.compile_flow", return_value=mock_compiled),
-            patch("fdsx.core.engine.RunRecorder") as mock_recorder_cls,
-            patch("fdsx.core.engine.display_completion_summary"),
-            patch("fdsx.core.engine.load_config"),
-        ):
-            mock_recorder_instance = MagicMock()
-            mock_recorder_instance.started_at = "2026-01-01T00:00:00+00:00"
-            mock_recorder_instance.completed_at = None
-            mock_recorder_instance.states = []
-            mock_recorder_instance.flow_name = "test"
-            mock_recorder_cls.return_value = mock_recorder_instance
-            run_flow(flow_path, thread_id=thread_id)
+        original_cwd = Path.cwd()
+        try:
+            os.chdir(flow_path.parent)
+            with (
+                patch("fdsx.core.engine.compile_flow", return_value=mock_compiled),
+                patch("fdsx.core.engine.RunRecorder") as mock_recorder_cls,
+                patch("fdsx.core.engine.display_completion_summary"),
+                patch("fdsx.core.engine.load_config"),
+            ):
+                mock_recorder_instance = MagicMock()
+                mock_recorder_instance.started_at = "2026-01-01T00:00:00+00:00"
+                mock_recorder_instance.completed_at = None
+                mock_recorder_instance.states = []
+                mock_recorder_instance.flow_name = "test"
+                mock_recorder_cls.return_value = mock_recorder_instance
+                run_flow(flow_path, thread_id=thread_id)
+        finally:
+            os.chdir(original_cwd)
 
         assert len(captured) == 1, "compile_flow.graph.stream was not called"
         return captured[0]

--- a/tests/unit/test_selector.py
+++ b/tests/unit/test_selector.py
@@ -200,14 +200,10 @@ class TestDiscoverWorkflows:
 
     def test_directory_shadows_flat_file(self, tmp_path):
         """A directory 'review' shadows a flat file 'review.yaml'."""
-        (tmp_path / "review.yaml").write_text(
-            _minimal_workflow("RF", "Review flat")
-        )
+        (tmp_path / "review.yaml").write_text(_minimal_workflow("RF", "Review flat"))
         review_dir = tmp_path / "review"
         review_dir.mkdir()
-        (review_dir / "workflow.yaml").write_text(
-            _minimal_workflow("RD", "Review dir")
-        )
+        (review_dir / "workflow.yaml").write_text(_minimal_workflow("RD", "Review dir"))
 
         results = discover_workflows(tmp_path)
 
@@ -268,7 +264,9 @@ class TestDiscoverWorkflows:
         link_dir = tmp_path / "linked"
         link_dir.symlink_to(real_dir)
 
-        with pytest.warns(RuntimeWarning, match="Skipping symlinked workflow directory"):
+        with pytest.warns(
+            RuntimeWarning, match="Skipping symlinked workflow directory"
+        ):
             results = discover_workflows(tmp_path)
 
         # real_dir is also a subdirectory, so it should be discovered
@@ -815,7 +813,10 @@ class TestResolveWorkflowForTask:
             )
 
             # input() must NOT be called — if it is, the MagicMock raises on iteration
-            with patch("builtins.input", side_effect=AssertionError("input() must not be called in auto mode")):
+            with patch(
+                "builtins.input",
+                side_effect=AssertionError("input() must not be called in auto mode"),
+            ):
                 result = resolve_workflow_for_task(
                     task_description="Do something",
                     workflows_dir=workflows_dir,

--- a/tests/unit/test_stream_logger.py
+++ b/tests/unit/test_stream_logger.py
@@ -13,11 +13,7 @@ Tests verify:
 
 import sys
 import threading
-from io import StringIO
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from fdsx.logging.stream_logger import LOG_FILE_SUFFIX, StreamLogger
 
@@ -267,8 +263,12 @@ class TestStreamLoggerQuietMode:
         logger_quiet.on_stderr("line two")
         logger_quiet.close()
 
-        normal_content = (log_dir_normal / f"State{LOG_FILE_SUFFIX}").read_text(encoding="utf-8")
-        quiet_content = (log_dir_quiet / f"State{LOG_FILE_SUFFIX}").read_text(encoding="utf-8")
+        normal_content = (log_dir_normal / f"State{LOG_FILE_SUFFIX}").read_text(
+            encoding="utf-8"
+        )
+        quiet_content = (log_dir_quiet / f"State{LOG_FILE_SUFFIX}").read_text(
+            encoding="utf-8"
+        )
         assert normal_content == quiet_content
 
     def test_quiet_true_log_file_still_created(self, tmp_path):

--- a/tests/unit/test_subprocess_completion.py
+++ b/tests/unit/test_subprocess_completion.py
@@ -291,7 +291,11 @@ class TestCompletionEvent:
         try:
             start = time.time()
             result = _run_subprocess(
-                args=[_PYTHON, "-c", "import sys,time; print('output',flush=True); time.sleep(999)"],
+                args=[
+                    _PYTHON,
+                    "-c",
+                    "import sys,time; print('output',flush=True); time.sleep(999)",
+                ],
                 completion_event=event,
             )
             elapsed = time.time() - start
@@ -312,7 +316,11 @@ class TestCompletionEvent:
         try:
             start = time.time()
             result = _run_subprocess(
-                args=[_PYTHON, "-c", "import time; print('voluntary',flush=True); time.sleep(1)"],
+                args=[
+                    _PYTHON,
+                    "-c",
+                    "import time; print('voluntary',flush=True); time.sleep(1)",
+                ],
                 completion_event=event,
             )
             elapsed = time.time() - start
@@ -334,7 +342,8 @@ class TestCompletionEvent:
             start = time.time()
             result = _run_subprocess(
                 args=[
-                    _PYTHON, "-c",
+                    _PYTHON,
+                    "-c",
                     "import signal,time; signal.signal(signal.SIGTERM,signal.SIG_IGN);"
                     " print('output',flush=True); time.sleep(999)",
                 ],
@@ -369,7 +378,8 @@ class TestCompletionEvent:
         try:
             result = _run_subprocess(
                 args=[
-                    _PYTHON, "-c",
+                    _PYTHON,
+                    "-c",
                     "import time;"
                     " print('line1',flush=True);"
                     " print('line2',flush=True);"
@@ -395,7 +405,8 @@ class TestCompletionEvent:
             with caplog.at_level(logging.DEBUG, logger="fdsx.providers.base"):
                 _run_subprocess(
                     args=[
-                        _PYTHON, "-c",
+                        _PYTHON,
+                        "-c",
                         "import signal,time; signal.signal(signal.SIGTERM,signal.SIG_IGN);"
                         " print('x',flush=True); time.sleep(999)",
                     ],
@@ -414,7 +425,11 @@ class TestCompletionEvent:
         try:
             with caplog.at_level(logging.DEBUG, logger="fdsx.providers.base"):
                 _run_subprocess(
-                    args=[_PYTHON, "-c", "print('ok',flush=True); import time; time.sleep(1)"],
+                    args=[
+                        _PYTHON,
+                        "-c",
+                        "print('ok',flush=True); import time; time.sleep(1)",
+                    ],
                     completion_event=event,
                 )
         finally:
@@ -454,7 +469,8 @@ class TestCompletionEventTimeoutInteraction:
         try:
             result = _run_subprocess(
                 args=[
-                    _PYTHON, "-c",
+                    _PYTHON,
+                    "-c",
                     "import time; print('data',flush=True); time.sleep(999)",
                 ],
                 timeout=30,
@@ -483,10 +499,12 @@ def _make_result_ndjson(result_value: str = "ok") -> str:
 
 def _make_content_block_delta_ndjson(text: str = "hello") -> str:
     """Return a stream-json NDJSON line for a content_block_delta event."""
-    return json.dumps({
-        "type": "content_block_delta",
-        "delta": {"type": "text_delta", "text": text},
-    })
+    return json.dumps(
+        {
+            "type": "content_block_delta",
+            "delta": {"type": "text_delta", "text": text},
+        }
+    )
 
 
 class TestMakeStreamCallbackCompletionEvent:
@@ -532,10 +550,19 @@ class TestMakeStreamCallbackCompletionEvent:
             output_lines.append, completion_event=event
         )
 
-        stream_callback(json.dumps({"type": "content_block_start", "content_block": {"type": "text", "text": ""}}))
+        stream_callback(
+            json.dumps(
+                {
+                    "type": "content_block_start",
+                    "content_block": {"type": "text", "text": ""},
+                }
+            )
+        )
         stream_callback(json.dumps({"type": "content_block_stop"}))
 
-        assert not event.is_set(), "Event should not be set for content_block_start/stop"
+        assert not event.is_set(), (
+            "Event should not be set for content_block_start/stop"
+        )
 
     def test_completion_event_set_exactly_once_on_multiple_result_events(self):
         """Event.set() is idempotent — multiple result events do not raise errors."""
@@ -582,7 +609,9 @@ class TestClaudeProviderExecuteCompletionEvent:
             captured_kwargs.update(kwargs)
             return ProviderResult(exit_code=0, stdout="", stderr="")
 
-        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="hello", output_callback=output_lines.append)
 
         assert "completion_event" in captured_kwargs, (
@@ -601,7 +630,9 @@ class TestClaudeProviderExecuteCompletionEvent:
             captured_kwargs.update(kwargs)
             return ProviderResult(exit_code=0, stdout="done", stderr="")
 
-        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess):
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
             provider.execute(prompt="hello")
 
         # No completion_event key, or it is None

--- a/tests/unit/test_subprocess_realtime_streaming.py
+++ b/tests/unit/test_subprocess_realtime_streaming.py
@@ -20,17 +20,17 @@ from fdsx.providers.base import _run_subprocess
 # flush=True is critical: ensures the child process flushes to the pipe
 # immediately, isolating the Python-side iterator buffering as the sole cause.
 _STDOUT_CMD = (
-    "python3 -c \""
+    'python3 -c "'
     "import sys, time; "
     "[print(f'line{i}', flush=True) or time.sleep(0.3) for i in range(3)]"
-    "\""
+    '"'
 )
 
 _STDERR_CMD = (
-    "python3 -c \""
+    'python3 -c "'
     "import sys, time; "
     "[print(f'line{i}', file=sys.stderr, flush=True) or time.sleep(0.3) for i in range(3)]"
-    "\""
+    '"'
 )
 
 # A callback firing this many seconds before process completion is evidence of

--- a/tests/unit/test_subprocess_stdin.py
+++ b/tests/unit/test_subprocess_stdin.py
@@ -75,7 +75,11 @@ class TestSubprocessStdinFallback:
         # Format: "_pad=<padding>; echo boundary_ok"
         prefix = "_pad="
         suffix = "; echo boundary_ok"
-        padding_len = ARG_MAX_STDIN_THRESHOLD - len(prefix.encode("utf-8")) - len(suffix.encode("utf-8"))
+        padding_len = (
+            ARG_MAX_STDIN_THRESHOLD
+            - len(prefix.encode("utf-8"))
+            - len(suffix.encode("utf-8"))
+        )
         cmd = prefix + ("x" * padding_len) + suffix
 
         assert len(cmd.encode("utf-8")) == ARG_MAX_STDIN_THRESHOLD
@@ -90,7 +94,12 @@ class TestSubprocessStdinFallback:
         # Construct a command that is exactly one byte below threshold.
         prefix = "_pad="
         suffix = "; echo below_ok"
-        padding_len = ARG_MAX_STDIN_THRESHOLD - 1 - len(prefix.encode("utf-8")) - len(suffix.encode("utf-8"))
+        padding_len = (
+            ARG_MAX_STDIN_THRESHOLD
+            - 1
+            - len(prefix.encode("utf-8"))
+            - len(suffix.encode("utf-8"))
+        )
         cmd = prefix + ("x" * padding_len) + suffix
 
         assert len(cmd.encode("utf-8")) == ARG_MAX_STDIN_THRESHOLD - 1
@@ -193,5 +202,5 @@ class TestStderrCallback:
         assert "stdout_line" in stdout_lines
         assert "stderr_line" in stderr_lines
         # Lines should not cross-contaminate
-        assert not any("stderr_line" in l for l in stdout_lines)
-        assert not any("stdout_line" in l for l in stderr_lines)
+        assert not any("stderr_line" in line for line in stdout_lines)
+        assert not any("stdout_line" in line for line in stderr_lines)

--- a/tests/unit/test_uuidv7.py
+++ b/tests/unit/test_uuidv7.py
@@ -26,7 +26,9 @@ class TestUUIDv7Format:
         # M (version) is at index 14 (after removing dashes: position 12)
         # With dashes: positions 0-7, dash, 9-12, dash, 14-17, dash, 19-22, dash, 24-35
         version_nibble = uid[14]
-        assert version_nibble == "7", f"Expected version nibble '7', got '{version_nibble}' in {uid}"
+        assert version_nibble == "7", (
+            f"Expected version nibble '7', got '{version_nibble}' in {uid}"
+        )
 
     def test_uuid7_variant_bits(self) -> None:
         """FR-1.3: Variant bits (first nibble at position 19) must be '8', '9', 'a', or 'b'."""

--- a/tests/unit/test_workflow_cui.py
+++ b/tests/unit/test_workflow_cui.py
@@ -2,8 +2,6 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from fdsx.display.terminal import confirm_workflow_assignments_interactive
 from fdsx.models.task import TaskEntry, TaskFile
 
@@ -24,8 +22,7 @@ class TestConfirmWorkflowAssignmentsInteractive:
     def _make_workflows(self, *names: str) -> list[tuple[Path, str, str]]:
         """Helper to create available_workflows list from names."""
         return [
-            (Path(name), f"Description for {name}", Path(name).stem)
-            for name in names
+            (Path(name), f"Description for {name}", Path(name).stem) for name in names
         ]
 
     def test_confirm_returns_assignments_dict(self):
@@ -299,7 +296,6 @@ class TestConfirmWorkflowAssignmentsInteractive:
         """Changing the same assignment twice keeps the last value (uses 2 tasks)."""
         task_files = self._make_task_files("Fix the bug", "Write tests")
         wf1 = Path("review.yaml")
-        wf2 = Path("implement.yaml")
         wf3 = Path("test.yaml")
         assignments = {(0, 0): wf1, (1, 0): wf1}
         display_keys = [(0, 0), (1, 0)]
@@ -339,14 +335,16 @@ class TestConfirmWorkflowAssignmentsInteractive:
         display_keys = [(0, 0)]
         assignments: dict[tuple[int, int], Path] = {}
         workflows = self._make_workflows("review.yaml")
+        stream = StringIO()
 
         with patch("fdsx.display.terminal.is_interactive", return_value=True):
-            with patch("builtins.input", return_value="c") as mock_input:
+            with patch("builtins.input", side_effect=["c", "q"]) as mock_input:
                 result = confirm_workflow_assignments_interactive(
-                    display_keys, assignments, task_files, workflows
+                    display_keys, assignments, task_files, workflows, stream=stream
                 )
 
         mock_input.assert_called()
+        assert "Cannot confirm" in stream.getvalue()
         assert result is None, (
             "Unassigned single task should block on 'c' until assigned"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,6 @@ wheels = [
 
 [[package]]
 name = "fdsx"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -232,6 +233,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "structlog", specifier = ">=24" },
     { name = "typer", specifier = ">=0.9" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6" },
     { name = "uuid-utils", specifier = ">=0.9" },
 ]
 provides-extras = ["dev"]
@@ -1158,6 +1160,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `.github/workflows/publish.yml` with four jobs:
  - **test**: matrix over Python 3.10–3.13; runs ruff, mypy, pytest
  - **build**: builds sdist + wheel, uploads as artifact (needs: test)
  - **publish-to-testpypi**: triggered by `workflow_dispatch` with `testpypi: true` input; publishes to TestPyPI via Trusted Publishers (OIDC)
  - **publish-to-pypi**: triggered on `v*` tag pushes; publishes to PyPI via Trusted Publishers (OIDC)
- Add `LICENSE` and `MANIFEST.in` for PyPI packaging
- Update `pyproject.toml` with dynamic versioning and publish metadata
- Isolate integration tests and add `cli_test_utils` helper

## How to test

- **TestPyPI**: Go to Actions → publish workflow → Run workflow, enable the `testpypi` toggle
- **PyPI release**: Push a `v*` tag (e.g., `git tag v0.1.0 && git push origin v0.1.0`)
- Both publish jobs require PyPI/TestPyPI environments with Trusted Publisher OIDC configured in the repo settings

## Checklist

- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `mypy src/fdsx` passes
- [x] 930 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)