### PR TITLE
feat: detect abort terminal states and report them as aborted

### DIFF
--- a/src/fdsx/core/engine/__init__.py
+++ b/src/fdsx/core/engine/__init__.py
@@ -8,6 +8,7 @@ to work without changes.
 from .batch import run_batch
 from .results import (
     _calc_elapsed,
+    _detect_abort_status,
     _extract_results,
     _find_failed_state,
     _sanitize_state_for_log,
@@ -26,8 +27,8 @@ from .validate import FlowValidationError, validate_flow
 __all__ = [
     "FlowValidationError",
     "_calc_elapsed",
+    "_detect_abort_status",
     "_extract_results",
-    "_filter_actionable_entries",
     "_find_failed_state",
     "_sanitize_state_for_log",
     "_update_task_status",

--- a/src/fdsx/core/engine/__init__.py
+++ b/src/fdsx/core/engine/__init__.py
@@ -29,6 +29,7 @@ __all__ = [
     "_calc_elapsed",
     "_detect_abort_status",
     "_extract_results",
+    "_filter_actionable_entries",
     "_find_failed_state",
     "_sanitize_state_for_log",
     "_update_task_status",

--- a/src/fdsx/core/engine/results.py
+++ b/src/fdsx/core/engine/results.py
@@ -72,3 +72,24 @@ def _find_failed_state(recorder: RunRecorder) -> tuple[str, str] | None:
         if state.get("status") == "error":
             return (str(state.get("name", "unknown")), str(state.get("error", "")))
     return None
+
+
+def _detect_abort_status(
+    recorder: RunRecorder,
+) -> tuple[str, str | None, str | None]:
+    """Detect if the workflow ended at an abort state.
+
+    Args:
+        recorder: The RunRecorder instance
+
+    Returns:
+        Tuple of (status, failed_state_name, error_message):
+        - If last state name starts with "abort_": ("aborted", state_name, "workflow aborted")
+        - Otherwise: ("completed", None, None)
+    """
+    if recorder.states:
+        last = recorder.states[-1]
+        name = last.get("name", "")
+        if isinstance(name, str) and name.startswith("abort_"):
+            return ("aborted", name, "workflow aborted")
+    return ("completed", None, None)

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -22,6 +22,7 @@ from fdsx.logging.recorder import FDSX_DIR_NAME, LOGS_DIR_NAME, RUNS_DIR_NAME
 from .interrupts import handle_interrupts
 from .results import (
     _calc_elapsed,
+    _detect_abort_status,
     _extract_results,
     _find_failed_state,
     _sanitize_state_for_log,
@@ -166,16 +167,34 @@ def run_flow(
                 last_state = final_state_info.values
 
         results = _extract_results(last_state, compiled.result_paths)
-        recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+        status, failed_state, error_msg = _detect_abort_status(recorder)
+        recorder.finalize(_sanitize_state_for_log(last_state), status)
         recorder.save(base_dir=base_dir)
-        display_completion_summary(flow.name, _calc_elapsed(recorder))
+        if failed_state is not None:
+            display_completion_summary(
+                flow.name,
+                _calc_elapsed(recorder),
+                failed_state,
+                error_msg or "workflow aborted",
+            )
+        else:
+            display_completion_summary(flow.name, _calc_elapsed(recorder))
         return results
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         results = _extract_results(last_state, compiled.result_paths)
-        recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+        status, failed_state, error_msg = _detect_abort_status(recorder)
+        recorder.finalize(_sanitize_state_for_log(last_state), status)
         recorder.save(base_dir=base_dir)
-        display_completion_summary(flow.name, _calc_elapsed(recorder))
+        if failed_state is not None:
+            display_completion_summary(
+                flow.name,
+                _calc_elapsed(recorder),
+                failed_state,
+                error_msg or "workflow aborted",
+            )
+        else:
+            display_completion_summary(flow.name, _calc_elapsed(recorder))
         return results
     except Exception as e:
         if checkpoint_manager is not None:

--- a/src/fdsx/core/extraction.py
+++ b/src/fdsx/core/extraction.py
@@ -168,7 +168,7 @@ def _keyword_strategy(output: str, pattern: str) -> str | None:
 
     Splits the pattern by '|' to get a list of keywords, then searches
     for each keyword case-insensitively using word boundaries in the output.
-    Returns the keyword whose occurrence appears earliest in the output
+    Returns the keyword whose occurrence appears latest in the output
     (with original case from pattern).
 
     Args:
@@ -181,18 +181,18 @@ def _keyword_strategy(output: str, pattern: str) -> str | None:
     keywords = pattern.split("|")
     output_lower = output.lower()
 
-    earliest_match = None
-    earliest_pos = len(output)
+    latest_match = None
+    latest_pos = -1
 
     for keyword in keywords:
         keyword_lower = keyword.lower()
         pattern_escaped = re.escape(keyword_lower)
-        match = re.search(r"\b" + pattern_escaped + r"\b", output_lower)
-        if match and match.start() < earliest_pos:
-            earliest_pos = match.start()
-            earliest_match = keyword
+        for match in re.finditer(r"\b" + pattern_escaped + r"\b", output_lower):
+            if match.start() > latest_pos:
+                latest_pos = match.start()
+                latest_match = keyword
 
-    return earliest_match
+    return latest_match
 
 
 def _execute_llm_fallback(

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from fdsx.core.engine import (
     _calc_elapsed,
+    _detect_abort_status,
     _extract_results,
     _find_failed_state,
     _workflow_persist_id,
@@ -138,6 +139,43 @@ class TestFindFailedState:
         recorder = self._make_recorder()
         recorder.states = []
         assert _find_failed_state(recorder) is None
+
+
+class TestDetectAbortStatus:
+    """Tests for _detect_abort_status helper in engine."""
+
+    def _make_recorder(self) -> RunRecorder:
+        return RunRecorder(
+            thread_id="test-thread-id",
+            flow_name="TestFlow",
+        )
+
+    def test_abort_state_returns_aborted_status(self):
+        """Last state starting with 'abort_' returns aborted status."""
+        recorder = self._make_recorder()
+        recorder.states = [
+            {"name": "step1", "status": "completed"},
+            {"name": "abort_design_issues", "status": "completed"},
+        ]
+        result = _detect_abort_status(recorder)
+        assert result == ("aborted", "abort_design_issues", "workflow aborted")
+
+    def test_regular_state_returns_completed(self):
+        """Last state not starting with 'abort_' returns completed status."""
+        recorder = self._make_recorder()
+        recorder.states = [
+            {"name": "step1", "status": "completed"},
+            {"name": "step2", "status": "completed"},
+        ]
+        result = _detect_abort_status(recorder)
+        assert result == ("completed", None, None)
+
+    def test_empty_states_returns_completed(self):
+        """Empty recorder.states returns completed status."""
+        recorder = self._make_recorder()
+        recorder.states = []
+        result = _detect_abort_status(recorder)
+        assert result == ("completed", None, None)
 
 
 class TestErrorPathFallback:

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -96,11 +96,11 @@ class TestKeywordStrategy:
         result = _keyword_strategy(output, "APPROVED|REJECTED")
         assert result == "REJECTED"
 
-    def test_first_keyword_wins(self):
-        """When multiple keywords appear, earliest in output wins."""
+    def test_last_keyword_wins(self):
+        """When multiple keywords appear, latest in output wins."""
         output = "both approved and rejected appear"
         result = _keyword_strategy(output, "APPROVED|REJECTED")
-        assert result == "APPROVED"  # "approved" appears first in output
+        assert result == "REJECTED"  # "rejected" appears last in output
 
     def test_no_match_returns_none(self):
         output = "The status is unknown"
@@ -136,16 +136,22 @@ class TestKeywordStrategy:
         assert result == "APPROVED"
 
     def test_output_order_not_pattern_order(self):
-        """Regression: keyword matching should return the earliest occurrence in output, not first in pattern list."""
+        """Regression: keyword matching should return the latest occurrence in output, not first in pattern list."""
         output = "first REJECTED then APPROVED"
         result = _keyword_strategy(output, "APPROVED|REJECTED")
-        assert result == "REJECTED"
+        assert result == "APPROVED"
 
     def test_output_order_multiple_keywords(self):
-        """When multiple keywords appear, return the one that appears first in output."""
+        """When multiple keywords appear, return the one that appears last in output."""
         output = "the decision is APPROVED, not REJECTED"
         result = _keyword_strategy(output, "MAYBE|APPROVED|REJECTED")
-        assert result == "APPROVED"
+        assert result == "REJECTED"
+
+    def test_keyword_in_prose_before_verdict_returns_verdict(self):
+        """Regression: keyword appearing in prose before the actual verdict should not be returned."""
+        output = "there is no pending implementation to reject so I will APPROVE"
+        result = _keyword_strategy(output, "APPROVE|REJECT")
+        assert result == "APPROVE"
 
 
 class TestExecuteStrategy:


### PR DESCRIPTION
Add `_detect_abort_status` helper in `results.py` that inspects the last recorded state name: if it starts with `abort_`, the workflow finalizes with status `"aborted"` and renders a failure-style completion summary; otherwise it reports `"completed"` as before.

Also fix `_keyword_strategy` to return the *latest* occurrence in output rather than the earliest, so a verdict keyword that appears at the end of prose (after incidental mentions) is correctly selected.