### PR TITLE
feat: split source tracking & global task variables

### DIFF
--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -1,0 +1,134 @@
+# Tasks: Split Source Tracking & Global Task Variables
+
+**Feature**: Split Source Tracking & Global Task Variables
+**Spec**: `specs/20260324000402-split-source-global-vars/spec.md`
+**Plan**: `specs/20260324000402-split-source-global-vars/plan.md`
+**Generated**: 2026-03-24
+
+---
+
+## Phase 1: TaskFile Model — Add `source` Field
+
+**Goal**: Add an optional `source` field to the `TaskFile` Pydantic model.
+
+- [x] T001 Add unit tests for TaskFile `source` field construction in `tests/unit/test_models.py`
+- [x] T002 Add `source: str | None = Field(default=None)` to `TaskFile` model in `src/fdsx/models/task.py`
+
+## Phase 2: TaskFile Serialization — Write `source` to YAML
+
+**Goal**: When saving a TaskFile with `source` set, include it in the YAML output. Omit when `None`.
+
+- [ ] T003 Add serialization tests for `save_task_file` with/without `source` in `tests/unit/test_models.py`
+- [ ] T004 Update `save_task_file` to conditionally include `source` in serialized dict in `src/fdsx/models/task.py`
+
+## Phase 3: TaskFile Deserialization — Read `source` from YAML
+
+**Goal**: When loading a task YAML that contains a `source` field, populate `TaskFile.source`.
+
+- [ ] T005 Add deserialization tests for `load_task_file` with/without `source` in `tests/unit/test_models.py`
+- [ ] T006 Update `load_task_file` to extract `source` from raw dict in both flat and list branches in `src/fdsx/models/task.py`
+
+## Phase 4: Split Command — Inject Source Path
+
+**Goal**: `fdsx split <file>` records the verbatim input path as `source` in each generated task YAML.
+
+- [ ] T007 Add integration test for split with source tracking in `tests/integration/test_split.py`
+- [ ] T008 Update `write_task_files` to accept and assign `source`, and pass source from split CLI in `src/fdsx/core/batch.py` and `src/fdsx/cli/main.py`
+
+## Phase 5: Static Analysis — Global Variable Recognition
+
+**Goal**: `{task}` and `{source}` in non-start states no longer trigger static analysis warnings.
+
+- [ ] T009 Add tests for global variable recognition (`{task}`, `{source}`, `{unknown_var}`) in `tests/unit/test_models.py` or `tests/unit/test_variables.py`
+- [ ] T010 Define `GLOBAL_TASK_VARS = {"task", "source"}` and seed into `analyze_variable_references` in `src/fdsx/core/variables.py`
+
+## Phase 6: Execution — Source Auto-Injection
+
+**Goal**: `{source}` resolves in all workflow states during task execution.
+
+- [ ] T011 Add integration tests for source injection during execution in `tests/integration/test_tasks_dir.py` and `tests/integration/test_batch.py`
+- [ ] T012 Add `task_inputs["source"] = task_file.source or ""` in `run_batch` and `run_tasks_dir` in `src/fdsx/core/engine.py`
+
+## Phase 7: Update Existing Tests
+
+**Goal**: Verify all existing tests pass with the changes; fix any broken assertions.
+
+- [ ] T013 Run full test suite and fix any tests broken by the new `source` field
+
+---
+
+## Dependencies
+
+```
+Phase 1 (T001-T002) ── model exists
+    │
+    ├──▶ Phase 2 (T003-T004) ── serialization
+    │        │
+    │        └──▶ Phase 3 (T005-T006) ── deserialization
+    │                 │
+    │                 └──▶ Phase 4 (T007-T008) ── split command
+    │                          │
+    │                          └──▶ Phase 6 (T011-T012) ── execution injection
+    │
+    └──▶ Phase 5 (T009-T010) ── static analysis (independent of Phases 2-4)
+
+Phase 7 (T013) ── after all other phases complete
+```
+
+**Key observations**:
+- Phase 5 (static analysis) is independent of Phases 2-4 and can run in parallel after Phase 1
+- Within each phase, test tasks must complete before implementation tasks (TDD)
+- Phase 7 is a final validation gate
+
+## Parallel Execution Opportunities
+
+| Tasks | Can Parallel? | Reason |
+|-------|--------------|--------|
+| T001, T009 | No | T009 tests variable analysis, unrelated to model, but both could start after repo setup |
+| T003, T009 | Yes | Different files: `test_models.py` vs `test_variables.py` |
+| T004, T010 | Yes | Different files: `task.py` vs `variables.py` |
+| T007, T011 | No | T011 depends on Phase 4 (source must exist in YAML first) |
+
+## Implementation Strategy
+
+1. **MVP**: Phases 1-4 deliver the core value — `fdsx split` records source and task files round-trip it
+2. **Incremental**: Phase 5 (static analysis) and Phase 6 (execution injection) extend the value to runtime
+3. **Validation**: Phase 7 ensures nothing is broken
+
+## Task Summary
+
+| Phase | Tasks | Description |
+|-------|-------|-------------|
+| Phase 1 | T001-T002 | TaskFile model |
+| Phase 2 | T003-T004 | Serialization |
+| Phase 3 | T005-T006 | Deserialization |
+| Phase 4 | T007-T008 | Split command |
+| Phase 5 | T009-T010 | Static analysis |
+| Phase 6 | T011-T012 | Execution injection |
+| Phase 7 | T013 | Test validation |
+| **Total** | **13 tasks** | |
+
+## Suggested Execution Commands
+
+```bash
+# Phase 1: TaskFile Model
+takt run code "Phase 1: Add source field to TaskFile model (T001-T002)"
+
+# Phase 2: Serialization
+takt run code "Phase 2: Update save_task_file to write source to YAML (T003-T004)"
+
+# Phase 3: Deserialization
+takt run code "Phase 3: Update load_task_file to read source from YAML (T005-T006)"
+
+# Phase 4: Split Command
+takt run code "Phase 4: Pass source path through split pipeline (T007-T008)"
+
+# Phase 5: Static Analysis (can run in parallel with Phases 2-4)
+takt run code "Phase 5: Add GLOBAL_TASK_VARS and update analyze_variable_references (T009-T010)"
+
+# Phase 6: Execution Injection
+takt run code "Phase 6: Inject source into task_inputs at execution sites (T011-T012)"
+
+# Phase 7: Validation
+takt run code "Phase 7: Run full test suite and fix any broken tests (T013)"
+```

--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -39,8 +39,8 @@
 
 **Goal**: `{task}` and `{source}` in non-start states no longer trigger static analysis warnings.
 
-- [ ] T009 Add tests for global variable recognition (`{task}`, `{source}`, `{unknown_var}`) in `tests/unit/test_models.py` or `tests/unit/test_variables.py`
-- [ ] T010 Define `GLOBAL_TASK_VARS = {"task", "source"}` and seed into `analyze_variable_references` in `src/fdsx/core/variables.py`
+- [x] T009 Add tests for global variable recognition (`{task}`, `{source}`, `{unknown_var}`) in `tests/unit/test_models.py` or `tests/unit/test_variables.py`
+- [x] T010 Define `GLOBAL_TASK_VARS = {"task", "source"}` and seed into `analyze_variable_references` in `src/fdsx/core/variables.py`
 
 ## Phase 6: Execution — Source Auto-Injection
 

--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -53,7 +53,7 @@
 
 **Goal**: Verify all existing tests pass with the changes; fix any broken assertions.
 
-- [ ] T013 Run full test suite and fix any tests broken by the new `source` field
+- [x] T013 Run full test suite and fix any tests broken by the new `source` field
 
 ---
 

--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -32,8 +32,8 @@
 
 **Goal**: `fdsx split <file>` records the verbatim input path as `source` in each generated task YAML.
 
-- [ ] T007 Add integration test for split with source tracking in `tests/integration/test_split.py`
-- [ ] T008 Update `write_task_files` to accept and assign `source`, and pass source from split CLI in `src/fdsx/core/batch.py` and `src/fdsx/cli/main.py`
+- [x] T007 Add integration test for split with source tracking in `tests/integration/test_split.py`
+- [x] T008 Update `write_task_files` to accept and assign `source`, and pass source from split CLI in `src/fdsx/core/batch.py` and `src/fdsx/cli/main.py`
 
 ## Phase 5: Static Analysis — Global Variable Recognition
 

--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -18,8 +18,8 @@
 
 **Goal**: When saving a TaskFile with `source` set, include it in the YAML output. Omit when `None`.
 
-- [ ] T003 Add serialization tests for `save_task_file` with/without `source` in `tests/unit/test_models.py`
-- [ ] T004 Update `save_task_file` to conditionally include `source` in serialized dict in `src/fdsx/models/task.py`
+- [x] T003 Add serialization tests for `save_task_file` with/without `source` in `tests/unit/test_models.py`
+- [x] T004 Update `save_task_file` to conditionally include `source` in serialized dict in `src/fdsx/models/task.py`
 
 ## Phase 3: TaskFile Deserialization — Read `source` from YAML
 

--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -46,8 +46,8 @@
 
 **Goal**: `{source}` resolves in all workflow states during task execution.
 
-- [ ] T011 Add integration tests for source injection during execution in `tests/integration/test_tasks_dir.py` and `tests/integration/test_batch.py`
-- [ ] T012 Add `task_inputs["source"] = task_file.source or ""` in `run_batch` and `run_tasks_dir` in `src/fdsx/core/engine.py`
+- [x] T011 Add integration tests for source injection during execution in `tests/integration/test_tasks_dir.py` and `tests/integration/test_batch.py`
+- [x] T012 Add `task_inputs["source"] = task_file.source or ""` in `run_batch` and `run_tasks_dir` in `src/fdsx/core/engine.py`
 
 ## Phase 7: Update Existing Tests
 

--- a/specs/20260324000402-split-source-global-vars/tasks.md
+++ b/specs/20260324000402-split-source-global-vars/tasks.md
@@ -25,8 +25,8 @@
 
 **Goal**: When loading a task YAML that contains a `source` field, populate `TaskFile.source`.
 
-- [ ] T005 Add deserialization tests for `load_task_file` with/without `source` in `tests/unit/test_models.py`
-- [ ] T006 Update `load_task_file` to extract `source` from raw dict in both flat and list branches in `src/fdsx/models/task.py`
+- [x] T005 Add deserialization tests for `load_task_file` with/without `source` in `tests/unit/test_models.py`
+- [x] T006 Update `load_task_file` to extract `source` from raw dict in both flat and list branches in `src/fdsx/models/task.py`
 
 ## Phase 4: Split Command — Inject Source Path
 

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -345,7 +345,7 @@ def split(
                 return
 
             spinner.update(f"Writing {len(groups)} task file(s)...")
-            created_files = write_task_files(groups, tasks_dir)
+            created_files = write_task_files(groups, tasks_dir, source=str(task_file))
 
         typer.echo(
             f"Created {len(created_files)} task file(s) in {TASKS_DIR}/", err=True

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -322,7 +322,9 @@ def _scan_max_task_index(tasks_dir: Path) -> int:
     return max_idx
 
 
-def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Path]:
+def write_task_files(
+    groups: list[list[TaskEntry]], tasks_dir: Path, *, source: str | None = None
+) -> list[Path]:
     """Write task groups to numbered YAML files in the tasks directory.
 
     Creates files in the format: tasks_dir/NNN-<slug>.yaml where NNN continues
@@ -333,6 +335,7 @@ def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Pat
     Args:
         groups: List of file groups, each containing TaskEntry objects
         tasks_dir: Directory to write task files to
+        source: Optional source/origin path to record in each task file
 
     Returns:
         List of created file paths
@@ -353,7 +356,7 @@ def write_task_files(groups: list[list[TaskEntry]], tasks_dir: Path) -> list[Pat
         if not group:
             continue
 
-        task_file = TaskFile(entries=group)
+        task_file = TaskFile(entries=group, source=source)
         slug = _slugify(group[0].description)
         file_path = tasks_dir / f"{base_index + i + 1:03d}-{slug}.yaml"
         save_task_file(file_path, task_file)

--- a/src/fdsx/core/engine.py
+++ b/src/fdsx/core/engine.py
@@ -349,7 +349,7 @@ def run_batch(
         )
 
         try:
-            task_inputs = {"task": task_description}
+            task_inputs = {"task": task_description, "source": str(tasks_file)}
             run_flow(
                 flow_path=workflow_path,
                 inputs=task_inputs,
@@ -945,7 +945,7 @@ def run_tasks_dir(
             )
 
             try:
-                task_inputs = {"task": description}
+                task_inputs = {"task": description, "source": task_file.source or ""}
                 run_flow(
                     flow_path=effective_workflow,
                     inputs=task_inputs,

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -9,6 +9,9 @@ from fdsx.models.flow import Branch, Flow, ParallelState, State
 # Sub-directory inside run_dir where result files are written
 RESULT_FILE_DATA_DIR = "data"
 
+# Global variables automatically available in every state (injected at runtime by the runner)
+GLOBAL_TASK_VARS: set[str] = {"task", "source"}
+
 
 def write_result_to_file(varname: str, value: Any, run_dir: Path) -> str:
     """Write a result value to a file inside <run_dir>/data/.
@@ -436,6 +439,10 @@ def analyze_variable_references(
     if input_keys:
         for state_name in reachable_states:
             available_vars[state_name] = available_vars[state_name] | input_keys
+
+    # Seed all reachable states with global task variables (task, source)
+    for state_name in reachable_states:
+        available_vars[state_name] = available_vars[state_name] | GLOBAL_TASK_VARS
 
     for state_name in reachable_states:
         state = flow.states[state_name]

--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -145,6 +145,7 @@ def load_task_file(path: Path) -> TaskFile:
     if raw is None:
         return TaskFile()
 
+    source = None
     if isinstance(raw, dict):
         source = raw.get("source")
         if "tasks" in raw:
@@ -167,8 +168,9 @@ def load_task_file(path: Path) -> TaskFile:
                 except ValidationError as e:
                     raise ValueError(f"Invalid task entry {i} in {path}: {e}") from e
         else:
+            entry_raw = {k: v for k, v in raw.items() if k != "source"}
             try:
-                entries = [TaskEntry.model_validate(raw)]
+                entries = [TaskEntry.model_validate(entry_raw)]
             except ValidationError as e:
                 raise ValueError(f"Invalid task entry in {path}: {e}") from e
     else:

--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -81,6 +81,10 @@ class TaskFile(BaseModel):
         default_factory=list,
         description="List of task entries in this file",
     )
+    source: str | None = Field(
+        default=None,
+        description="Source/origin of the task file",
+    )
 
 
 _ALLOWED_SYSTEM_SYMLINK_ANCESTORS = {
@@ -142,6 +146,7 @@ def load_task_file(path: Path) -> TaskFile:
         return TaskFile()
 
     if isinstance(raw, dict):
+        source = raw.get("source")
         if "tasks" in raw:
             tasks_raw = raw["tasks"]
             if not isinstance(tasks_raw, list):
@@ -171,7 +176,10 @@ def load_task_file(path: Path) -> TaskFile:
             f"Unexpected task file format at {path}: expected a YAML mapping"
         )
 
-    return TaskFile(entries=entries)
+    try:
+        return TaskFile(entries=entries, source=source)
+    except ValidationError as e:
+        raise ValueError(f"Invalid task file metadata in {path}: {e}") from e
 
 
 def save_task_file(path: Path, task_file: TaskFile) -> None:
@@ -196,6 +204,9 @@ def save_task_file(path: Path, task_file: TaskFile) -> None:
         data = task_file.entries[0].model_dump(exclude_none=True)
     else:
         data = {"tasks": [e.model_dump(exclude_none=True) for e in task_file.entries]}
+
+    if task_file.source is not None:
+        data["source"] = task_file.source
 
     content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
 

--- a/tests/integration/test_batch.py
+++ b/tests/integration/test_batch.py
@@ -225,3 +225,32 @@ class TestBatchQuietFlagPropagation:
         assert mock_run_flow.called
         for call_args in mock_run_flow.call_args_list:
             assert call_args.kwargs.get("quiet") is False
+
+
+class TestBatchSourceInjection:
+    def test_run_batch_injects_source_as_tasks_file_path(self):
+        flow_path = FIXTURES_DIR / "batch_flow.yaml"
+        tasks_file = FIXTURES_DIR / "sample_tasks.md"
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout="1. Task 1\n2. Task 2",
+            stderr="",
+        )
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            with patch(
+                "fdsx.core.engine.load_config",
+                return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
+            ):
+                with patch("fdsx.core.engine.display_task_list", return_value=True):
+                    with patch("fdsx.core.engine.run_flow") as mock_run_flow:
+                        with tempfile.TemporaryDirectory() as tmpdir:
+                            base_dir = Path(tmpdir)
+                            engine.run_batch(flow_path, tasks_file, base_dir)
+
+        assert mock_run_flow.called
+        for call_args in mock_run_flow.call_args_list:
+            inputs = call_args.kwargs.get("inputs") or call_args.args[1]
+            assert inputs["source"] == str(tasks_file)

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -331,6 +331,44 @@ class TestSplitCliIntegration:
         assert len(paths) == 1
         assert "Created 1 task file" in result.stderr
 
+    def test_split_command_records_source_path(self, tmp_path, monkeypatch):
+        """Test that split command records the source path in generated task files."""
+        from typer.testing import CliRunner
+        from fdsx.cli.main import app
+
+        task_file = tmp_path / "my_input.md"
+        task_file.write_text("Implement feature A\nImplement feature B")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Implement feature A"}, {"description": "Implement feature B"}]]',
+            stderr="",
+        )
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+
+        with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
+            with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+                runner = CliRunner()
+                result = runner.invoke(
+                    app, ["split", str(task_file)], catch_exceptions=False
+                )
+
+        assert result.exit_code == 0
+
+        tasks_dir = tmp_path / TASKS_DIR
+        yaml_files = list(tasks_dir.glob("*.yaml"))
+        assert len(yaml_files) == 1
+
+        content = yaml_files[0].read_text()
+        data = yaml.safe_load(content)
+        assert "source" in data
+        assert data["source"] == str(task_file)
+
     # T001: Split succeeds when only completed/ dir exists (no pending tasks)
     def test_split_command_succeeds_with_only_completed_dir(
         self, tmp_path, monkeypatch

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -934,3 +934,52 @@ class TestRunTasksDirQuietFlagPropagation:
             assert mock_run_flow.called
             for call_args in mock_run_flow.call_args_list:
                 assert call_args.kwargs.get("quiet") is False
+
+
+class TestRunTasksDirSourceInjection:
+    def test_source_injected_when_task_file_has_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = FIXTURES_DIR / "batch_flow.yaml"
+
+            tf = TaskFile(
+                source="features.md",
+                entries=[TaskEntry(description="task A")],
+            )
+            save_task_file(tasks_dir / "001-a.yaml", tf)
+
+            captured_inputs: list[dict] = []
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
+                captured_inputs.append(dict(inputs))
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert len(captured_inputs) == 1
+            assert captured_inputs[0]["task"] == "task A"
+            assert captured_inputs[0]["source"] == "features.md"
+
+    def test_source_injected_as_empty_string_when_task_file_source_is_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = FIXTURES_DIR / "batch_flow.yaml"
+
+            tf = TaskFile(entries=[TaskEntry(description="task B")])
+            save_task_file(tasks_dir / "001-b.yaml", tf)
+
+            captured_inputs: list[dict] = []
+
+            def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
+                captured_inputs.append(dict(inputs))
+                return {"result": "ok"}
+
+            with patch("fdsx.core.engine.run_flow", side_effect=mock_run_flow):
+                with patch("fdsx.core.engine.display_tasks_dir_summary"):
+                    engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert len(captured_inputs) == 1
+            assert captured_inputs[0]["task"] == "task B"
+            assert captured_inputs[0]["source"] == ""

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -159,7 +159,12 @@ class TestPromptFileResolution:
             )
 
     def test_input_keys_prevent_false_positive_in_loader(self):
-        """F2: load_flow must accept input_keys and suppress warnings for runtime-provided vars."""
+        """F2: load_flow must accept input_keys and suppress warnings for runtime-provided vars.
+
+        Uses {cli_input} instead of {task} because {task} is now a
+        recognised global variable (GLOBAL_TASK_VARS) and would never be
+        flagged as undefined.
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             flow_yaml = Path(tmpdir) / "flow.yaml"
             flow_yaml.write_text(
@@ -176,17 +181,17 @@ class TestPromptFileResolution:
                 "  middle:\n"
                 "    type: task\n"
                 "    provider: system\n"
-                "    command: echo {task}\n"
+                "    command: echo {cli_input}\n"
                 "    result_path: '$.other'\n"
                 "    end: true\n"
             )
             # Without input_keys: flow is rejected (variable errors are blocking)
             flow_bad, errors = load_flow(flow_yaml)
             assert flow_bad is None
-            assert any("task" in e for e in errors)
+            assert any("cli_input" in e for e in errors)
 
             # With input_keys: no warnings
-            flow_ok, no_warnings = load_flow(flow_yaml, input_keys={"task"})
+            flow_ok, no_warnings = load_flow(flow_yaml, input_keys={"cli_input"})
             assert flow_ok is not None, (
                 f"Expected load to succeed but got: {no_warnings}"
             )

--- a/tests/unit/test_task_model.py
+++ b/tests/unit/test_task_model.py
@@ -169,6 +169,33 @@ class TestLoadTaskFileFlat:
             with pytest.raises(ValueError, match="Invalid task file metadata"):
                 load_task_file(path)
 
+    def test_flat_yaml_source_not_leaked_into_entry(self):
+        """Finding-1 regression: source key must be stripped before TaskEntry.model_validate
+        in the flat branch, so it never contaminates TaskEntry fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(
+                yaml.dump({"description": "Fix login bug", "source": "cli"})
+            )
+
+            tf = load_task_file(path)
+            assert len(tf.entries) == 1
+            # source goes to TaskFile.source, not into the entry's fields
+            assert tf.source == "cli"
+            entry_dict = tf.entries[0].model_dump(exclude_none=True)
+            assert "source" not in entry_dict
+
+    def test_flat_yaml_source_initialized_before_isinstance_block(self):
+        """Finding-4 regression: source must be initialized to None before the
+        isinstance(raw, dict) block so it is never unbound when TaskFile is constructed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            # Standard flat YAML without source — source must be None, not unbound
+            path.write_text(yaml.dump({"description": "Simple task"}))
+
+            tf = load_task_file(path)
+            assert tf.source is None
+
 
 class TestLoadTaskFileList:
     def test_loads_list_yaml(self):

--- a/tests/unit/test_task_model.py
+++ b/tests/unit/test_task_model.py
@@ -72,6 +72,16 @@ class TestTaskEntryDefaults:
             TaskEntry(description="test", workflow=".")
 
 
+class TestTaskFileSource:
+    def test_source_defaults_to_none(self):
+        tf = TaskFile(entries=[TaskEntry(description="test")])
+        assert tf.source is None
+
+    def test_source_can_be_set(self):
+        tf = TaskFile(entries=[TaskEntry(description="test")], source="cli")
+        assert tf.source == "cli"
+
+
 class TestTaskFileSingleEntry:
     def test_flat_format_parsed(self):
         tf = TaskFile(entries=[TaskEntry(description="Fix the bug", status="pending")])
@@ -124,6 +134,31 @@ class TestLoadTaskFileFlat:
             tf = load_task_file(path)
             assert tf.entries[0].status == "pending"
 
+    def test_loads_flat_yaml_with_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(
+                yaml.dump({"description": "Fix login bug", "source": "cli"})
+            )
+
+            tf = load_task_file(path)
+            assert tf.source == "cli"
+
+    def test_loads_flat_yaml_without_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(yaml.dump({"description": "Fix login bug"}))
+
+            tf = load_task_file(path)
+            assert tf.source is None
+
+    def test_raises_on_invalid_source_type_flat(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            path.write_text(yaml.dump({"description": "Fix bug", "source": ["bad"]}))
+            with pytest.raises(ValueError, match="Invalid task file metadata"):
+                load_task_file(path)
+
 
 class TestLoadTaskFileList:
     def test_loads_list_yaml(self):
@@ -153,6 +188,53 @@ class TestLoadTaskFileList:
 
             tf = load_task_file(path)
             assert tf.entries[0].status == "pending"
+
+    def test_loads_list_yaml_with_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(
+                yaml.dump(
+                    {
+                        "source": "api",
+                        "tasks": [
+                            {"description": "Fix login bug", "status": "pending"},
+                        ],
+                    }
+                )
+            )
+
+            tf = load_task_file(path)
+            assert tf.source == "api"
+
+    def test_loads_list_yaml_without_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(
+                yaml.dump(
+                    {
+                        "tasks": [
+                            {"description": "Fix login bug", "status": "pending"},
+                        ],
+                    }
+                )
+            )
+
+            tf = load_task_file(path)
+            assert tf.source is None
+
+    def test_raises_on_invalid_source_type_list(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            path.write_text(
+                yaml.dump(
+                    {
+                        "tasks": [{"description": "Fix bug"}],
+                        "source": ["bad"],
+                    }
+                )
+            )
+            with pytest.raises(ValueError, match="Invalid task file metadata"):
+                load_task_file(path)
 
 
 class TestLoadTaskFileRawListRejected:
@@ -309,6 +391,63 @@ class TestSaveTaskFileFlat:
             assert "null" not in content
             assert "None" not in content
 
+    def test_save_flat_with_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            tf = TaskFile(
+                entries=[TaskEntry(description="Fix the bug", status="pending")],
+                source="cli",
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            assert data["source"] == "cli"
+
+    def test_save_flat_without_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            tf = TaskFile(
+                entries=[TaskEntry(description="Fix the bug", status="pending")]
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            assert "source" not in data
+
+    def test_save_multi_with_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="Task 1"),
+                    TaskEntry(description="Task 2"),
+                ],
+                source="api",
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            assert data["source"] == "api"
+            assert "tasks" in data
+
+    def test_save_multi_without_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            tf = TaskFile(
+                entries=[
+                    TaskEntry(description="Task 1"),
+                    TaskEntry(description="Task 2"),
+                ]
+            )
+            save_task_file(path, tf)
+
+            content = path.read_text()
+            data = yaml.safe_load(content)
+            assert "source" not in data
+
 
 class TestSaveTaskFileMulti:
     def test_save_multi_entry(self):
@@ -380,6 +519,35 @@ class TestRoundTrip:
             loaded = load_task_file(path)
             assert len(loaded.entries) == 1
             assert loaded.entries[0].workflow == "plan.yaml"
+
+    def test_single_entry_with_source_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "task.yaml"
+            original = TaskFile(
+                entries=[TaskEntry(description="Fix bug", status="pending")],
+                source="cli",
+            )
+            save_task_file(path, original)
+
+            loaded = load_task_file(path)
+            assert len(loaded.entries) == 1
+            assert loaded.source == "cli"
+
+    def test_multi_entry_with_source_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "tasks.yaml"
+            original = TaskFile(
+                entries=[
+                    TaskEntry(description="Task 1", status="completed"),
+                    TaskEntry(description="Task 2", status="failed"),
+                ],
+                source="api",
+            )
+            save_task_file(path, original)
+
+            loaded = load_task_file(path)
+            assert len(loaded.entries) == 2
+            assert loaded.source == "api"
 
 
 class TestLoadTaskFileSymlinkProtection:

--- a/tests/unit/test_task_model.py
+++ b/tests/unit/test_task_model.py
@@ -81,6 +81,16 @@ class TestTaskFileSource:
         tf = TaskFile(entries=[TaskEntry(description="test")], source="cli")
         assert tf.source == "cli"
 
+    def test_source_accepts_arbitrary_string(self):
+        """T001: TaskFile.source accepts an arbitrary path string."""
+        tf = TaskFile(entries=[TaskEntry(description="test")], source="/path/to/tasks.yaml")
+        assert tf.source == "/path/to/tasks.yaml"
+
+    def test_source_accepts_none_explicitly(self):
+        """T001: TaskFile.source=None is accepted explicitly."""
+        tf = TaskFile(entries=[TaskEntry(description="test")], source=None)
+        assert tf.source is None
+
 
 class TestTaskFileSingleEntry:
     def test_flat_format_parsed(self):

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -434,6 +434,7 @@ class TestAnalyzeVariableReferences:
         """F2: variables provided via --input must not be flagged as undefined."""
         # Without input_keys the start state is excluded from checking (it is start_at),
         # so we need a second state to demonstrate the fix.
+        # Note: 'task' and 'source' are global vars; use a custom key to test input_keys.
         flow2 = Flow(
             name="Test Flow 2",
             description="Test flow for input keys",
@@ -449,17 +450,17 @@ class TestAnalyzeVariableReferences:
                 "middle": TaskState(
                     type="task",
                     provider="system",
-                    command="echo {task}",
+                    command="echo {cli_input}",
                     result_path="$.other",
                     end=True,
                 ),
             },
         )
-        # Without input_keys: should flag missing 'task'
+        # Without input_keys: should flag missing 'cli_input'
         errors_without = analyze_variable_references(flow2)
-        assert any("task" in e for e in errors_without)
+        assert any("cli_input" in e for e in errors_without)
         # With input_keys: should be clean
-        errors_with = analyze_variable_references(flow2, input_keys={"task"})
+        errors_with = analyze_variable_references(flow2, input_keys={"cli_input"})
         assert len(errors_with) == 0
 
     # F3 regression: full-path tracking + prefix matching
@@ -739,3 +740,50 @@ class TestAnalyzeVariableReferencesExtract:
         )
         errors = analyze_variable_references(flow)
         assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+
+class TestGlobalTaskVarsRecognition:
+    """T009: Global task variables (task, source) must be recognised without errors."""
+
+    def _make_flow(self, command: str) -> Flow:
+        """Helper: 2-state flow where 'middle' uses the given command."""
+        return Flow(
+            name="Global Var Flow",
+            description="Test flow for global task variable recognition",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.result",
+                    next="middle",
+                ),
+                "middle": TaskState(
+                    type="task",
+                    provider="system",
+                    command=command,
+                    result_path="$.other",
+                    end=True,
+                ),
+            },
+        )
+
+    def test_task_var_no_warning_in_non_start_state(self):
+        """{task} in a non-start state must not produce any error."""
+        flow = self._make_flow("echo {task}")
+        errors = analyze_variable_references(flow)
+        assert errors == []
+
+    def test_source_var_no_warning_in_non_start_state(self):
+        """{source} in a non-start state must not produce any error."""
+        flow = self._make_flow("echo {source}")
+        errors = analyze_variable_references(flow)
+        assert errors == []
+
+    def test_unknown_var_still_warned_in_non_start_state(self):
+        """{unknown_var} in a non-start state must still produce an error."""
+        flow = self._make_flow("echo {unknown_var}")
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 1
+        assert "unknown_var" in errors[0]


### PR DESCRIPTION
## Summary

- **Source tracking**: `fdsx split <file>` now records the original input file path as a `source` field in each generated task YAML. This source persists through serialization/deserialization round-trips.
- **Global task variables**: Introduced `GLOBAL_TASK_VARS = {"task", "source"}` so that `{task}` and `{source}` references in non-start states no longer trigger false-positive static analysis warnings.
- **Runtime injection**: `{source}` resolves automatically during execution in both `run_batch` and `run_tasks_dir` code paths.

## Changes

| Phase | Tasks | Description |
|-------|-------|-------------|
| Phase 1 | T001-T002 | Add `source: str \| None` field to `TaskFile` model |
| Phase 2 | T003-T004 | Serialize `source` to YAML (omit when `None`) |
| Phase 3 | T005-T006 | Deserialize `source` from YAML in both flat and list formats |
| Phase 4 | T007-T008 | Pass source path from `split` CLI through `write_task_files` |
| Phase 5 | T009-T010 | Define `GLOBAL_TASK_VARS` and seed into `analyze_variable_references` |
| Phase 6 | T011-T012 | Inject `source` into `task_inputs` at execution sites |
| Phase 7 | T013 | Fix flat-format source leak & unbound variable; full test validation |

## Files Modified

- `src/fdsx/models/task.py` — TaskFile model, load/save with source
- `src/fdsx/core/batch.py` — `write_task_files` accepts `source` param
- `src/fdsx/core/engine.py` — source injection in `run_batch`/`run_tasks_dir`
- `src/fdsx/core/variables.py` — `GLOBAL_TASK_VARS` definition
- `src/fdsx/cli/main.py` — CLI split command passes source
- `tests/unit/test_task_model.py` — model, serialization, deserialization tests
- `tests/unit/test_variables.py` — global variable recognition tests
- `tests/unit/test_loader.py` — updated false-positive test
- `tests/integration/test_split.py` — source tracking integration test
- `tests/integration/test_batch.py` — batch source injection test
- `tests/integration/test_tasks_dir.py` — tasks_dir source injection test

## Test plan

- [x] All 1277 tests pass (`python -m pytest` — 0 failures)
- [x] New unit tests cover source field construction, serialization, deserialization
- [x] New integration tests cover split source tracking, batch/tasks_dir injection
- [x] Regression tests for flat-format source leak and unbound variable fix
- [x] Backward compatibility verified: existing code without `source` works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)