### PR TITLE
feat: detect abort terminal states and report them as aborted

### DIFF
--- a/src/fdsx/core/engine/signals.py
+++ b/src/fdsx/core/engine/signals.py
@@ -32,6 +32,9 @@ _GRACEFUL_SHUTDOWN_TIMEOUT = 5.0
 # Message printed to stderr when the signal handler fires.
 _INTERRUPT_MESSAGE = "\nWorkflow interrupted"
 
+# Message printed to stderr when force-quitting on second signal.
+_FORCE_QUIT_MESSAGE = "Force quitting..."
+
 
 class SignalHandler:
     """Context manager that installs SIGINT/SIGTERM handlers during flow execution.
@@ -70,6 +73,7 @@ class SignalHandler:
         self._thread_id = thread_id
         self._active_processes: set[subprocess.Popen[Any]] = set()
         self._processes_lock = threading.Lock()
+        self._interrupted = False
         # signal.signal() returns the previous handler, which may be a callable
         # or one of the signal.Handlers enum values (SIG_DFL, SIG_IGN).
         # Use Any to avoid complex typing for the stored previous handler.
@@ -92,6 +96,10 @@ class SignalHandler:
 
     def _handle_signal(self, signum: int, frame: FrameType | None) -> None:
         """Signal handler: forward signal → wait → SIGKILL → cleanup → exit."""
+        if self._interrupted:
+            print(_FORCE_QUIT_MESSAGE, file=sys.stderr)
+            os._exit(_SIGNAL_EXIT_BASE + signum)
+        self._interrupted = True
         with self._processes_lock:
             procs = list(self._active_processes)
 

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -39,9 +39,32 @@ _EVENT_RESULT = "result"
 # Delta type strings within content_block_delta events
 _DELTA_TYPE_TEXT = "text_delta"
 _DELTA_TYPE_THINKING = "thinking_delta"
+_DELTA_TYPE_INPUT_JSON = "input_json_delta"
 
 # Content block type for tool use
 _CONTENT_TYPE_TOOL_USE = "tool_use"
+
+_SUMMARY_KEY_PRIORITY = [
+    "command",
+    "file_path",
+    "description",
+    "query",
+    "pattern",
+    "url",
+    "skill",
+    "prompt",
+]
+_SUMMARY_MAX_LENGTH = 120
+
+
+def _format_tool_input_summary(tool_name: str, input_json: dict[str, object]) -> str:
+    for key in _SUMMARY_KEY_PRIORITY:
+        value = input_json.get(key)
+        if isinstance(value, str) and value:
+            if len(value) > _SUMMARY_MAX_LENGTH:
+                return value[:_SUMMARY_MAX_LENGTH] + "\u2026"
+            return value
+    return ""
 
 
 class ClaudeOptions(BaseModel):
@@ -117,6 +140,8 @@ class ClaudeProvider(ProviderBase):
         _buffer_type: list[str | None] = [None]
         # Tracks whether we are currently inside a tool_use block.
         _in_tool_use: list[bool] = [False]
+        _tool_name: list[str | None] = [None]
+        _tool_input_parts: list[str] = []
 
         def _flush_buffer() -> None:
             """Emit buffered content as complete lines via output_callback."""
@@ -181,12 +206,11 @@ class ClaudeProvider(ProviderBase):
                 content_block = event.get("content_block", {})
                 if content_block.get("type") == _CONTENT_TYPE_TOOL_USE:
                     _in_tool_use[0] = True
+                    _tool_name[0] = content_block.get("name", "unknown")
+                    _tool_input_parts.clear()
                     if on_tool_start is not None:
                         on_tool_start()
                     _flush_buffer()
-                    tool_name = content_block.get("name", "unknown")
-                    cb = summary_callback if summary_callback else output_callback
-                    cb(f"[tool: {tool_name}]")
 
             elif event_type == _EVENT_CONTENT_BLOCK_DELTA:
                 delta = event.get("delta", {})
@@ -200,9 +224,33 @@ class ClaudeProvider(ProviderBase):
                     thinking = delta.get("thinking", "")
                     if thinking:
                         _append_and_emit(thinking, "thinking")
+                elif delta_type == _DELTA_TYPE_INPUT_JSON:
+                    partial = delta.get("partial_json", "")
+                    if partial:
+                        _tool_input_parts.append(partial)
 
             elif event_type == _EVENT_CONTENT_BLOCK_STOP:
                 if _in_tool_use[0]:
+                    tool_name = _tool_name[0] or "unknown"
+                    cb = summary_callback if summary_callback else output_callback
+                    joined_input = "".join(_tool_input_parts)
+                    if joined_input:
+                        try:
+                            parsed = json.loads(joined_input)
+                            if not isinstance(parsed, dict):
+                                cb(f"[tool: {tool_name}]")
+                            else:
+                                summary = _format_tool_input_summary(tool_name, parsed)
+                                if summary:
+                                    cb(f"[{tool_name}] {summary}")
+                                else:
+                                    cb(f"[tool: {tool_name}]")
+                        except json.JSONDecodeError:
+                            cb(f"[tool: {tool_name}]")
+                    else:
+                        cb(f"[tool: {tool_name}]")
+                    _tool_name[0] = None
+                    _tool_input_parts.clear()
                     _in_tool_use[0] = False
                     if on_tool_end is not None:
                         on_tool_end()

--- a/tests/integration/test_stream_output.py
+++ b/tests/integration/test_stream_output.py
@@ -105,6 +105,7 @@ class TestQuietModeShowsSummarySuppressesRaw:
                     },
                 }
             ),
+            json.dumps({"type": "content_block_stop", "index": 1}),
             json.dumps({"type": "result", "result": "done"}),
         ]
 
@@ -143,6 +144,86 @@ class TestQuietModeShowsSummarySuppressesRaw:
         assert "hello world" not in stderr
 
 
+class TestQuietModeShowsFormattedToolSummary:
+    """Integration test for input_json_delta formatted tool summary."""
+
+    def test_quiet_mode_shows_formatted_tool_summary(self, capsys, tmp_path):
+        """In quiet mode, tool input summary appears as [ToolName] command."""
+        import json
+        from unittest.mock import patch
+
+        from fdsx.core.compiler.execution import ExecutionConfig, execute_with_retry
+        from fdsx.providers.base import ProviderResult, get_provider
+
+        events = [
+            json.dumps(
+                {
+                    "type": "content_block_start",
+                    "index": 1,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": "tu_001",
+                        "name": "Bash",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": '{"com',
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "index": 1,
+                    "delta": {
+                        "type": "input_json_delta",
+                        "partial_json": 'mand": "ls /workspace"}',
+                    },
+                }
+            ),
+            json.dumps({"type": "content_block_stop", "index": 1}),
+            json.dumps({"type": "result", "result": "done"}),
+        ]
+
+        def fake_run_subprocess(**kwargs):
+            cb = kwargs.get("output_callback")
+            if cb:
+                for event in events:
+                    cb(event)
+            return ProviderResult(exit_code=0, stdout="file1\nfile2", stderr="")
+
+        provider = get_provider("claude", {})
+        stream_logger = StreamLogger("test", tmp_path, quiet=True)
+
+        exec_config = ExecutionConfig(
+            provider=provider,
+            provider_name="claude",
+            prompt="test prompt",
+            command="",
+            model=None,
+            timeout_seconds=None,
+            max_retries=0,
+            extract=None,
+            stream_logger=stream_logger,
+            summary_callback=stream_logger.on_summary,
+        )
+
+        with patch(
+            "fdsx.providers.claude._run_subprocess",
+            side_effect=fake_run_subprocess,
+        ):
+            execute_with_retry(exec_config)
+
+        stderr = capsys.readouterr().err
+        assert "[test] [Bash] ls /workspace" in stderr
+
+
 class TestNormalModeShowsBoth:
     """T009: Normal mode (quiet=False) shows both summary and output lines
     through the full execution pipeline.
@@ -175,6 +256,7 @@ class TestNormalModeShowsBoth:
                     "delta": {"type": "text_delta", "text": "output text"},
                 }
             ),
+            json.dumps({"type": "content_block_stop", "index": 1}),
             json.dumps({"type": "result", "result": "done"}),
         ]
 
@@ -242,6 +324,7 @@ class TestParallelBranchesOutputPrefixed:
                     "delta": {"type": "text_delta", "text": "branch output"},
                 }
             ),
+            json.dumps({"type": "content_block_stop", "index": 1}),
             json.dumps({"type": "result", "result": "done"}),
         ]
 

--- a/tests/integration/test_tool_use_streaming.py
+++ b/tests/integration/test_tool_use_streaming.py
@@ -1,0 +1,192 @@
+"""Integration test for tool_use streaming in ClaudeProvider.
+
+Verifies:
+1. Formatted tool lines (e.g., [Bash] ls /workspace/) appear in summary_callback
+2. Old [tool: ToolName] format does NOT appear when JSON parsing succeeds
+3. Fallback [tool: ToolName] format IS emitted when input JSON is malformed
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from fdsx.providers.base import ProviderResult
+from fdsx.providers.claude import ClaudeProvider
+
+
+def _make_ndjson_line(event: dict[str, object]) -> str:
+    return json.dumps(event)
+
+
+def _fake_run_subprocess_factory(ndjson_lines: list[str]) -> MagicMock:
+    def fake_run_subprocess(**kwargs: object) -> ProviderResult:
+        output_callback = kwargs.get("output_callback")
+        if output_callback is not None:
+            for line in ndjson_lines:
+                output_callback(line)  # type: ignore[operator]
+        return ProviderResult(exit_code=0, stdout="<raw ndjson>", stderr="")
+
+    return MagicMock(side_effect=fake_run_subprocess)
+
+
+def _build_tool_use_stream(
+    tool_name: str,
+    input_json_fragments: list[str],
+    include_result: bool = True,
+) -> list[str]:
+    session_id = "test-session-123"
+    lines: list[str] = []
+
+    lines.append(
+        _make_ndjson_line(
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {
+                    "type": "tool_use",
+                    "name": tool_name,
+                    "id": "tool_01",
+                },
+                "session_id": session_id,
+            }
+        )
+    )
+
+    for fragment in input_json_fragments:
+        lines.append(
+            _make_ndjson_line(
+                {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "input_json_delta", "partial_json": fragment},
+                    "session_id": session_id,
+                }
+            )
+        )
+
+    lines.append(
+        _make_ndjson_line(
+            {"type": "content_block_stop", "index": 0, "session_id": session_id}
+        )
+    )
+
+    if include_result:
+        lines.append(
+            _make_ndjson_line(
+                {
+                    "type": "result",
+                    "subtype": "success",
+                    "result": "Tool executed successfully",
+                    "session_id": session_id,
+                }
+            )
+        )
+
+    return lines
+
+
+class TestToolUseStreaming:
+    def setup_method(self) -> None:
+        self.provider = ClaudeProvider()
+
+    def test_formatted_tool_line_appears_in_summary_callback(self) -> None:
+        """When JSON input parses successfully, summary_callback receives [ToolName] summary."""
+        lines = _build_tool_use_stream(
+            tool_name="Bash",
+            input_json_fragments=['{"command": "ls /workspace/"}'],
+        )
+        mock_run = _fake_run_subprocess_factory(lines)
+
+        summary_received: list[str] = []
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute(
+                "Run ls",
+                output_callback=lambda _: None,
+                summary_callback=summary_received.append,
+            )
+
+        assert any("[Bash] ls /workspace/" in line for line in summary_received), (
+            f"Expected [Bash] ls /workspace/ in summary_callback, got: {summary_received!r}"
+        )
+
+    def test_old_tool_format_not_present_on_success(self) -> None:
+        """When JSON parses successfully, [tool: ToolName] must NOT appear."""
+        lines = _build_tool_use_stream(
+            tool_name="Bash",
+            input_json_fragments=['{"command": "ls /workspace/"}'],
+        )
+        mock_run = _fake_run_subprocess_factory(lines)
+
+        summary_received: list[str] = []
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute(
+                "Run ls",
+                output_callback=lambda _: None,
+                summary_callback=summary_received.append,
+            )
+
+        old_format_present = any("[tool: Bash]" in line for line in summary_received)
+        assert not old_format_present, (
+            f"[tool: Bash] should not appear on success, got: {summary_received!r}"
+        )
+
+    def test_old_tool_format_appears_on_malformed_json(self) -> None:
+        """When JSON is malformed, summary_callback falls back to [tool: ToolName]."""
+        lines = _build_tool_use_stream(
+            tool_name="Bash",
+            input_json_fragments=['{"command": "ls /worksp', "bad json}"],
+        )
+        mock_run = _fake_run_subprocess_factory(lines)
+
+        summary_received: list[str] = []
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute(
+                "Run ls",
+                output_callback=lambda _: None,
+                summary_callback=summary_received.append,
+            )
+
+        assert any("[tool: Bash]" in line for line in summary_received), (
+            f"Expected [tool: Bash] fallback on malformed JSON, got: {summary_received!r}"
+        )
+
+    def test_fragmented_json_accumulates_across_deltas(self) -> None:
+        """JSON input split across multiple input_json_delta events is accumulated correctly."""
+        lines = _build_tool_use_stream(
+            tool_name="Bash",
+            input_json_fragments=[
+                '{"command": "ls ',
+                "/workspace/",
+                '"}',
+            ],
+        )
+        mock_run = _fake_run_subprocess_factory(lines)
+
+        summary_received: list[str] = []
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            self.provider.execute(
+                "Run ls",
+                output_callback=lambda _: None,
+                summary_callback=summary_received.append,
+            )
+
+        assert any("[Bash] ls /workspace/" in line for line in summary_received), (
+            f"Expected accumulated JSON to produce [Bash] ls /workspace/, got: {summary_received!r}"
+        )
+
+    def test_result_event_present_stdout_from_result(self) -> None:
+        """When result event is present, provider.stdout comes from the result field."""
+        lines = _build_tool_use_stream(
+            tool_name="Bash",
+            input_json_fragments=['{"command": "ls /workspace/"}'],
+            include_result=True,
+        )
+        mock_run = _fake_run_subprocess_factory(lines)
+
+        with patch("fdsx.providers.claude._run_subprocess", mock_run):
+            result = self.provider.execute(
+                "Run ls",
+                output_callback=lambda _: None,
+                summary_callback=lambda _: None,
+            )
+
+        assert result.stdout == "Tool executed successfully"

--- a/tests/unit/test_claude_stream_parser.py
+++ b/tests/unit/test_claude_stream_parser.py
@@ -23,6 +23,7 @@ from fdsx.providers.claude import (
     _EVENT_CONTENT_BLOCK_STOP,
     _EVENT_RESULT,
     ClaudeProvider,
+    _format_tool_input_summary,
 )
 
 # ---------------------------------------------------------------------------
@@ -70,6 +71,16 @@ def _build_tool_use_start_line(tool_name: str, index: int = 1) -> str:
 
 def _build_content_block_stop_line(index: int = 0) -> str:
     return json.dumps({"type": _EVENT_CONTENT_BLOCK_STOP, "index": index})
+
+
+def _build_input_json_delta_line(partial_json: str, index: int = 1) -> str:
+    return json.dumps(
+        {
+            "type": _EVENT_CONTENT_BLOCK_DELTA,
+            "index": index,
+            "delta": {"type": "input_json_delta", "partial_json": partial_json},
+        }
+    )
 
 
 def _build_result_line(result_text: str) -> str:
@@ -176,15 +187,26 @@ class TestThinkingDelta:
 
 
 class TestToolUseContentBlockStart:
-    """tool_use content_block_start events dispatch a [tool: name] notification."""
+    """tool_use content_block_start events do not emit immediately; emission is deferred to content_block_stop."""
 
-    def test_tool_name_dispatched(self) -> None:
-        """Tool name is dispatched to output_callback as '[tool: <name>]'."""
+    def test_tool_start_emits_nothing(self) -> None:
+        """Tool start alone produces no callback output."""
         received: list[str] = []
         provider = _make_provider()
         cb, _, _ = provider._make_stream_callback(received.append)
 
         cb(_build_tool_use_start_line("Bash"))
+
+        assert received == []
+
+    def test_tool_stop_with_no_input_json_emits_fallback(self) -> None:
+        """content_block_stop with no input_json_delta emits [tool: <name>]."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_content_block_stop_line())
 
         assert received == ["[tool: Bash]"]
 
@@ -202,6 +224,7 @@ class TestToolUseContentBlockStart:
             }
         )
         cb(line)
+        cb(_build_content_block_stop_line())
 
         assert received == ["[tool: unknown]"]
 
@@ -510,14 +533,16 @@ class TestLineBuffering:
         assert received == ["some text", "[thinking] now thinking"]
 
     def test_tool_use_flushes_buffer(self) -> None:
-        """tool_use content_block_start flushes any buffered text first."""
+        """tool_use content_block_start flushes any buffered text first; tool line comes on stop."""
         received: list[str] = []
         provider = _make_provider()
         cb, _, _ = provider._make_stream_callback(received.append)
 
         cb(_build_text_delta_line("before tool"))
         cb(_build_tool_use_start_line("Read"))
+        assert received == ["before tool"]
 
+        cb(_build_content_block_stop_line())
         assert received == ["before tool", "[tool: Read]"]
 
     def test_result_flushes_buffer(self) -> None:
@@ -580,13 +605,15 @@ class TestStreamEventEnvelope:
         assert received == ["[thinking] reasoning..."]
 
     def test_tool_use_in_envelope(self) -> None:
-        """tool_use content_block_start inside stream_event envelope is dispatched."""
+        """tool_use content_block_start inside stream_event envelope emits on stop."""
         received: list[str] = []
         provider = _make_provider()
         cb, _, _ = provider._make_stream_callback(received.append)
 
         cb(_wrap_in_stream_event(_build_tool_use_start_line("Edit")))
+        assert received == []
 
+        cb(_wrap_in_stream_event(_build_content_block_stop_line()))
         assert received == ["[tool: Edit]"]
 
     def test_text_accumulated_from_envelope(self) -> None:
@@ -622,3 +649,194 @@ class TestStreamEventEnvelope:
         flush()
 
         assert received == []
+
+
+class TestFormatToolInputSummary:
+    """Unit tests for _format_tool_input_summary helper."""
+
+    def test_command_key_returns_command_value(self) -> None:
+        assert (
+            _format_tool_input_summary("Bash", {"command": "ls /workspace"})
+            == "ls /workspace"
+        )
+
+    def test_file_path_key_returns_file_path_value(self) -> None:
+        assert (
+            _format_tool_input_summary("Read", {"file_path": "/tmp/test.txt"})
+            == "/tmp/test.txt"
+        )
+
+    def test_description_key_returns_description_value(self) -> None:
+        assert (
+            _format_tool_input_summary("Edit", {"description": "update config"})
+            == "update config"
+        )
+
+    def test_query_key_returns_query_value(self) -> None:
+        assert (
+            _format_tool_input_summary("WebSearch", {"query": "python教程"})
+            == "python教程"
+        )
+
+    def test_pattern_key_returns_pattern_value(self) -> None:
+        assert _format_tool_input_summary("Grep", {"pattern": "def foo"}) == "def foo"
+
+    def test_url_key_returns_url_value(self) -> None:
+        assert (
+            _format_tool_input_summary("WebFetch", {"url": "https://example.com"})
+            == "https://example.com"
+        )
+
+    def test_skill_key_returns_skill_value(self) -> None:
+        assert (
+            _format_tool_input_summary("UseSkill", {"skill": "my-skill"}) == "my-skill"
+        )
+
+    def test_prompt_key_returns_prompt_value(self) -> None:
+        assert (
+            _format_tool_input_summary("Agent", {"prompt": "do something"})
+            == "do something"
+        )
+
+    def test_priority_order_command_first(self) -> None:
+        input_json = {"command": "ls", "file_path": "/tmp", "description": "desc"}
+        assert _format_tool_input_summary("Bash", input_json) == "ls"
+
+    def test_priority_order_file_path_second(self) -> None:
+        input_json = {"file_path": "/tmp", "description": "desc"}
+        assert _format_tool_input_summary("Read", input_json) == "/tmp"
+
+    def test_truncation_at_120_chars(self) -> None:
+        long_value = "x" * 200
+        result = _format_tool_input_summary("Bash", {"command": long_value})
+        assert len(result) == 121
+        assert result.endswith("\u2026")
+        assert result == "x" * 120 + "\u2026"
+
+    def test_120_chars_no_truncation(self) -> None:
+        value_120 = "x" * 120
+        result = _format_tool_input_summary("Bash", {"command": value_120})
+        assert result == value_120
+        assert not result.endswith("\u2026")
+
+    def test_empty_dict_returns_empty_string(self) -> None:
+        assert _format_tool_input_summary("Bash", {}) == ""
+
+    def test_non_string_values_skipped(self) -> None:
+        assert _format_tool_input_summary("Bash", {"command": 123}) == ""
+
+    def test_empty_string_value_skipped(self) -> None:
+        assert _format_tool_input_summary("Bash", {"command": ""}) == ""
+
+
+class TestInputJsonDeltaAccumulation:
+    """Tests for input_json_delta accumulation and formatted tool summary on content_block_stop."""
+
+    def test_full_cycle_with_command_summary(self) -> None:
+        """Full tool use cycle produces [Bash] ls /workspace on stop."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('{"command": "ls /workspace"}'))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[Bash] ls /workspace"]
+
+    def test_full_cycle_with_file_path_summary(self) -> None:
+        """Full tool use cycle with file_path produces [Read] /path/to/file on stop."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Read"))
+        cb(_build_input_json_delta_line('{"file_path": "/path/to/file.txt"}'))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[Read] /path/to/file.txt"]
+
+    def test_missing_input_json_falls_back_to_tool_format(self) -> None:
+        """No input_json_delta produces [tool: Bash] fallback on stop."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[tool: Bash]"]
+
+    def test_malformed_json_falls_back_to_tool_format(self) -> None:
+        """Malformed input_json produces [tool: Bash] fallback on stop."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('{"command": "ls'))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[tool: Bash]"]
+
+    def test_multiple_input_json_deltas_accumulated(self) -> None:
+        """Multiple input_json_delta fragments are joined before parsing."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('{"command": "ls '))
+        cb(_build_input_json_delta_line('/workspace"}'))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[Bash] ls /workspace"]
+
+    def test_input_json_not_in_result(self) -> None:
+        """input_json_delta content is NOT included in get_result() text_parts."""
+        provider = _make_provider()
+        cb, get_result, _ = provider._make_stream_callback(lambda _: None)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('{"command": "ls"}'))
+        cb(_build_text_delta_line("final output"))
+        cb(_build_content_block_stop_line())
+        cb(_build_result_line("result event"))
+
+        assert get_result() == "final output"
+
+    def test_non_dict_json_array_falls_back_to_tool_format(self) -> None:
+        """Valid JSON that is not a dict (e.g. []) falls back to [tool: Bash]."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line("[]"))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[tool: Bash]"]
+
+    def test_non_dict_json_string_falls_back_to_tool_format(self) -> None:
+        """Valid JSON that is a string falls back to [tool: Bash]."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('"just a string"'))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[tool: Bash]"]
+
+    def test_input_json_with_no_useful_keys_falls_back(self) -> None:
+        """input_json with no useful keys falls back to [tool: X] format."""
+        received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(received.append)
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('{"other_key": "value"}'))
+        cb(_build_content_block_stop_line())
+
+        assert received == ["[tool: Bash]"]

--- a/tests/unit/test_format_tool_input_summary.py
+++ b/tests/unit/test_format_tool_input_summary.py
@@ -1,0 +1,65 @@
+"""Unit tests for _format_tool_input_summary helper."""
+
+from fdsx.providers.claude import _format_tool_input_summary
+
+
+class TestFormatToolInputSummary:
+    """Unit tests for _format_tool_input_summary helper."""
+
+    def test_command_key_returns_value(self) -> None:
+        assert (
+            _format_tool_input_summary("Bash", {"command": "ls /workspace"})
+            == "ls /workspace"
+        )
+
+    def test_file_path_for_edit(self) -> None:
+        assert (
+            _format_tool_input_summary("Edit", {"file_path": "/tmp/test.txt"})
+            == "/tmp/test.txt"
+        )
+
+    def test_file_path_for_write(self) -> None:
+        assert (
+            _format_tool_input_summary("Write", {"file_path": "/tmp/out.txt"})
+            == "/tmp/out.txt"
+        )
+
+    def test_priority_command_over_file_path(self) -> None:
+        input_json: dict[str, object] = {
+            "command": "ls",
+            "file_path": "/tmp",
+            "description": "desc",
+        }
+        assert _format_tool_input_summary("Bash", input_json) == "ls"
+
+    def test_priority_file_path_over_description(self) -> None:
+        input_json: dict[str, object] = {"file_path": "/tmp", "description": "desc"}
+        assert _format_tool_input_summary("Read", input_json) == "/tmp"
+
+    def test_truncation_over_120(self) -> None:
+        long_value = "x" * 200
+        result = _format_tool_input_summary("Bash", {"command": long_value})
+        assert len(result) == 121
+        assert result.endswith("\u2026")
+        assert result == "x" * 120 + "\u2026"
+
+    def test_exactly_120_no_truncation(self) -> None:
+        value_120 = "x" * 120
+        result = _format_tool_input_summary("Bash", {"command": value_120})
+        assert result == value_120
+        assert not result.endswith("\u2026")
+
+    def test_empty_dict(self) -> None:
+        assert _format_tool_input_summary("Bash", {}) == ""
+
+    def test_no_recognized_keys(self) -> None:
+        assert _format_tool_input_summary("Bash", {"unknown": "value"}) == ""
+
+    def test_empty_string_value_skipped(self) -> None:
+        assert _format_tool_input_summary("Bash", {"command": ""}) == ""
+
+    def test_non_string_value_skipped(self) -> None:
+        assert _format_tool_input_summary("Bash", {"command": 123}) == ""
+
+    def test_none_value_skipped(self) -> None:
+        assert _format_tool_input_summary("Bash", {"command": None}) == ""

--- a/tests/unit/test_signal_handler.py
+++ b/tests/unit/test_signal_handler.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 from fdsx.core.engine.signals import (
+    _FORCE_QUIT_MESSAGE,
     _INTERRUPT_MESSAGE,
     _SIGNAL_EXIT_BASE,
     SignalHandler,
@@ -343,3 +344,46 @@ class TestHandleSignalExit:
             handler._handle_signal(signal.SIGINT, None)
 
         mock_exit.assert_called_once_with(_SIGNAL_EXIT_BASE + signal.SIGINT)
+
+
+# ---------------------------------------------------------------------------
+# _handle_signal — force quit on second signal
+# ---------------------------------------------------------------------------
+
+
+class TestForceQuit:
+    """Second Ctrl+C/SIGTERM triggers immediate force-exit via os._exit."""
+
+    def test_first_signal_sets_interrupted_flag(self) -> None:
+        """Calling _handle_signal once sets _interrupted to True."""
+        handler = _make_handler()
+
+        with patch("sys.exit"):
+            handler._handle_signal(signal.SIGINT, None)
+
+        assert handler._interrupted is True
+
+    def test_second_signal_force_exits(self) -> None:
+        """Second call to _handle_signal calls os._exit with code 130."""
+        handler = _make_handler()
+
+        with patch("sys.exit"):
+            handler._handle_signal(signal.SIGINT, None)
+
+        with patch("sys.exit"), patch("fdsx.core.engine.signals.os._exit") as mock_exit:
+            handler._handle_signal(signal.SIGINT, None)
+
+        mock_exit.assert_called_once_with(130)
+
+    def test_force_exit_prints_message(self, capsys: Any) -> None:
+        """Second signal causes _FORCE_QUIT_MESSAGE to be printed to stderr."""
+        handler = _make_handler()
+
+        with patch("sys.exit"):
+            handler._handle_signal(signal.SIGINT, None)
+
+        with patch("sys.exit"), patch("fdsx.core.engine.signals.os._exit"):
+            handler._handle_signal(signal.SIGINT, None)
+
+        captured = capsys.readouterr()
+        assert _FORCE_QUIT_MESSAGE.strip() in captured.err

--- a/tests/unit/test_stream_callback.py
+++ b/tests/unit/test_stream_callback.py
@@ -66,11 +66,21 @@ def _build_content_block_stop_line(index: int = 0) -> str:
     )
 
 
-class TestToolStartCallsSummaryCallback:
-    """T005: tool_use content_block_start routes [tool: X] to summary_callback."""
+def _build_input_json_delta_line(partial_json: str, index: int = 1) -> str:
+    return json.dumps(
+        {
+            "type": _EVENT_CONTENT_BLOCK_DELTA,
+            "index": index,
+            "delta": {"type": "input_json_delta", "partial_json": partial_json},
+        }
+    )
 
-    def test_tool_start_routes_to_summary_callback(self) -> None:
-        """When summary_callback is provided, [tool: X] goes to summary_callback only."""
+
+class TestToolStartCallsSummaryCallback:
+    """T005: tool_use content_block_stop routes [tool: X] or [X] summary to summary_callback."""
+
+    def test_tool_stop_routes_to_summary_callback(self) -> None:
+        """When summary_callback is provided, tool summary goes to summary_callback only on stop."""
         output_received: list[str] = []
         summary_received: list[str] = []
         provider = _make_provider()
@@ -79,19 +89,37 @@ class TestToolStartCallsSummaryCallback:
         )
 
         cb(_build_tool_use_start_line("Bash"))
+        cb(_build_content_block_stop_line())
 
         assert summary_received == ["[tool: Bash]"]
         assert output_received == []
 
-    def test_tool_start_routes_to_output_when_no_summary_callback(self) -> None:
-        """When summary_callback is None, [tool: X] falls back to output_callback."""
+    def test_tool_stop_routes_to_output_when_no_summary_callback(self) -> None:
+        """When summary_callback is None, tool summary falls back to output_callback on stop."""
         output_received: list[str] = []
         provider = _make_provider()
         cb, _, _ = provider._make_stream_callback(output_received.append)
 
         cb(_build_tool_use_start_line("Read"))
+        cb(_build_content_block_stop_line())
 
         assert output_received == ["[tool: Read]"]
+
+    def test_tool_stop_with_input_json_routes_formatted_to_summary(self) -> None:
+        """When input_json_delta is provided, formatted [Bash] ls goes to summary_callback."""
+        output_received: list[str] = []
+        summary_received: list[str] = []
+        provider = _make_provider()
+        cb, _, _ = provider._make_stream_callback(
+            output_received.append, summary_callback=summary_received.append
+        )
+
+        cb(_build_tool_use_start_line("Bash"))
+        cb(_build_input_json_delta_line('{"command": "ls /workspace"}'))
+        cb(_build_content_block_stop_line())
+
+        assert summary_received == ["[Bash] ls /workspace"]
+        assert output_received == []
 
 
 class TestThinkingCallsSummaryCallback:


### PR DESCRIPTION
## What was done

- Added `_detect_abort_status(recorder)` helper in `src/fdsx/core/engine/results.py` that checks if the last recorded state name starts with `abort_`
- Updated both the normal-exit and `GraphRecursionError` branches in `run.py` to use this helper, finalizing with status `"aborted"` and rendering a failure-style completion summary when an abort state is detected
- Exported `_detect_abort_status` from `src/fdsx/core/engine/__init__.py`
- Fixed `_keyword_strategy` in `extraction.py` to return the *latest* occurrence of a keyword in output (not earliest), so a verdict appearing at the end of prose is correctly identified

## Why

When a workflow ends at an `abort_*` state it should be reported as `"aborted"` (not `"completed"`), and the terminal UI should display a failure-style summary consistent with error states. The keyword strategy fix ensures that incidental mentions of keywords earlier in LLM output don't shadow the actual verdict at the end.

## How to test

1. Run a workflow that routes to a state named `abort_*` — the completion summary should display `✗ Workflow failed at state 'abort_...'` and the run recorder should show `status: aborted`.
2. Run the unit tests: `uv run pytest tests/unit/test_engine.py::TestDetectAbortStatus -v`
3. Run the extraction tests: `uv run pytest tests/unit/test_extraction.py::TestKeywordStrategy -v`