### PR TITLE
fix: preserve non-ASCII characters in task YAML output

### DIFF
--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -210,7 +210,9 @@ def save_task_file(path: Path, task_file: TaskFile) -> None:
     if task_file.source is not None:
         data["source"] = task_file.source
 
-    content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+    content = yaml.safe_dump(
+        data, default_flow_style=False, sort_keys=False, allow_unicode=True
+    )
 
     if path.is_symlink():
         raise ValueError(f"Refusing to write: target is a symlink: {path}")

--- a/src/fdsx/models/task.py
+++ b/src/fdsx/models/task.py
@@ -210,7 +210,7 @@ def save_task_file(path: Path, task_file: TaskFile) -> None:
     if task_file.source is not None:
         data["source"] = task_file.source
 
-    content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+    content = yaml.safe_dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
     if path.is_symlink():
         raise ValueError(f"Refusing to write: target is a symlink: {path}")


### PR DESCRIPTION
## Summary
- `yaml.safe_dump` escapes non-ASCII characters by default, causing Japanese (and other Unicode) text to render as `\uXXXX` sequences in task YAML files
- Added `allow_unicode=True` to the `save_task_file()` call in `src/fdsx/models/task.py` so UTF-8 characters are emitted directly

## Test plan
- [x] Existing `test_task_model.py` tests pass (58/58)
- [x] Manual verification: Japanese text round-trips correctly through `yaml.safe_dump`

🤖 Generated with [Claude Code](https://claude.com/claude-code)