### PR TITLE
feat: provider hang protection — inactivity timeout, Codex completion_event, per-provider config (Phases 2-5)

### DIFF
--- a/specs/20260324140130-provider-hang-protection/tasks.md
+++ b/specs/20260324140130-provider-hang-protection/tasks.md
@@ -44,7 +44,7 @@ Add structured-stream completion detection to the Codex provider, matching the e
 
 **Independent test criteria**: Run `python -m pytest tests/unit/test_codex_stream_parser.py tests/integration/test_codex_completion.py -v` — all new tests pass.
 
-- [ ] T004 Write tests for Codex completion_event in `tests/unit/test_codex_stream_parser.py` (extend) and `tests/integration/test_codex_completion.py` (new)
+- [x] T004 Write tests for Codex completion_event in `tests/unit/test_codex_stream_parser.py` (extend) and `tests/integration/test_codex_completion.py` (new)
   - Unit tests (extend `tests/unit/test_codex_stream_parser.py`):
     - `test_completion_event_set_on_agent_message_completed` — `item.completed` + `agent_message` → event set
     - `test_completion_event_set_on_turn_failed` — `turn.failed` → event set
@@ -53,12 +53,12 @@ Add structured-stream completion detection to the Codex provider, matching the e
   - Integration test (new `tests/integration/test_codex_completion.py`):
     - `test_codex_hanging_process_killed_by_completion_event` — subprocess emits JSONL with terminal event then hangs; verify termination cascade kills it within ~15s and output preserved
 
-- [ ] T005 Implement Codex completion_event in `src/fdsx/providers/codex.py`
+- [x] T005 Implement Codex completion_event in `src/fdsx/providers/codex.py`
   - Add `completion_event: threading.Event | None = None` parameter to `_make_stream_callback`
   - In `stream_callback`: set `completion_event` when event is terminal (`item.completed` + `agent_message`, `turn.failed`, `error`)
   - In `execute()` when `output_callback is not None`: create `completion_event = threading.Event()`, pass to both `_make_stream_callback` and `_run_subprocess`
 
-- [ ] T006 Verify Phase 3 tests pass: `python -m pytest tests/unit/test_codex_stream_parser.py tests/integration/test_codex_completion.py -v`
+- [x] T006 Verify Phase 3 tests pass: `python -m pytest tests/unit/test_codex_stream_parser.py tests/integration/test_codex_completion.py -v`
 
 ## Phase 4: Per-Provider Inactivity Timeout Configuration (FR-3, FR-5, FR-6)
 

--- a/specs/20260324140130-provider-hang-protection/tasks.md
+++ b/specs/20260324140130-provider-hang-protection/tasks.md
@@ -91,11 +91,11 @@ End-to-end scenario tests validating the interaction between completion_event an
 
 **Independent test criteria**: `python -m pytest tests/ -v` — full suite passes with zero regressions.
 
-- [ ] T010 Write end-to-end scenario tests in `tests/integration/test_inactivity_timeout.py` (extend)
+- [x] T010 Write end-to-end scenario tests in `tests/integration/test_inactivity_timeout.py` (extend)
   - `test_completion_event_suppresses_inactivity_timeout` — process with both mechanisms: completion_event fires, inactivity timeout does NOT produce error
   - `test_inactivity_timeout_with_explicit_timeout` — both inactivity and explicit timeout set, inactivity fires first; verify inactivity error (not explicit timeout error)
 
-- [ ] T011 Full test suite regression: `python -m pytest tests/ -v` — all existing and new tests pass
+- [x] T011 Full test suite regression: `python -m pytest tests/ -v` — all existing and new tests pass
 
 ## Dependencies
 

--- a/specs/20260324140130-provider-hang-protection/tasks.md
+++ b/specs/20260324140130-provider-hang-protection/tasks.md
@@ -1,0 +1,149 @@
+# Tasks: Provider Hang Protection
+
+**Spec**: [spec.md](spec.md)
+**Plan**: [plan.md](plan.md)
+
+## Phase 1: Setup
+
+_No setup tasks needed — all changes extend existing files. No new dependencies._
+
+## Phase 2: Foundational — Inactivity Timeout in `_run_subprocess` (FR-2, FR-4)
+
+The core inactivity watchdog mechanism in `base.py`. All providers benefit automatically once this is in place.
+
+**Goal**: Any provider subprocess that goes silent for longer than the configured inactivity threshold is killed with a clear error.
+
+**Independent test criteria**: Run `python -m pytest tests/integration/test_inactivity_timeout.py -v` — all 6 tests pass.
+
+- [x] T001 Write integration tests for inactivity timeout in `tests/integration/test_inactivity_timeout.py`
+  - `test_process_killed_after_inactivity_period` — process outputs once then goes silent; killed after threshold with exit_code=124 and "inactivity timeout" in stderr
+  - `test_active_process_not_killed` — process outputs continuously beyond threshold; completes normally
+  - `test_startup_hang_killed` — process never produces any output; killed after threshold
+  - `test_inactivity_timeout_disabled_with_zero` — inactivity_timeout=0; process is NOT killed by inactivity
+  - `test_stderr_resets_inactivity_timer` — process outputs on stderr only; timer resets, not killed
+  - `test_inactivity_timeout_error_distinguishable_from_explicit_timeout` — different stderr message text for inactivity vs explicit timeout
+  - Use short thresholds (2-3s) and follow existing `test_subprocess_completion.py` pattern (real subprocess via `sys.executable`)
+
+- [x] T002 Implement inactivity watchdog in `src/fdsx/providers/base.py`
+  - Add `DEFAULT_INACTIVITY_TIMEOUT = 300` constant
+  - Add `inactivity_timeout: int | None = None` parameter to `_run_subprocess`
+  - Add shared `_last_activity` timestamp protected by `threading.Lock`, initialized to `time.monotonic()` at process launch
+  - Modify `_read_stdout` to update `_last_activity` on each line
+  - Modify `_read_stderr` to update `_last_activity` on each line
+  - Add `_inactivity_watchdog` daemon thread: checks every 1s if idle time exceeds threshold, checks `_suppressed` event before acting, runs termination cascade (SIGTERM → 5s → SIGKILL), sets `killed_by_inactivity` flag
+  - In result path: if `killed_by_inactivity`, return `ProviderResult(exit_code=124, stdout="", stderr="Process killed due to inactivity timeout after {N} seconds (no output received)")`
+  - When `completion_event` fires: set `_suppressed` event to prevent inactivity watchdog from killing
+
+- [x] T003 Verify Phase 2 tests pass: `python -m pytest tests/integration/test_inactivity_timeout.py -v`
+
+## Phase 3: Codex completion_event (FR-1)
+
+Add structured-stream completion detection to the Codex provider, matching the existing Claude provider pattern.
+
+**Goal**: Codex subprocess that hangs after emitting a terminal streaming event is killed by the completion_event termination cascade.
+
+**Independent test criteria**: Run `python -m pytest tests/unit/test_codex_stream_parser.py tests/integration/test_codex_completion.py -v` — all new tests pass.
+
+- [ ] T004 Write tests for Codex completion_event in `tests/unit/test_codex_stream_parser.py` (extend) and `tests/integration/test_codex_completion.py` (new)
+  - Unit tests (extend `tests/unit/test_codex_stream_parser.py`):
+    - `test_completion_event_set_on_agent_message_completed` — `item.completed` + `agent_message` → event set
+    - `test_completion_event_set_on_turn_failed` — `turn.failed` → event set
+    - `test_completion_event_set_on_error` — `error` → event set
+    - `test_completion_event_not_set_on_non_terminal` — `item.started` or `reasoning` completed → event NOT set
+  - Integration test (new `tests/integration/test_codex_completion.py`):
+    - `test_codex_hanging_process_killed_by_completion_event` — subprocess emits JSONL with terminal event then hangs; verify termination cascade kills it within ~15s and output preserved
+
+- [ ] T005 Implement Codex completion_event in `src/fdsx/providers/codex.py`
+  - Add `completion_event: threading.Event | None = None` parameter to `_make_stream_callback`
+  - In `stream_callback`: set `completion_event` when event is terminal (`item.completed` + `agent_message`, `turn.failed`, `error`)
+  - In `execute()` when `output_callback is not None`: create `completion_event = threading.Event()`, pass to both `_make_stream_callback` and `_run_subprocess`
+
+- [ ] T006 Verify Phase 3 tests pass: `python -m pytest tests/unit/test_codex_stream_parser.py tests/integration/test_codex_completion.py -v`
+
+## Phase 4: Per-Provider Inactivity Timeout Configuration (FR-3, FR-5, FR-6)
+
+Expose `inactivity_timeout` in each provider's options model and wire it through to `_run_subprocess`.
+
+**Goal**: Users can configure or disable inactivity timeout per-provider via YAML options.
+
+**Independent test criteria**: Run `python -m pytest tests/unit/test_provider_options.py -v` — all new option tests pass.
+
+- [ ] T007 Write tests for provider inactivity_timeout options in `tests/unit/test_provider_options.py` (extend)
+  - `test_codex_options_inactivity_timeout_default` — `CodexOptions()` has `inactivity_timeout=None`
+  - `test_codex_options_inactivity_timeout_custom` — `CodexOptions(inactivity_timeout=600)` accepted
+  - `test_codex_options_inactivity_timeout_zero_disables` — `CodexOptions(inactivity_timeout=0)` accepted
+  - Same three tests for `ClaudeOptions` and `OpenCodeOptions`
+  - `test_provider_passes_inactivity_timeout_to_run_subprocess` — mock `_run_subprocess`, verify each provider passes the resolved `inactivity_timeout`
+
+- [ ] T008 Add `inactivity_timeout` to provider options models in `src/fdsx/providers/codex.py`, `src/fdsx/providers/claude.py`, `src/fdsx/providers/opencode.py`
+  - Add `inactivity_timeout: int | None = None` field to each Options model
+  - In each `execute()`: resolve effective timeout (`options.inactivity_timeout if not None else DEFAULT_INACTIVITY_TIMEOUT`; 0 means disabled → pass 0)
+  - Pass `inactivity_timeout=effective_value` to `_run_subprocess`
+  - Import `DEFAULT_INACTIVITY_TIMEOUT` from `base`
+
+- [ ] T009 Verify Phase 4 tests pass: `python -m pytest tests/unit/test_provider_options.py -v`
+
+## Phase 5: Integration Verification
+
+End-to-end scenario tests validating the interaction between completion_event and inactivity timeout, plus full regression.
+
+**Goal**: Both protection mechanisms work correctly together without interference.
+
+**Independent test criteria**: `python -m pytest tests/ -v` — full suite passes with zero regressions.
+
+- [ ] T010 Write end-to-end scenario tests in `tests/integration/test_inactivity_timeout.py` (extend)
+  - `test_completion_event_suppresses_inactivity_timeout` — process with both mechanisms: completion_event fires, inactivity timeout does NOT produce error
+  - `test_inactivity_timeout_with_explicit_timeout` — both inactivity and explicit timeout set, inactivity fires first; verify inactivity error (not explicit timeout error)
+
+- [ ] T011 Full test suite regression: `python -m pytest tests/ -v` — all existing and new tests pass
+
+## Dependencies
+
+```
+T001 → T002 → T003 (Phase 2: inactivity timeout core)
+T004 → T005 → T006 (Phase 3: Codex completion_event)
+T007 → T008 → T009 (Phase 4: per-provider config)
+T010 → T011          (Phase 5: integration verification)
+
+Phase 2 must complete before Phase 5 (T010 depends on inactivity watchdog)
+Phase 3 must complete before Phase 5 (T010 depends on completion_event)
+Phase 4 must complete before Phase 5 (full regression needs all features)
+
+Phases 2, 3, 4 can run in parallel (independent code areas)
+```
+
+## Parallel Execution Opportunities
+
+- **T001 and T004 and T007** can run in parallel (all are test-writing tasks in different files)
+- **T002 and T005** can run in parallel after their test tasks complete (different source files, though T005 depends on `_run_subprocess` completion_event support which already exists)
+- **T008** can run in parallel with T002/T005 (different source files)
+
+## Implementation Strategy
+
+1. **MVP**: Phase 2 (T001-T003) — inactivity timeout protects all providers immediately
+2. **Incremental**: Phase 3 (T004-T006) — adds structured completion detection for Codex
+3. **Configuration**: Phase 4 (T007-T009) — exposes per-provider tuning
+4. **Validation**: Phase 5 (T010-T011) — confirms all mechanisms work together
+
+## Suggested takt Usage
+
+```bash
+# Phase 2: Inactivity timeout core
+takt run coder "Phase 2: Write inactivity timeout integration tests (T001) per plan.md Step 1.1"
+takt run coder "Phase 2: Implement inactivity watchdog in base.py (T002) per plan.md Step 1.2"
+takt run coder "Phase 2: Run and verify inactivity timeout tests pass (T003) per plan.md Step 1.3"
+
+# Phase 3: Codex completion_event
+takt run coder "Phase 3: Write Codex completion_event tests (T004) per plan.md Step 2.1"
+takt run coder "Phase 3: Implement Codex completion_event (T005) per plan.md Step 2.2"
+takt run coder "Phase 3: Run and verify Codex completion_event tests pass (T006) per plan.md Step 2.3"
+
+# Phase 4: Per-provider config
+takt run coder "Phase 4: Write provider options inactivity_timeout tests (T007) per plan.md Step 3.1"
+takt run coder "Phase 4: Add inactivity_timeout to provider options models (T008) per plan.md Step 3.2"
+takt run coder "Phase 4: Run and verify provider options tests pass (T009) per plan.md Step 3.3"
+
+# Phase 5: Integration verification
+takt run coder "Phase 5: Write end-to-end scenario tests for interaction between mechanisms (T010) per plan.md Step 4.1"
+takt run coder "Phase 5: Run full test suite regression (T011) per plan.md Step 4.2"
+```

--- a/specs/20260324140130-provider-hang-protection/tasks.md
+++ b/specs/20260324140130-provider-hang-protection/tasks.md
@@ -68,20 +68,20 @@ Expose `inactivity_timeout` in each provider's options model and wire it through
 
 **Independent test criteria**: Run `python -m pytest tests/unit/test_provider_options.py -v` — all new option tests pass.
 
-- [ ] T007 Write tests for provider inactivity_timeout options in `tests/unit/test_provider_options.py` (extend)
+- [x] T007 Write tests for provider inactivity_timeout options in `tests/unit/test_provider_options.py` (extend)
   - `test_codex_options_inactivity_timeout_default` — `CodexOptions()` has `inactivity_timeout=None`
   - `test_codex_options_inactivity_timeout_custom` — `CodexOptions(inactivity_timeout=600)` accepted
   - `test_codex_options_inactivity_timeout_zero_disables` — `CodexOptions(inactivity_timeout=0)` accepted
   - Same three tests for `ClaudeOptions` and `OpenCodeOptions`
   - `test_provider_passes_inactivity_timeout_to_run_subprocess` — mock `_run_subprocess`, verify each provider passes the resolved `inactivity_timeout`
 
-- [ ] T008 Add `inactivity_timeout` to provider options models in `src/fdsx/providers/codex.py`, `src/fdsx/providers/claude.py`, `src/fdsx/providers/opencode.py`
+- [x] T008 Add `inactivity_timeout` to provider options models in `src/fdsx/providers/codex.py`, `src/fdsx/providers/claude.py`, `src/fdsx/providers/opencode.py`
   - Add `inactivity_timeout: int | None = None` field to each Options model
   - In each `execute()`: resolve effective timeout (`options.inactivity_timeout if not None else DEFAULT_INACTIVITY_TIMEOUT`; 0 means disabled → pass 0)
   - Pass `inactivity_timeout=effective_value` to `_run_subprocess`
   - Import `DEFAULT_INACTIVITY_TIMEOUT` from `base`
 
-- [ ] T009 Verify Phase 4 tests pass: `python -m pytest tests/unit/test_provider_options.py -v`
+- [x] T009 Verify Phase 4 tests pass: `python -m pytest tests/unit/test_provider_options.py -v`
 
 ## Phase 5: Integration Verification
 

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import threading
+import time
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
@@ -9,6 +10,11 @@ logger = logging.getLogger(__name__)
 
 # Commands at or above this byte length are piped via stdin to avoid ARG_MAX limits.
 ARG_MAX_STDIN_THRESHOLD = 131072  # 128 KB
+
+# Default inactivity timeout in seconds (5 minutes). When no output is received
+# from the subprocess for this duration, the process is killed with exit_code=124.
+# Set inactivity_timeout=0 to disable.
+DEFAULT_INACTIVITY_TIMEOUT = 300
 
 
 @dataclass
@@ -64,6 +70,7 @@ def _run_subprocess(
     shell: bool = False,
     completion_event: threading.Event | None = None,
     env: dict[str, str] | None = None,
+    inactivity_timeout: int | None = None,
 ) -> ProviderResult:
     """Shared subprocess execution helper for all providers.
 
@@ -82,6 +89,9 @@ def _run_subprocess(
             wait 5s → SIGKILL. Collected data is preserved in the result.
         env: Optional extra environment variables. Merged with os.environ
             so the subprocess inherits the full environment.
+        inactivity_timeout: Seconds of silence (no stdout or stderr) before
+            the process is killed with exit_code=124. Set to 0 to disable.
+            None leaves the feature off (callers opt-in explicitly).
 
     Returns:
         ProviderResult with exit code and output.
@@ -114,6 +124,14 @@ def _run_subprocess(
         )
 
         killed_by_timeout = False
+        killed_by_inactivity = False
+
+        # Shared state for the inactivity watchdog
+        _last_activity: list[float] = [time.monotonic()]
+        _last_activity_lock = threading.Lock()
+        # _suppressed: set when the completion_event path takes control, preventing
+        # the inactivity watchdog from issuing a redundant kill.
+        _suppressed = threading.Event()
 
         def _watchdog() -> None:
             nonlocal killed_by_timeout
@@ -129,6 +147,47 @@ def _run_subprocess(
         if timeout:
             watchdog_thread = threading.Thread(target=_watchdog, daemon=True)
             watchdog_thread.start()
+
+        def _inactivity_watchdog() -> None:
+            nonlocal killed_by_inactivity
+            assert inactivity_timeout is not None  # guarded by caller
+            while True:
+                time.sleep(1)
+                if _suppressed.is_set():
+                    break
+                if process.poll() is not None:
+                    break
+                with _last_activity_lock:
+                    idle = time.monotonic() - _last_activity[0]
+                if idle > inactivity_timeout:
+                    # Re-check suppressed after acquiring idle measurement
+                    if _suppressed.is_set():
+                        break
+                    killed_by_inactivity = True
+                    logger.debug(
+                        "Process pid=%d killed due to inactivity timeout after %ds",
+                        process.pid,
+                        inactivity_timeout,
+                    )
+                    try:
+                        process.terminate()  # SIGTERM
+                    except OSError:
+                        pass  # Already dead
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        try:
+                            process.kill()  # SIGKILL
+                        except OSError:
+                            pass  # Already dead
+                        process.wait()  # Reap zombie
+                    break
+
+        if inactivity_timeout:
+            inactivity_watchdog_thread = threading.Thread(
+                target=_inactivity_watchdog, daemon=True
+            )
+            inactivity_watchdog_thread.start()
 
         # Write stdin data if provided, then close stdin
         if stdin_data is not None and process.stdin:
@@ -150,6 +209,9 @@ def _run_subprocess(
                             break
                         line = raw_line.rstrip("\n")
                         stdout_lines.append(line)
+                        if inactivity_timeout:
+                            with _last_activity_lock:
+                                _last_activity[0] = time.monotonic()
                         if output_callback:
                             output_callback(line)
                 except BrokenPipeError:
@@ -164,6 +226,9 @@ def _run_subprocess(
                             break
                         line = raw_line.rstrip("\n")
                         stderr_lines.append(line)
+                        if inactivity_timeout:
+                            with _last_activity_lock:
+                                _last_activity[0] = time.monotonic()
                         if stderr_callback:
                             stderr_callback(line)
                 except BrokenPipeError:
@@ -182,6 +247,8 @@ def _run_subprocess(
                     break
 
             if completion_event.is_set():
+                # Suppress inactivity watchdog — completion_event takes control
+                _suppressed.set()
                 # Termination cascade: wait for voluntary exit → SIGTERM → SIGKILL
                 try:
                     process.wait(timeout=5)  # 1) Wait for voluntary exit
@@ -210,10 +277,14 @@ def _run_subprocess(
                         process.wait()  # 5) Reap zombie
                 stdout_thread.join(timeout=1)
                 stderr_thread.join(timeout=1)
+                if inactivity_timeout:
+                    inactivity_watchdog_thread.join(timeout=1)
             else:
                 # stdout EOF reached naturally (process likely exited already)
                 stderr_thread.join(timeout=5)
                 process.wait()
+                if inactivity_timeout:
+                    inactivity_watchdog_thread.join(timeout=1)
         elif timeout:
             # When a timeout is configured, wait for the watchdog to finish
             # first (it either returns immediately if the process finished
@@ -223,18 +294,29 @@ def _run_subprocess(
             watchdog_thread.join()
             stdout_thread.join(timeout=1)
             stderr_thread.join(timeout=1)
+            if inactivity_timeout:
+                inactivity_watchdog_thread.join(timeout=1)
             if not killed_by_timeout:
                 process.wait()
         else:
             stdout_thread.join()
             stderr_thread.join(timeout=5)
             process.wait()
+            if inactivity_timeout:
+                inactivity_watchdog_thread.join(timeout=1)
 
         if killed_by_timeout:
             return ProviderResult(
                 exit_code=124,
                 stdout="",
                 stderr=f"Command timed out after {timeout} seconds",
+            )
+
+        if killed_by_inactivity:
+            return ProviderResult(
+                exit_code=124,
+                stdout="",
+                stderr=f"Process killed due to inactivity timeout after {inactivity_timeout} seconds (no output received)",
             )
 
         stdout = "\n".join(stdout_lines)

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import (
     ARG_MAX_STDIN_THRESHOLD,
+    DEFAULT_INACTIVITY_TIMEOUT,
     ProviderBase,
     ProviderResult,
     _run_subprocess,
@@ -54,6 +55,7 @@ class ClaudeOptions(BaseModel):
     dangerously_skip_permissions: bool = False
     allowed_tools: list[str] = []
     disallowed_tools: list[str] = []
+    inactivity_timeout: int | None = None
 
     def to_cli_flags(self) -> list[str]:
         """Translate options to Claude CLI flags."""
@@ -246,6 +248,12 @@ class ClaudeProvider(ProviderBase):
             args.extend(["--model", model])
         args.extend(self.options.to_cli_flags())
 
+        effective_inactivity = (
+            self.options.inactivity_timeout
+            if self.options.inactivity_timeout is not None
+            else DEFAULT_INACTIVITY_TIMEOUT
+        )
+
         if output_callback is not None:
             args.extend(_STREAM_FORMAT_FLAGS)
             completion_event = threading.Event()
@@ -259,6 +267,7 @@ class ClaudeProvider(ProviderBase):
                 stderr_callback=stderr_callback,
                 stdin_data=stdin_data,
                 completion_event=completion_event,
+                inactivity_timeout=effective_inactivity,
             )
             flush()
             parsed_stdout = get_result()
@@ -276,4 +285,5 @@ class ClaudeProvider(ProviderBase):
             output_callback=output_callback,
             stderr_callback=stderr_callback,
             stdin_data=stdin_data,
+            inactivity_timeout=effective_inactivity,
         )

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import threading
 from typing import Callable, Literal
 
 from pydantic import BaseModel, ConfigDict
@@ -65,7 +66,9 @@ class CodexProvider(ProviderBase):
         self.options: CodexOptions = options if options is not None else CodexOptions()
 
     def _make_stream_callback(
-        self, output_callback: Callable[[str], None]
+        self,
+        output_callback: Callable[[str], None],
+        completion_event: threading.Event | None = None,
     ) -> tuple[Callable[[str], None], Callable[[], str | None]]:
         """Create a streaming callback that parses Codex ``--json`` JSONL lines.
 
@@ -123,6 +126,8 @@ class CodexProvider(ProviderBase):
                     if text:
                         agent_message_parts.append(text)
                         output_callback(text)
+                    if completion_event is not None:
+                        completion_event.set()
                 elif item_type == _ITEM_TYPE_REASONING:
                     text = item.get("text", "")
                     if text:
@@ -130,11 +135,15 @@ class CodexProvider(ProviderBase):
 
             elif event_type == _EVENT_TURN_FAILED:
                 logger.warning("turn.failed event received: %s", event.get("error", ""))
+                if completion_event is not None:
+                    completion_event.set()
 
             elif event_type == _EVENT_ERROR:
                 logger.warning(
                     "Codex error event: %s", event.get("message", str(event))
                 )
+                if completion_event is not None:
+                    completion_event.set()
 
         def get_result() -> str | None:
             if agent_message_parts:
@@ -182,13 +191,17 @@ class CodexProvider(ProviderBase):
 
         if output_callback is not None:
             args.extend(_STREAM_FORMAT_FLAGS)
-            stream_callback, get_result = self._make_stream_callback(output_callback)
+            completion_event = threading.Event()
+            stream_callback, get_result = self._make_stream_callback(
+                output_callback, completion_event
+            )
             result = _run_subprocess(
                 args=args,
                 timeout=timeout,
                 output_callback=stream_callback,
                 stderr_callback=stderr_callback,
                 stdin_data=stdin_data,
+                completion_event=completion_event,
             )
             parsed_stdout = get_result()
             if parsed_stdout is not None:

--- a/src/fdsx/providers/codex.py
+++ b/src/fdsx/providers/codex.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import (
     ARG_MAX_STDIN_THRESHOLD,
+    DEFAULT_INACTIVITY_TIMEOUT,
     ProviderBase,
     ProviderResult,
     _run_subprocess,
@@ -44,6 +45,7 @@ class CodexOptions(BaseModel):
     approval_policy: Literal["untrusted", "on-request", "never"] | None = None
     full_auto: bool = False
     dangerously_bypass_approvals_and_sandbox: bool = False
+    inactivity_timeout: int | None = None
 
     def to_cli_flags(self) -> list[str]:
         """Translate options to Codex CLI flags."""
@@ -189,6 +191,12 @@ class CodexProvider(ProviderBase):
             args.append(prompt)
             stdin_data = None
 
+        effective_inactivity = (
+            self.options.inactivity_timeout
+            if self.options.inactivity_timeout is not None
+            else DEFAULT_INACTIVITY_TIMEOUT
+        )
+
         if output_callback is not None:
             args.extend(_STREAM_FORMAT_FLAGS)
             completion_event = threading.Event()
@@ -202,6 +210,7 @@ class CodexProvider(ProviderBase):
                 stderr_callback=stderr_callback,
                 stdin_data=stdin_data,
                 completion_event=completion_event,
+                inactivity_timeout=effective_inactivity,
             )
             parsed_stdout = get_result()
             if parsed_stdout is not None:
@@ -218,4 +227,5 @@ class CodexProvider(ProviderBase):
             output_callback=output_callback,
             stderr_callback=stderr_callback,
             stdin_data=stdin_data,
+            inactivity_timeout=effective_inactivity,
         )

--- a/src/fdsx/providers/opencode.py
+++ b/src/fdsx/providers/opencode.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict
 
 from fdsx.providers.base import (
     ARG_MAX_STDIN_THRESHOLD,
+    DEFAULT_INACTIVITY_TIMEOUT,
     ProviderBase,
     ProviderResult,
     _run_subprocess,
@@ -17,6 +18,7 @@ class OpenCodeOptions(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     permission: str | dict[str, Any] | None = None
+    inactivity_timeout: int | None = None
 
     def to_cli_flags(self) -> list[str]:
         """Translate options to OpenCode CLI flags (none currently defined)."""
@@ -73,6 +75,12 @@ class OpenCodeProvider(ProviderBase):
 
         env = self.options.to_env() or None
 
+        effective_inactivity = (
+            self.options.inactivity_timeout
+            if self.options.inactivity_timeout is not None
+            else DEFAULT_INACTIVITY_TIMEOUT
+        )
+
         return _run_subprocess(
             args=args,
             timeout=timeout,
@@ -80,4 +88,5 @@ class OpenCodeProvider(ProviderBase):
             stderr_callback=stderr_callback,
             stdin_data=stdin_data,
             env=env,
+            inactivity_timeout=effective_inactivity,
         )

--- a/tests/integration/test_codex_completion.py
+++ b/tests/integration/test_codex_completion.py
@@ -1,0 +1,80 @@
+"""Integration tests for Codex provider completion_event cascade (Phase 3: T004).
+
+These tests verify the full end-to-end flow:
+  CodexProvider._make_stream_callback sets completion_event on terminal JSONL events
+  → _run_subprocess receives the event and initiates the termination cascade
+  → A hanging subprocess (still sleeping after terminal event) is killed within ~15s
+  → All output emitted before the hang is preserved in the result
+
+All tests use real subprocesses via sys.executable to ensure realistic behavior.
+
+Test criteria (T006): python -m pytest tests/integration/test_codex_completion.py -v
+"""
+
+import json
+import sys
+import threading
+import time
+
+from fdsx.providers.base import _run_subprocess
+from fdsx.providers.codex import (
+    CodexProvider,
+    _EVENT_ITEM_COMPLETED,
+    _ITEM_TYPE_AGENT_MESSAGE,
+)
+
+# Use the same Python interpreter as the test runner.
+_PYTHON = sys.executable
+
+# Upper bound on how long each test may take:
+# completion_event fires immediately after terminal event is read,
+# then cascade: 5s voluntary wait + SIGTERM + 5s + SIGKILL.
+_TEST_TIMEOUT = 15
+
+
+class TestCodexHangingProcessKilledByCompletionEvent:
+    """A process that emits a terminal Codex JSONL event then hangs is killed."""
+
+    def test_codex_hanging_process_killed_by_completion_event(self) -> None:
+        """subprocess emits JSONL terminal event then hangs; termination cascade
+        kills it within _TEST_TIMEOUT and output is preserved."""
+        terminal_line = json.dumps(
+            {
+                "type": _EVENT_ITEM_COMPLETED,
+                "item": {
+                    "id": "item_001",
+                    "type": _ITEM_TYPE_AGENT_MESSAGE,
+                    "text": "Hello world",
+                },
+            }
+        )
+        script = (
+            f"import sys, time\n"
+            f"print({terminal_line!r}, flush=True)\n"
+            f"time.sleep(999)\n"
+        )
+
+        provider = CodexProvider()
+        output_lines: list[str] = []
+        completion_event = threading.Event()
+        stream_callback, get_result = provider._make_stream_callback(
+            output_lines.append, completion_event
+        )
+
+        start = time.time()
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", script],
+            output_callback=stream_callback,
+            completion_event=completion_event,
+        )
+        elapsed = time.time() - start
+
+        assert elapsed < _TEST_TIMEOUT, (
+            f"Test took {elapsed:.1f}s — exceeds {_TEST_TIMEOUT}s limit"
+        )
+        assert output_lines == ["Hello world"], (
+            f"Expected ['Hello world'], got {output_lines!r}"
+        )
+        assert get_result() == "Hello world", (
+            f"Expected 'Hello world' from get_result(), got {get_result()!r}"
+        )

--- a/tests/integration/test_inactivity_timeout.py
+++ b/tests/integration/test_inactivity_timeout.py
@@ -1,0 +1,187 @@
+"""Integration tests for inactivity timeout watchdog (Phase 2: T001).
+
+These tests verify that _run_subprocess correctly kills subprocesses that go
+silent for longer than the configured inactivity threshold, while allowing
+active processes (those that produce output regularly) to run to completion.
+
+All tests use real subprocesses via sys.executable to ensure realistic behavior.
+Short thresholds (2s) keep the test suite fast while providing sufficient margin.
+
+Test criteria (T003): python -m pytest tests/integration/test_inactivity_timeout.py -v
+"""
+
+import sys
+import time
+
+from fdsx.providers.base import _run_subprocess
+
+# Use the same Python interpreter as the test runner.
+_PYTHON = sys.executable
+
+# Short inactivity threshold for tests (seconds). The watchdog polls every 1s,
+# so a process is killed within ~(threshold + 1)s of going silent.
+_INACTIVITY_THRESHOLD = 2
+
+# Upper bound on how long each test may take: threshold + watchdog poll + cascade overhead.
+_TEST_TIMEOUT = 15
+
+
+class TestProcessKilledAfterInactivityPeriod:
+    """Process goes silent after initial output → killed after threshold."""
+
+    def test_process_killed_after_inactivity_period(self):
+        """Process outputs once then goes silent; killed after threshold with
+        exit_code=124 and 'inactivity timeout' in stderr."""
+        start = time.time()
+        result = _run_subprocess(
+            args=[
+                _PYTHON,
+                "-c",
+                "import sys, time;"
+                " print('output', flush=True);"
+                " time.sleep(999)",
+            ],
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+        )
+        elapsed = time.time() - start
+
+        assert result.exit_code == 124, (
+            f"Expected exit_code=124 (inactivity kill), got {result.exit_code}"
+        )
+        assert "inactivity timeout" in result.stderr.lower(), (
+            f"Expected 'inactivity timeout' in stderr, got: {result.stderr!r}"
+        )
+        assert elapsed < _TEST_TIMEOUT, (
+            f"Test took {elapsed:.1f}s — exceeds {_TEST_TIMEOUT}s limit"
+        )
+
+
+class TestActiveProcessNotKilled:
+    """Process that outputs continuously beyond threshold completes normally."""
+
+    def test_active_process_not_killed(self):
+        """Process emitting output every 0.5s (within 2s threshold) is not killed."""
+        # Output 6 lines at 0.5s intervals → runs for ~3s, well beyond threshold
+        # but never silent for more than 0.5s
+        result = _run_subprocess(
+            args=[
+                _PYTHON,
+                "-c",
+                "import time;"
+                " [(__import__('sys').stdout.write('line\\n'), __import__('sys').stdout.flush(), time.sleep(0.5)) for _ in range(6)]",
+            ],
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected exit_code=0 (normal completion), got {result.exit_code}"
+        )
+        assert "inactivity" not in result.stderr.lower(), (
+            f"Process should not be killed by inactivity, stderr: {result.stderr!r}"
+        )
+
+
+class TestStartupHangKilled:
+    """Process that never produces any output is killed after threshold."""
+
+    def test_startup_hang_killed(self):
+        """Process that hangs immediately (no output) is killed after threshold."""
+        start = time.time()
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(999)"],
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+        )
+        elapsed = time.time() - start
+
+        assert result.exit_code == 124, (
+            f"Expected exit_code=124 (inactivity kill), got {result.exit_code}"
+        )
+        assert "inactivity timeout" in result.stderr.lower(), (
+            f"Expected 'inactivity timeout' in stderr, got: {result.stderr!r}"
+        )
+        assert elapsed < _TEST_TIMEOUT, (
+            f"Test took {elapsed:.1f}s — exceeds {_TEST_TIMEOUT}s limit"
+        )
+
+
+class TestInactivityTimeoutDisabledWithZero:
+    """inactivity_timeout=0 disables the watchdog; process is NOT killed."""
+
+    def test_inactivity_timeout_disabled_with_zero(self):
+        """Process with inactivity_timeout=0 completes normally even with silence."""
+        # Process produces no output, then exits after 1s.
+        # With inactivity_timeout=0 (disabled), it should NOT be killed early.
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(1)"],
+            inactivity_timeout=0,
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected exit_code=0 (no inactivity kill), got {result.exit_code}"
+        )
+        assert "inactivity" not in result.stderr.lower(), (
+            f"Unexpected inactivity kill with timeout=0, stderr: {result.stderr!r}"
+        )
+
+
+class TestStderrResetsInactivityTimer:
+    """Stderr output resets the inactivity timer; process is not killed."""
+
+    def test_stderr_resets_inactivity_timer(self):
+        """Process writing to stderr every 0.5s (no stdout) is not killed by inactivity."""
+        # 6 stderr lines at 0.5s intervals → runs for ~3s, timer reset each time
+        result = _run_subprocess(
+            args=[
+                _PYTHON,
+                "-c",
+                "import sys, time;"
+                " [(sys.stderr.write('err\\n'), sys.stderr.flush(), time.sleep(0.5))"
+                "  for _ in range(6)]",
+            ],
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected exit_code=0 (timer reset by stderr), got {result.exit_code}"
+        )
+        # The collected stderr should contain our expected lines, not an inactivity message
+        assert "inactivity timeout" not in result.stderr.lower(), (
+            f"Process should not be killed by inactivity, stderr: {result.stderr!r}"
+        )
+
+
+class TestInactivityTimeoutErrorDistinguishable:
+    """Inactivity timeout and explicit timeout produce different stderr messages."""
+
+    def test_inactivity_timeout_error_distinguishable_from_explicit_timeout(self):
+        """inactivity vs explicit timeout errors have distinct stderr messages."""
+        # Inactivity timeout: process goes silent
+        inactivity_result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(999)"],
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+        )
+        assert inactivity_result.exit_code == 124
+        assert "inactivity timeout" in inactivity_result.stderr.lower(), (
+            f"Expected 'inactivity timeout' in inactivity result, got: {inactivity_result.stderr!r}"
+        )
+
+        # Explicit timeout: process simply takes too long
+        explicit_result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(999)"],
+            timeout=1,
+        )
+        assert explicit_result.exit_code == 124
+        assert "timed out" in explicit_result.stderr.lower(), (
+            f"Expected 'timed out' in explicit timeout result, got: {explicit_result.stderr!r}"
+        )
+
+        # The messages must be different from each other
+        assert inactivity_result.stderr != explicit_result.stderr, (
+            "Inactivity and explicit timeout should produce different error messages"
+        )
+        assert "inactivity" not in explicit_result.stderr.lower(), (
+            f"Explicit timeout result should not mention 'inactivity': {explicit_result.stderr!r}"
+        )
+        assert "timed out" not in inactivity_result.stderr.lower(), (
+            f"Inactivity result should not say 'timed out': {inactivity_result.stderr!r}"
+        )

--- a/tests/integration/test_inactivity_timeout.py
+++ b/tests/integration/test_inactivity_timeout.py
@@ -11,6 +11,7 @@ Test criteria (T003): python -m pytest tests/integration/test_inactivity_timeout
 """
 
 import sys
+import threading
 import time
 
 from fdsx.providers.base import _run_subprocess
@@ -184,4 +185,83 @@ class TestInactivityTimeoutErrorDistinguishable:
         )
         assert "timed out" not in inactivity_result.stderr.lower(), (
             f"Inactivity result should not say 'timed out': {inactivity_result.stderr!r}"
+        )
+
+
+class TestCompletionEventSuppressesInactivityTimeout:
+    """completion_event fires → inactivity watchdog is suppressed, no inactivity error."""
+
+    def test_completion_event_suppresses_inactivity_timeout(self):
+        """When completion_event fires, inactivity watchdog is suppressed.
+
+        Process emits a 'ready' line then hangs. The output_callback sets
+        completion_event which sets _suppressed, causing the inactivity watchdog
+        to exit without killing. The termination cascade (from completion_event)
+        kills the hanging process. Result must not show an inactivity timeout error.
+        """
+        completion_event = threading.Event()
+
+        def on_output(line: str) -> None:
+            if "ready" in line:
+                completion_event.set()
+
+        start = time.time()
+        result = _run_subprocess(
+            args=[
+                _PYTHON,
+                "-c",
+                "import sys, time;"
+                " print('ready', flush=True);"
+                " time.sleep(999)",
+            ],
+            completion_event=completion_event,
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+            output_callback=on_output,
+        )
+        elapsed = time.time() - start
+
+        assert "inactivity timeout" not in result.stderr.lower(), (
+            f"completion_event should suppress inactivity kill; stderr: {result.stderr!r}"
+        )
+        assert elapsed < _TEST_TIMEOUT, (
+            f"Test took {elapsed:.1f}s — exceeds {_TEST_TIMEOUT}s limit"
+        )
+
+
+class TestInactivityTimeoutWithExplicitTimeout:
+    """Both inactivity_timeout and explicit timeout set; inactivity fires first."""
+
+    def test_inactivity_timeout_with_explicit_timeout(self):
+        """Both timeouts configured; inactivity fires first.
+
+        Process outputs once then goes silent. Inactivity threshold (2s) is much
+        shorter than explicit timeout (30s). The inactivity watchdog fires first,
+        producing an inactivity error (exit_code=124, 'inactivity timeout' in
+        stderr) — not an explicit timeout error ('timed out').
+        """
+        start = time.time()
+        result = _run_subprocess(
+            args=[
+                _PYTHON,
+                "-c",
+                "import sys, time;"
+                " print('output', flush=True);"
+                " time.sleep(999)",
+            ],
+            timeout=30,
+            inactivity_timeout=_INACTIVITY_THRESHOLD,
+        )
+        elapsed = time.time() - start
+
+        assert result.exit_code == 124, (
+            f"Expected exit_code=124 (inactivity kill), got {result.exit_code}"
+        )
+        assert "inactivity timeout" in result.stderr.lower(), (
+            f"Expected inactivity error, got: {result.stderr!r}"
+        )
+        assert "timed out" not in result.stderr.lower(), (
+            f"Should be inactivity error, not explicit timeout; stderr: {result.stderr!r}"
+        )
+        assert elapsed < _TEST_TIMEOUT, (
+            f"Test took {elapsed:.1f}s — exceeds {_TEST_TIMEOUT}s limit"
         )

--- a/tests/unit/test_codex_stream_parser.py
+++ b/tests/unit/test_codex_stream_parser.py
@@ -13,6 +13,7 @@ Tests verify correct handling of:
 """
 
 import json
+import threading
 
 from fdsx.providers.codex import (
     CodexProvider,
@@ -521,3 +522,68 @@ class TestErrorEvent:
         cb(json.dumps({"type": _EVENT_ERROR, "message": "network error"}))
 
         assert get_result() == "partial"
+
+
+# ---------------------------------------------------------------------------
+# Tests: completion_event
+# ---------------------------------------------------------------------------
+
+
+class TestCompletionEvent:
+    """completion_event is set only on terminal events."""
+
+    def test_completion_event_set_on_agent_message_completed(self) -> None:
+        """item.completed + agent_message sets completion_event."""
+        event = threading.Event()
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None, completion_event=event)
+
+        assert not event.is_set()
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="done"))
+        assert event.is_set()
+
+    def test_completion_event_set_on_turn_failed(self) -> None:
+        """turn.failed event sets completion_event."""
+        event = threading.Event()
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None, completion_event=event)
+
+        assert not event.is_set()
+        cb(_build_turn_failed("rate limit"))
+        assert event.is_set()
+
+    def test_completion_event_set_on_error(self) -> None:
+        """error event sets completion_event."""
+        event = threading.Event()
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None, completion_event=event)
+
+        assert not event.is_set()
+        cb(json.dumps({"type": _EVENT_ERROR, "message": "quota exceeded"}))
+        assert event.is_set()
+
+    def test_completion_event_not_set_on_non_terminal(self) -> None:
+        """item.started and item.completed + reasoning do NOT set completion_event."""
+        event = threading.Event()
+        provider = _make_provider()
+        cb, _ = provider._make_stream_callback(lambda _: None, completion_event=event)
+
+        # item.started for agent_message — not terminal
+        cb(_build_item_started(_ITEM_TYPE_AGENT_MESSAGE))
+        assert not event.is_set()
+
+        # item.completed + reasoning — not terminal
+        cb(_build_item_completed(_ITEM_TYPE_REASONING, text="thinking"))
+        assert not event.is_set()
+
+    def test_completion_event_none_does_not_raise_on_terminal_events(self) -> None:
+        """When completion_event=None, terminal events are handled without errors."""
+        provider = _make_provider()
+        cb, get_result = provider._make_stream_callback(lambda _: None, completion_event=None)
+
+        # Should not raise
+        cb(_build_item_completed(_ITEM_TYPE_AGENT_MESSAGE, text="result"))
+        cb(_build_turn_failed("error"))
+        cb(json.dumps({"type": _EVENT_ERROR, "message": "fail"}))
+
+        assert get_result() == "result"

--- a/tests/unit/test_provider_options.py
+++ b/tests/unit/test_provider_options.py
@@ -1,9 +1,11 @@
 """Unit tests for provider option models (T004, T006, T007) and get_provider factory (T014)."""
 
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
-from fdsx.providers.base import get_provider
+from fdsx.providers.base import DEFAULT_INACTIVITY_TIMEOUT, ProviderResult, get_provider
 from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
 from fdsx.providers.codex import CodexOptions, CodexProvider
 from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
@@ -78,6 +80,21 @@ class TestClaudeOptions:
         """Extra fields must be rejected."""
         with pytest.raises(ValidationError):
             ClaudeOptions(unknown_field="value")  # type: ignore[call-arg]
+
+    def test_claude_options_inactivity_timeout_default(self):
+        """inactivity_timeout defaults to None."""
+        opts = ClaudeOptions()
+        assert opts.inactivity_timeout is None
+
+    def test_claude_options_inactivity_timeout_custom(self):
+        """Custom inactivity_timeout value is accepted."""
+        opts = ClaudeOptions(inactivity_timeout=600)
+        assert opts.inactivity_timeout == 600
+
+    def test_claude_options_inactivity_timeout_zero_disables(self):
+        """inactivity_timeout=0 is accepted (disables the watchdog)."""
+        opts = ClaudeOptions(inactivity_timeout=0)
+        assert opts.inactivity_timeout == 0
 
     def test_claude_options_to_cli_flags_combined(self):
         """All fields set together produce correct combined flags in order."""
@@ -166,6 +183,21 @@ class TestCodexOptions:
         with pytest.raises(ValidationError):
             CodexOptions(unknown_field="value")  # type: ignore[call-arg]
 
+    def test_codex_options_inactivity_timeout_default(self):
+        """inactivity_timeout defaults to None."""
+        opts = CodexOptions()
+        assert opts.inactivity_timeout is None
+
+    def test_codex_options_inactivity_timeout_custom(self):
+        """Custom inactivity_timeout value is accepted."""
+        opts = CodexOptions(inactivity_timeout=600)
+        assert opts.inactivity_timeout == 600
+
+    def test_codex_options_inactivity_timeout_zero_disables(self):
+        """inactivity_timeout=0 is accepted (disables the watchdog)."""
+        opts = CodexOptions(inactivity_timeout=0)
+        assert opts.inactivity_timeout == 0
+
     def test_codex_options_to_cli_flags_combined(self):
         """All fields set together produce correct combined flags in order."""
         opts = CodexOptions(
@@ -201,6 +233,21 @@ class TestOpenCodeOptions:
         """Extra fields must be rejected."""
         with pytest.raises(ValidationError):
             OpenCodeOptions(unknown_field="value")  # type: ignore[call-arg]
+
+    def test_opencode_options_inactivity_timeout_default(self):
+        """inactivity_timeout defaults to None."""
+        opts = OpenCodeOptions()
+        assert opts.inactivity_timeout is None
+
+    def test_opencode_options_inactivity_timeout_custom(self):
+        """Custom inactivity_timeout value is accepted."""
+        opts = OpenCodeOptions(inactivity_timeout=600)
+        assert opts.inactivity_timeout == 600
+
+    def test_opencode_options_inactivity_timeout_zero_disables(self):
+        """inactivity_timeout=0 is accepted (disables the watchdog)."""
+        opts = OpenCodeOptions(inactivity_timeout=0)
+        assert opts.inactivity_timeout == 0
 
 
 class TestGetProvider:
@@ -272,3 +319,90 @@ class TestGetProvider:
         """get_provider with invalid options dict raises ValidationError."""
         with pytest.raises(ValidationError):
             get_provider("claude", {"permission_mode": "invalid_mode"})
+
+
+class TestProviderInactivityTimeoutWiring:
+    """T007: Verify each provider passes resolved inactivity_timeout to _run_subprocess."""
+
+    _MOCK_RESULT = ProviderResult(exit_code=0, stdout="", stderr="")
+
+    def test_codex_passes_default_inactivity_timeout(self):
+        """CodexProvider with default options passes DEFAULT_INACTIVITY_TIMEOUT to _run_subprocess."""
+        provider = CodexProvider(CodexOptions())
+        with patch("fdsx.providers.codex._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == DEFAULT_INACTIVITY_TIMEOUT
+
+    def test_codex_passes_custom_inactivity_timeout(self):
+        """CodexProvider with inactivity_timeout=600 passes 600 to _run_subprocess."""
+        provider = CodexProvider(CodexOptions(inactivity_timeout=600))
+        with patch("fdsx.providers.codex._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == 600
+
+    def test_codex_passes_zero_inactivity_timeout(self):
+        """CodexProvider with inactivity_timeout=0 passes 0 to _run_subprocess (disabled)."""
+        provider = CodexProvider(CodexOptions(inactivity_timeout=0))
+        with patch("fdsx.providers.codex._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == 0
+
+    def test_claude_passes_default_inactivity_timeout(self):
+        """ClaudeProvider with default options passes DEFAULT_INACTIVITY_TIMEOUT to _run_subprocess."""
+        provider = ClaudeProvider(ClaudeOptions())
+        with patch("fdsx.providers.claude._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == DEFAULT_INACTIVITY_TIMEOUT
+
+    def test_claude_passes_custom_inactivity_timeout(self):
+        """ClaudeProvider with inactivity_timeout=600 passes 600 to _run_subprocess."""
+        provider = ClaudeProvider(ClaudeOptions(inactivity_timeout=600))
+        with patch("fdsx.providers.claude._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == 600
+
+    def test_claude_passes_zero_inactivity_timeout(self):
+        """ClaudeProvider with inactivity_timeout=0 passes 0 to _run_subprocess (disabled)."""
+        provider = ClaudeProvider(ClaudeOptions(inactivity_timeout=0))
+        with patch("fdsx.providers.claude._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == 0
+
+    def test_opencode_passes_default_inactivity_timeout(self):
+        """OpenCodeProvider with default options passes DEFAULT_INACTIVITY_TIMEOUT to _run_subprocess."""
+        provider = OpenCodeProvider(OpenCodeOptions())
+        with patch("fdsx.providers.opencode._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == DEFAULT_INACTIVITY_TIMEOUT
+
+    def test_opencode_passes_custom_inactivity_timeout(self):
+        """OpenCodeProvider with inactivity_timeout=600 passes 600 to _run_subprocess."""
+        provider = OpenCodeProvider(OpenCodeOptions(inactivity_timeout=600))
+        with patch("fdsx.providers.opencode._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == 600
+
+    def test_opencode_passes_zero_inactivity_timeout(self):
+        """OpenCodeProvider with inactivity_timeout=0 passes 0 to _run_subprocess (disabled)."""
+        provider = OpenCodeProvider(OpenCodeOptions(inactivity_timeout=0))
+        with patch("fdsx.providers.opencode._run_subprocess", return_value=self._MOCK_RESULT) as mock_run:
+            provider.execute(prompt="hello")
+        mock_run.assert_called_once()
+        _, kwargs = mock_run.call_args
+        assert kwargs["inactivity_timeout"] == 0

--- a/tests/unit/test_subprocess_completion.py
+++ b/tests/unit/test_subprocess_completion.py
@@ -26,7 +26,7 @@ import threading
 import time
 from unittest.mock import patch
 
-from fdsx.providers.base import ProviderResult, _run_subprocess
+from fdsx.providers.base import DEFAULT_INACTIVITY_TIMEOUT, ProviderResult, _run_subprocess
 from fdsx.providers.claude import ClaudeProvider
 
 # Use sys.executable so tests run with the same Python interpreter as the test
@@ -640,3 +640,67 @@ class TestClaudeProviderExecuteCompletionEvent:
         assert completion_event is None, (
             "completion_event should not be passed when output_callback is None"
         )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Inactivity timeout unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultInactivityTimeoutConstant:
+    """DEFAULT_INACTIVITY_TIMEOUT is exported with the expected value."""
+
+    def test_default_inactivity_timeout_value(self):
+        """DEFAULT_INACTIVITY_TIMEOUT equals 300 (5 minutes)."""
+        assert DEFAULT_INACTIVITY_TIMEOUT == 300
+
+    def test_default_inactivity_timeout_is_int(self):
+        """DEFAULT_INACTIVITY_TIMEOUT is an integer."""
+        assert isinstance(DEFAULT_INACTIVITY_TIMEOUT, int)
+
+
+class TestInactivityTimeoutParameter:
+    """inactivity_timeout parameter accepted by _run_subprocess without error."""
+
+    def test_inactivity_timeout_none_default(self):
+        """inactivity_timeout=None (default) — fast process completes normally."""
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "print('ok')"],
+            inactivity_timeout=None,
+        )
+        assert result.exit_code == 0
+        assert result.stdout == "ok"
+
+    def test_inactivity_timeout_zero_disables_watchdog(self):
+        """inactivity_timeout=0 — process completes without being killed."""
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "print('ok')"],
+            inactivity_timeout=0,
+        )
+        assert result.exit_code == 0
+        assert result.stdout == "ok"
+
+    def test_inactivity_timeout_result_exit_code_124(self):
+        """Process killed by inactivity returns exit_code=124."""
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(999)"],
+            inactivity_timeout=2,
+        )
+        assert result.exit_code == 124
+
+    def test_inactivity_timeout_result_stderr_message(self):
+        """Inactivity kill message includes threshold duration."""
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(999)"],
+            inactivity_timeout=2,
+        )
+        assert "2" in result.stderr
+        assert "inactivity timeout" in result.stderr.lower()
+
+    def test_inactivity_timeout_result_stdout_empty(self):
+        """Process killed by inactivity has empty stdout (like explicit timeout)."""
+        result = _run_subprocess(
+            args=[_PYTHON, "-c", "import time; time.sleep(999)"],
+            inactivity_timeout=2,
+        )
+        assert result.stdout == ""


### PR DESCRIPTION
## Summary

- **Phase 2: Inactivity timeout watchdog** (T001–T003) — any provider subprocess that goes silent for longer than the configured threshold is terminated with exit code 124 and a clear error message
- **Phase 3: Codex completion_event** (T004–T006) — structured-stream completion detection added to CodexProvider so hanging subprocesses are killed by the termination cascade after a terminal JSONL event
- **Phase 4: Per-provider inactivity_timeout configuration** (T007–T009) — users can configure or disable inactivity timeout per-provider via YAML options
- **Phase 5: Integration verification** (T010–T011) — end-to-end scenario tests confirming completion_event and inactivity_timeout work correctly together

## What was done

Implements FR-1 (completion_event for Codex), FR-2 (inactivity-based timeout), FR-3 (per-provider config), FR-4 (distinguishable error), FR-5/FR-6 (configurable/disableable timeout) from the [provider hang protection spec](specs/20260324140130-provider-hang-protection/spec.md).

### Phase 2: Inactivity Timeout (T001–T003)
| File | Change |
|------|--------|
| `src/fdsx/providers/base.py` | Added `_inactivity_watchdog` daemon thread, `_last_activity` shared timestamp with lock, `_suppressed` event, `killed_by_inactivity` result path |
| `tests/integration/test_inactivity_timeout.py` | 6 new integration tests (real subprocesses, 2s thresholds) |
| `tests/unit/test_subprocess_completion.py` | 7 new unit tests (constant validation, parameter behavior) |

### Phase 3: Codex completion_event (T004–T006)
| File | Change |
|------|--------|
| `src/fdsx/providers/codex.py` | Added `completion_event` parameter to `_make_stream_callback`; fires on terminal events (`item.completed+agent_message`, `turn.failed`, `error`); wired through `execute()` to `_run_subprocess` |
| `tests/unit/test_codex_stream_parser.py` | 5 new unit tests in `TestCompletionEvent` class |
| `tests/integration/test_codex_completion.py` | New integration test — subprocess emits terminal JSONL then hangs; verifies termination cascade kills within 15s |

### Phase 4: Per-Provider Config (T007–T009)
| File | Change |
|------|--------|
| `src/fdsx/providers/codex.py` | Added `inactivity_timeout: int | None = None` to `CodexOptions`; resolve effective timeout and pass to `_run_subprocess` |
| `src/fdsx/providers/claude.py` | Added `inactivity_timeout: int | None = None` to `ClaudeOptions`; resolve effective timeout and pass to `_run_subprocess` |
| `src/fdsx/providers/opencode.py` | Added `inactivity_timeout: int | None = None` to `OpenCodeOptions`; resolve effective timeout and pass to `_run_subprocess` |
| `tests/unit/test_provider_options.py` | 9 model field tests + 9 wiring tests in `TestProviderInactivityTimeoutWiring` |

### Phase 5: Integration Verification (T010–T011)
| File | Change |
|------|--------|
| `tests/integration/test_inactivity_timeout.py` | 2 new end-to-end scenario tests: `test_completion_event_suppresses_inactivity_timeout` and `test_inactivity_timeout_with_explicit_timeout` |
| `specs/.../tasks.md` | T001–T011 all marked complete |

## Test plan

- [x] Phase 2: All 6 integration + 7 unit tests pass (inactivity timeout)
- [x] Phase 3: All 5 unit + 1 integration test pass (Codex completion_event)
- [x] Phase 4: All 57 provider options tests pass (model fields + wiring)
- [x] Phase 5: 2 end-to-end scenario tests pass (completion_event ↔ inactivity_timeout interaction)
- [x] Full regression: 1316 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)