### PR TITLE
fix: resolve all quality gate failures (format, mypy, pytest)

### DIFF
--- a/src/fdsx/cli/init_interactive.py
+++ b/src/fdsx/cli/init_interactive.py
@@ -1,0 +1,207 @@
+"""Interactive UI functions for fdsx init using Rich/Typer patterns."""
+
+from rich.console import Console
+from rich.table import Table
+
+from fdsx.models.init import ProviderSelection, TemplateInfo
+from fdsx.models.validators import VALID_PROVIDERS
+
+MODEL_PRESETS: dict[str, list[str]] = {
+    "claude": ["claude-sonnet-4-6", "claude-opus-4-6", "claude-haiku-4-5"],
+    "codex": ["o4-mini", "o3", "codex-mini"],
+    "gemini": ["gemini-2.5-pro", "gemini-2.5-flash"],
+}
+
+_console = Console(stderr=True)
+
+
+def _input(prompt: str = "") -> str:
+    """Thin wrapper around input() for test mocking.
+
+    Args:
+        prompt: Optional prompt string (if empty, prompt should already be displayed).
+    """
+    return input(prompt)
+
+
+def select_providers() -> list[str]:
+    """Display provider selection table and return chosen providers."""
+    table = Table(title="Select Providers", show_header=True, header_style="bold")
+    table.add_column("#", style="dim", width=4)
+    table.add_column("Provider")
+
+    providers = sorted(VALID_PROVIDERS)
+    for i, provider in enumerate(providers, start=1):
+        table.add_row(str(i), provider)
+
+    _console.print(table)
+    _console.print("Enter numbers separated by commas (e.g. 1,3): ", end="")
+
+    while True:
+        user_input = _input("").strip()
+        if not user_input:
+            _console.print("Please enter at least one provider.", style="red")
+            _console.print("Enter numbers separated by commas (e.g. 1,3): ", end="")
+            continue
+        try:
+            indices = [int(x.strip()) for x in user_input.split(",")]
+        except ValueError:
+            _console.print("Invalid input. Enter numbers only.", style="red")
+            _console.print("Enter numbers separated by commas (e.g. 1,3): ", end="")
+            continue
+        if not all(1 <= idx <= len(providers) for idx in indices):
+            _console.print(
+                f"Invalid selection. Enter numbers between 1 and {len(providers)}.",
+                style="red",
+            )
+            _console.print("Enter numbers separated by commas (e.g. 1,3): ", end="")
+            continue
+        if len(set(indices)) != len(indices):
+            _console.print("Duplicate selections are not allowed.", style="red")
+            _console.print("Enter numbers separated by commas (e.g. 1,3): ", end="")
+            continue
+        selected = [providers[idx - 1] for idx in indices]
+        return selected
+
+
+def select_models(providers: list[str]) -> list[ProviderSelection]:
+    """Display model selection for each provider and return selections."""
+    results: list[ProviderSelection] = []
+
+    for provider in providers:
+        presets = MODEL_PRESETS.get(provider, [])
+
+        if not presets:
+            _console.print(f"\n[bold]Provider:[/bold] {provider}")
+            _console.print("Enter model name: ", end="")
+            while True:
+                model = _input("").strip()
+                if not model:
+                    _console.print("Model name cannot be empty.", style="red")
+                    _console.print("Enter model name: ", end="")
+                    continue
+                results.append(ProviderSelection(provider=provider, model=model))
+                break
+            continue
+
+        table = Table(
+            title=f"Select Model for {provider}",
+            show_header=True,
+            header_style="bold",
+        )
+        table.add_column("#", style="dim", width=4)
+        table.add_column("Model")
+
+        for i, model in enumerate(presets, start=1):
+            table.add_row(str(i), model)
+
+        _console.print(f"\n[bold]Provider:[/bold] {provider}")
+        _console.print(table)
+        _console.print("Enter number (or type a custom model name): ", end="")
+
+        while True:
+            user_input = _input("").strip()
+            if not user_input:
+                _console.print("Please enter a selection.", style="red")
+                _console.print("Enter number (or type a custom model name): ", end="")
+                continue
+            try:
+                idx = int(user_input)
+                if 1 <= idx <= len(presets):
+                    results.append(
+                        ProviderSelection(provider=provider, model=presets[idx - 1])
+                    )
+                    break
+                _console.print(
+                    f"Invalid number. Enter between 1 and {len(presets)}.",
+                    style="red",
+                )
+                _console.print("Enter number (or type a custom model name): ", end="")
+            except ValueError:
+                results.append(ProviderSelection(provider=provider, model=user_input))
+                break
+    return results
+
+
+def select_templates(available: list[TemplateInfo]) -> list[TemplateInfo]:
+    """Display template selection table and return chosen templates."""
+    if not available:
+        return []
+
+    table = Table(
+        title="Select Templates",
+        show_header=True,
+        header_style="bold",
+    )
+    table.add_column("#", style="dim", width=4)
+    table.add_column("Template")
+    table.add_column("Source", style="dim")
+
+    for i, template in enumerate(available, start=1):
+        table.add_row(str(i), template.name, template.source)
+
+    _console.print(table)
+    _console.print(
+        "Enter numbers separated by commas (or press Enter for none): ", end=""
+    )
+
+    while True:
+        user_input = _input("").strip()
+        if not user_input:
+            return []
+        try:
+            indices = [int(x.strip()) for x in user_input.split(",")]
+        except ValueError:
+            _console.print("Invalid input. Enter numbers only.", style="red")
+            _console.print(
+                "Enter numbers separated by commas (or press Enter for none): ",
+                end="",
+            )
+            continue
+        if not all(1 <= idx <= len(available) for idx in indices):
+            _console.print(
+                f"Invalid selection. Enter numbers between 1 and {len(available)}.",
+                style="red",
+            )
+            _console.print(
+                "Enter numbers separated by commas (or press Enter for none): ",
+                end="",
+            )
+            continue
+        if len(set(indices)) != len(indices):
+            _console.print("Duplicate selections are not allowed.", style="red")
+            _console.print(
+                "Enter numbers separated by commas (or press Enter for none): ",
+                end="",
+            )
+            continue
+        selected = [available[idx - 1] for idx in indices]
+        return selected
+
+
+def confirm_existing_project() -> bool:
+    """Ask user whether to proceed with an existing project directory."""
+    _console.print("Project directory already exists. Continue? (y/n): ", end="")
+    while True:
+        user_input = _input("").strip().lower()
+        if user_input in ("y", "yes"):
+            return True
+        if user_input in ("n", "no"):
+            return False
+        _console.print("Please enter 'y' or 'n'.", style="red")
+        _console.print("Continue? (y/n): ", end="")
+
+
+def confirm_overwrite(workflow_name: str) -> bool:
+    """Ask user whether to overwrite an existing workflow file."""
+    _console.print(
+        f"Workflow '{workflow_name}' already exists. Overwrite? (y/n): ", end=""
+    )
+    while True:
+        user_input = _input("").strip().lower()
+        if user_input in ("y", "yes"):
+            return True
+        if user_input in ("n", "no"):
+            return False
+        _console.print("Please enter 'y' or 'n'.", style="red")
+        _console.print(f"Overwrite '{workflow_name}'? (y/n): ", end="")

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -15,9 +15,15 @@ from fdsx.core.batch import (
 )
 from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
-from fdsx.core.init import ensure_gitignore, needs_init, scaffold
+from fdsx.core.init import (
+    discover_templates,
+    ensure_gitignore,
+    needs_init,
+    scaffold,
+)
 from fdsx.core.thread_id import generate_thread_id
 from fdsx.display.terminal import Spinner, _sanitize_output, display_resume_command
+from fdsx.models.init import InitConfig, ProviderSelection
 
 app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework")
 
@@ -57,10 +63,15 @@ def main(
     else:
         _interactive_mode = sys.stdin.isatty()
     if _interactive_mode and needs_init(Path.cwd()):
-        created = scaffold(Path.cwd())
+        templates = discover_templates()
+        default_provider = ProviderSelection(
+            provider="claude", model="claude-sonnet-4-7"
+        )
+        config = InitConfig(providers=[default_provider], templates=templates)
+        result = scaffold(Path.cwd(), config)
         typer.echo("Initialized .fdsx/ directory with example workflows.\n", err=True)
         typer.echo("Created:", err=True)
-        for f in created:
+        for f in result.created:
             typer.echo(f"  {f}", err=True)
         typer.echo("", err=True)
         typer.echo("Next steps:", err=True)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -6,6 +6,13 @@ import typer
 
 from fdsx import __version__
 from fdsx.checkpoint.manager import CheckpointManager
+from fdsx.cli.init_interactive import (
+    confirm_existing_project,
+    confirm_overwrite,
+    select_models,
+    select_providers,
+    select_templates,
+)
 from fdsx.core import engine
 from fdsx.core.batch import (
     COMPLETED_SUBDIR,
@@ -16,6 +23,7 @@ from fdsx.core.batch import (
 from fdsx.core.config import TaskSplitterConfig, load_config
 from fdsx.core.engine import FlowValidationError
 from fdsx.core.init import (
+    check_conflicts,
     discover_templates,
     ensure_gitignore,
     needs_init,
@@ -23,7 +31,7 @@ from fdsx.core.init import (
 )
 from fdsx.core.thread_id import generate_thread_id
 from fdsx.display.terminal import Spinner, _sanitize_output, display_resume_command
-from fdsx.models.init import InitConfig, ProviderSelection
+from fdsx.models.init import InitConfig
 
 app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework")
 
@@ -62,28 +70,11 @@ def main(
         _interactive_mode = False
     else:
         _interactive_mode = sys.stdin.isatty()
-    if _interactive_mode and needs_init(Path.cwd()):
-        templates = discover_templates()
-        default_provider = ProviderSelection(
-            provider="claude", model="claude-sonnet-4-7"
-        )
-        config = InitConfig(providers=[default_provider], templates=templates)
-        result = scaffold(Path.cwd(), config)
-        typer.echo("Initialized .fdsx/ directory with example workflows.\n", err=True)
-        typer.echo("Created:", err=True)
-        for f in result.created:
-            typer.echo(f"  {f}", err=True)
-        typer.echo("", err=True)
-        typer.echo("Next steps:", err=True)
+    if ctx.invoked_subcommand != "init" and needs_init(Path.cwd()):
         typer.echo(
-            "  1. Edit .fdsx/config.yaml to configure profiles and provider settings",
+            "No .fdsx/ directory found. Run 'fdsx init' to set up your project.",
             err=True,
         )
-        typer.echo("  2. Customize workflows in .fdsx/workflows/", err=True)
-        rerun_cmd = (
-            f"fdsx {ctx.invoked_subcommand}" if ctx.invoked_subcommand else "fdsx"
-        )
-        typer.echo(f"  3. Re-run your command: {rerun_cmd}", err=True)
         raise typer.Exit(code=0)
     elif (
         _interactive_mode
@@ -269,6 +260,61 @@ def _display_resume_on_error(
         display_resume_command(mode="tasks-dir", tasks_dir=tasks_dir)
     elif thread_id is not None:
         display_resume_command(mode="single-flow", thread_id=thread_id)
+
+
+@app.command()
+def init() -> None:
+    """Initialize a new fdsx project with interactive provider and template selection."""
+    if not sys.stdin.isatty():
+        typer.echo(
+            "Error: fdsx init requires an interactive terminal.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    try:
+        templates = discover_templates()
+        cwd = Path.cwd()
+
+        if not needs_init(cwd) and not confirm_existing_project():
+            raise typer.Exit(code=0)
+
+        providers = select_providers()
+        provider_selections = select_models(providers)
+        selected_templates = select_templates(templates)
+
+        allow_overwrite: set[str] = set()
+        if selected_templates:
+            conflicts = check_conflicts(cwd, selected_templates)
+            for conflict in conflicts:
+                if confirm_overwrite(conflict):
+                    allow_overwrite.add(conflict)
+
+        config = InitConfig(providers=provider_selections, templates=selected_templates)
+        result = scaffold(cwd, config, allow_overwrite)
+
+        typer.echo("Initialized .fdsx/ directory.\n", err=True)
+        typer.echo("Created:", err=True)
+        for f in result.created:
+            typer.echo(f"  {f}", err=True)
+        if result.skipped_config:
+            typer.echo("  .fdsx/config.yaml (preserved)", err=True)
+        if result.skipped_workflows:
+            typer.echo("\nSkipped (already exist):", err=True)
+            for w in result.skipped_workflows:
+                typer.echo(f"  .fdsx/workflows/{w}", err=True)
+        typer.echo("\nNext steps:", err=True)
+        typer.echo(
+            "  1. Edit .fdsx/config.yaml to configure profiles and provider settings",
+            err=True,
+        )
+        typer.echo("  2. Customize workflows in .fdsx/workflows/", err=True)
+        typer.echo(
+            "  3. Run a workflow: fdsx run .fdsx/workflows/<name>/workflow.yaml",
+            err=True,
+        )
+    except KeyboardInterrupt:
+        raise typer.Exit(code=130) from None
 
 
 @app.command()

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -400,7 +400,7 @@ def compile_flow(
             graph.add_conditional_edges(
                 state_name,
                 _create_routing_function(state),
-                {choice.next: choice.next for choice in choices} | {default: default},  # type: ignore[arg-type]
+                {choice.next: choice.next for choice in choices} | {default: default},
             )
 
     graph.set_entry_point(flow.start_at)

--- a/src/fdsx/core/init.py
+++ b/src/fdsx/core/init.py
@@ -1,5 +1,11 @@
 import importlib.resources
+import os
 from pathlib import Path
+from typing import Any
+
+import yaml
+
+from fdsx.models.init import ProviderSelection, TemplateInfo
 
 GITIGNORE_TEMPLATE = """\
 # fdsx runtime directories
@@ -91,3 +97,97 @@ def scaffold(cwd: Path) -> list[str]:
 
     created_paths.append(str(config_path.relative_to(cwd)))
     return sorted(created_paths)
+
+
+def _resolve_xdg_templates_dir() -> Path:
+    """Resolve the XDG config templates directory for user templates.
+
+    Returns the path even if it does not exist, since discover_templates
+    handles non-existence gracefully.
+    """
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    config_dir = Path(xdg) if xdg else Path.home() / ".config"
+    return config_dir / "fdsx" / "templates" / "workflows"
+
+
+def discover_templates() -> list[TemplateInfo]:
+    """Discover available workflow templates.
+
+    Returns builtin templates first (from the fdsx.examples.workflows package),
+    followed by user templates from the XDG config directory.
+    """
+    templates: list[TemplateInfo] = []
+
+    examples_pkg = importlib.resources.files("fdsx.examples.workflows")
+    builtin_dirs: list[tuple[str, Any]] = []
+    for resource in examples_pkg.iterdir():
+        if resource.name in ("__init__.py", "__pycache__"):
+            continue
+        if not resource.is_dir():
+            continue
+        if (resource / "workflow.yaml").is_file():
+            builtin_dirs.append((resource.name, resource))
+
+    for name, resource in builtin_dirs:
+        with importlib.resources.as_file(resource) as template_dir:
+            templates.append(
+                TemplateInfo(
+                    name=name,
+                    path=template_dir,
+                    source="builtin",
+                )
+            )
+
+    user_templates_dir = _resolve_xdg_templates_dir()
+    if user_templates_dir.exists():
+        for subdir in user_templates_dir.iterdir():
+            if not subdir.is_dir():
+                continue
+            if (subdir / "workflow.yaml").exists():
+                templates.append(
+                    TemplateInfo(
+                        name=subdir.name,
+                        path=subdir,
+                        source="user",
+                    )
+                )
+
+    return templates
+
+
+_MAX_PERMISSION_OPTIONS: dict[str, dict[str, Any]] = {
+    "claude": {"dangerously_skip_permissions": True},
+    "codex": {"dangerously_bypass_approvals_and_sandbox": True},
+    "gemini": {"yolo": True},
+    "opencode": {"permission": "auto-edit"},
+}
+
+
+def generate_config_yaml(providers: list[ProviderSelection]) -> str:
+    """Generate a config.yaml string with profiles and max-permission provider options.
+
+    Args:
+        providers: List of provider selections (provider + model).
+
+    Returns:
+        YAML string suitable for writing to .fdsx/config.yaml.
+    """
+    profiles: dict[str, dict[str, str]] = {}
+    provider_configs: dict[str, dict[str, Any]] = {}
+
+    for selection in providers:
+        profile_name = f"default-{selection.provider}"
+        profiles[profile_name] = {
+            "provider": selection.provider,
+            "model": selection.model,
+        }
+        if selection.provider in _MAX_PERMISSION_OPTIONS:
+            provider_configs[selection.provider] = _MAX_PERMISSION_OPTIONS[
+                selection.provider
+            ]
+
+    config_dict: dict[str, Any] = {"profiles": profiles}
+    if provider_configs:
+        config_dict["providers"] = provider_configs
+
+    return yaml.dump(config_dict, default_flow_style=False)

--- a/src/fdsx/core/init.py
+++ b/src/fdsx/core/init.py
@@ -13,15 +13,24 @@ CONFIG_TEMPLATE = """\
 # workflows_dir: .fdsx/workflows  # Directory containing workflow definitions
 # auto_workflow: false  # Automatically select workflow when only one exists
 # profiles:
-#   smarty:  # Profile for planning and analysis tasks
+#   smarty:  # Profile for planning and analysis tasks (plan-implement-review)
 #     provider: claude
 #     model: claude-sonnet-4-7
-#   specialist:  # Profile for implementation tasks
+#   specialist:  # Profile for review tasks (plan-implement-review)
 #     provider: claude
 #     model: claude-sonnet-4-7
-#   doer:  # Profile for quick execution tasks
+#   doer:  # Profile for quick execution tasks (plan-implement-review)
 #     provider: opencode
 #     model: opencode
+#   planner:  # Profile for planning tasks (linear-basic, parallel-basic)
+#     provider: claude
+#     model: claude-sonnet-4-7
+#   coder:  # Profile for implementation tasks (linear-basic, parallel-basic)
+#     provider: claude
+#     model: claude-sonnet-4-7
+#   reviewer:  # Profile for review tasks (linear-basic, parallel-basic)
+#     provider: claude
+#     model: claude-sonnet-4-7
 # providers:  # Provider binary overrides (null uses defaults)
 #   claude: null
 #   codex: null

--- a/src/fdsx/core/init.py
+++ b/src/fdsx/core/init.py
@@ -1,11 +1,13 @@
 import importlib.resources
 import os
+import shutil
+import tempfile
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from fdsx.models.init import ProviderSelection, TemplateInfo
+from fdsx.models.init import InitConfig, ProviderSelection, ScaffoldResult, TemplateInfo
 
 GITIGNORE_TEMPLATE = """\
 # fdsx runtime directories
@@ -60,43 +62,154 @@ def ensure_gitignore(cwd: Path) -> None:
         gitignore_path.write_text(GITIGNORE_TEMPLATE)
 
 
-def scaffold(cwd: Path) -> list[str]:
+def check_conflicts(cwd: Path, templates: list[TemplateInfo]) -> list[str]:
+    """Return workflow names that already exist in .fdsx/workflows/."""
+    cwd = Path(cwd)
+    workflows_dir = cwd / ".fdsx" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+    existing_workflows = {d.name for d in workflows_dir.iterdir() if d.is_dir()}
+    return [t.name for t in templates if t.name in existing_workflows]
+
+
+def scaffold(
+    cwd: Path,
+    config: InitConfig,
+    allow_overwrite: set[str] | None = None,
+) -> ScaffoldResult:
+    """Scaffold .fdsx/ directory with selected templates and config.
+
+    Args:
+        cwd: Working directory to scaffold into.
+        config: InitConfig containing selected providers and templates.
+        allow_overwrite: Set of workflow names to overwrite if they already exist.
+
+    Returns:
+        ScaffoldResult with created files and skipped items info.
+    """
     cwd = Path(cwd)
     fdsx_dir = cwd / ".fdsx"
-    workflows_dir = fdsx_dir / "workflows"
+    allow_overwrite = allow_overwrite or set()
+    created: list[str] = []
+    skipped_workflows: list[str] = []
 
+    existing_fdsx = fdsx_dir.is_dir()
+    if existing_fdsx:
+        return _scaffold_existing(cwd, config, allow_overwrite)
+    else:
+        return _scaffold_fresh(cwd, config, allow_overwrite, created, skipped_workflows)
+
+
+def _scaffold_fresh(
+    cwd: Path,
+    config: InitConfig,
+    allow_overwrite: set[str],
+    created: list[str],
+    skipped_workflows: list[str],
+) -> ScaffoldResult:
+    """Scaffold fresh .fdsx/ directory using atomic temp dir + rename."""
+    fdsx_dir = cwd / ".fdsx"
+    tmp_dir: Path | None = None
+    try:
+        tmp_dir = Path(tempfile.mkdtemp(dir=str(cwd), prefix=".fdsx.tmp."))
+        tmp_workflows_dir = tmp_dir / "workflows"
+        tmp_workflows_dir.mkdir(parents=True)
+
+        config_yaml = generate_config_yaml(config.providers)
+        config_path = tmp_dir / "config.yaml"
+        config_path.write_text(config_yaml)
+
+        for template in config.templates:
+            workflow_dir = tmp_workflows_dir / template.name
+            workflow_dir.mkdir(parents=True, exist_ok=True)
+            for file_resource in template.path.iterdir():
+                if file_resource.name == "__init__.py":
+                    continue
+                if not file_resource.is_file():
+                    continue
+                content = file_resource.read_text()
+                dest_file = workflow_dir / file_resource.name
+                dest_file.write_text(content)
+                created.append(f".fdsx/workflows/{template.name}/{file_resource.name}")
+
+        gitignore_path = tmp_dir / ".gitignore"
+        gitignore_path.write_text(GITIGNORE_TEMPLATE)
+
+        Path.rename(tmp_dir, fdsx_dir)
+        tmp_dir = None
+
+        created.append(".fdsx/config.yaml")
+        return ScaffoldResult(
+            created=sorted(created),
+            skipped_config=False,
+            skipped_workflows=skipped_workflows,
+        )
+    finally:
+        if tmp_dir is not None and Path(tmp_dir).exists():
+            shutil.rmtree(tmp_dir)
+
+
+def _scaffold_existing(
+    cwd: Path,
+    config: InitConfig,
+    allow_overwrite: set[str],
+) -> ScaffoldResult:
+    """Scaffold into existing .fdsx/ directory (protected, non-atomic)."""
+    fdsx_dir = cwd / ".fdsx"
+    workflows_dir = fdsx_dir / "workflows"
     workflows_dir.mkdir(parents=True, exist_ok=True)
 
+    created: list[str] = []
+    skipped_config = False
+    skipped_workflows: list[str] = []
+
     config_path = fdsx_dir / "config.yaml"
-    config_path.write_text(CONFIG_TEMPLATE)
+    if config_path.exists():
+        skipped_config = True
+    else:
+        config_yaml = generate_config_yaml(config.providers)
+        config_path.write_text(config_yaml)
+        created.append(str(config_path.relative_to(cwd)))
 
-    ensure_gitignore(cwd)
+    gitignore_path = fdsx_dir / ".gitignore"
+    if not gitignore_path.exists():
+        gitignore_path.write_text(GITIGNORE_TEMPLATE)
 
-    examples_pkg = importlib.resources.files("fdsx.examples.workflows")
-    created_paths: list[str] = []
+    for template in config.templates:
+        dest_workflow_dir = workflows_dir / template.name
+        if dest_workflow_dir.exists():
+            if template.name in allow_overwrite:
+                shutil.rmtree(dest_workflow_dir)
+                _copy_template(template, dest_workflow_dir, cwd, created)
+            else:
+                skipped_workflows.append(template.name)
+        else:
+            _copy_template(template, dest_workflow_dir, cwd, created)
 
-    for resource in examples_pkg.iterdir():
-        if resource.name in ("__init__.py", "__pycache__"):
+    return ScaffoldResult(
+        created=sorted(created),
+        skipped_config=skipped_config,
+        skipped_workflows=skipped_workflows,
+    )
+
+
+def _copy_template(
+    template: TemplateInfo,
+    dest_workflow_dir: Path,
+    cwd: Path,
+    created: list[str],
+) -> None:
+    """Copy template files to destination workflow directory."""
+    dest_workflow_dir.mkdir(parents=True, exist_ok=True)
+    for file_resource in template.path.iterdir():
+        if file_resource.name == "__init__.py":
             continue
-        if not resource.is_dir():
+        if not file_resource.is_file():
             continue
-
-        workflow_name = resource.name
-        dest_workflow_dir = workflows_dir / workflow_name
-        dest_workflow_dir.mkdir(parents=True, exist_ok=True)
-
-        for file_resource in resource.iterdir():
-            if file_resource.name == "__init__.py":
-                continue
-            if not file_resource.is_file():
-                continue
-            content = file_resource.read_text()
-            dest_file = dest_workflow_dir / file_resource.name
-            dest_file.write_text(content)
-            created_paths.append(str(dest_file.relative_to(cwd)))
-
-    created_paths.append(str(config_path.relative_to(cwd)))
-    return sorted(created_paths)
+        content = file_resource.read_text()
+        dest_file = dest_workflow_dir / file_resource.name
+        dest_file.write_text(content)
+        created.append(str(dest_file.relative_to(cwd)))
 
 
 def _resolve_xdg_templates_dir() -> Path:

--- a/src/fdsx/examples/workflows/linear-basic/implement-prompt.txt
+++ b/src/fdsx/examples/workflows/linear-basic/implement-prompt.txt
@@ -1,0 +1,5 @@
+You are an implementation agent. Follow this plan exactly and write the code.
+Output ALL files with their full paths and content.
+
+Plan:
+{plan}

--- a/src/fdsx/examples/workflows/linear-basic/plan-prompt.txt
+++ b/src/fdsx/examples/workflows/linear-basic/plan-prompt.txt
@@ -1,0 +1,5 @@
+You are a planning agent. Break down the following task into clear,
+actionable implementation steps. Be specific about which files to
+create, what functions to implement, and what types to define.
+
+Task: {task}

--- a/src/fdsx/examples/workflows/linear-basic/review-prompt.txt
+++ b/src/fdsx/examples/workflows/linear-basic/review-prompt.txt
@@ -1,0 +1,11 @@
+You are a code review agent. Evaluate the implementation for correctness,
+completeness, and adherence to the plan.
+
+Plan:
+{plan}
+
+Implementation:
+{implementation}
+
+Provide a thorough review and end with:
+APPROVED or REJECTED: <reason>

--- a/src/fdsx/examples/workflows/linear-basic/workflow.yaml
+++ b/src/fdsx/examples/workflows/linear-basic/workflow.yaml
@@ -1,0 +1,38 @@
+name: Linear Basic
+description: >
+  Simple 3-step linear workflow: Plan -> Implement -> Review.
+  Uses profile-based provider references for provider-agnostic execution.
+version: "1.0"
+start_at: plan
+
+states:
+  plan:
+    type: task
+    profile: planner
+    prompt_file: plan-prompt.txt
+    result_path: $.plan
+    timeout_seconds: 120
+    retry: 2
+    next: implement
+
+  implement:
+    type: task
+    profile: coder
+    prompt_file: implement-prompt.txt
+    result_path: $.implementation
+    timeout_seconds: 300
+    retry: 2
+    next: review
+
+  review:
+    type: task
+    profile: reviewer
+    prompt_file: review-prompt.txt
+    result_path: $.review
+    timeout_seconds: 180
+    retry: 2
+    next: done
+
+  done:
+    type: pass
+    end: true

--- a/src/fdsx/examples/workflows/parallel-basic/plan-prompt.txt
+++ b/src/fdsx/examples/workflows/parallel-basic/plan-prompt.txt
@@ -1,0 +1,8 @@
+You are a planning agent. Break down the following task into clear,
+actionable implementation steps. Be specific about which files to
+create, what functions to implement, and what types to define.
+
+Task: {task}
+
+Also output a brief description of the expected implementation
+(Implementation:) that the parallel reviewers can use.

--- a/src/fdsx/examples/workflows/parallel-basic/workflow.yaml
+++ b/src/fdsx/examples/workflows/parallel-basic/workflow.yaml
@@ -1,0 +1,76 @@
+name: Parallel Basic
+description: >
+  Parallel workflow: Plan -> Implement -> Parallel Review (2 branches) -> Done.
+  Demonstrates parallel execution with profile-based provider references.
+version: "1.0"
+start_at: plan
+
+states:
+  plan:
+    type: task
+    profile: planner
+    prompt_file: plan-prompt.txt
+    result_path: $.plan
+    timeout_seconds: 120
+    retry: 2
+    next: implement
+
+  implement:
+    type: task
+    profile: coder
+    prompt_template: |
+      You are an implementation agent. Follow this plan exactly and write the code.
+      Output ALL files with their full paths and content.
+
+      Plan:
+      {plan}
+    result_path: $.implementation
+    timeout_seconds: 300
+    retry: 2
+    next: parallel_review
+
+  parallel_review:
+    type: parallel
+    branches:
+      - profile: reviewer
+        prompt_template: |
+          You are a code quality review agent focused on correctness,
+          best practices, and completeness.
+
+          Plan:
+          {plan}
+
+          Implementation:
+          {implementation}
+
+          End with APPROVED or REJECTED: <reason>
+        extract:
+          strategy: [keyword, regex]
+          pattern: "APPROVED|REJECTED"
+          result_path: $.code_quality_decision
+        timeout_seconds: 180
+        retry: 2
+
+      - profile: reviewer
+        prompt_template: |
+          You are a security review agent. Check for input validation,
+          injection risks, XSS, error handling leaks, and auth concerns.
+
+          Implementation:
+          {implementation}
+
+          End with APPROVED or REJECTED: <reason>
+        extract:
+          strategy: [keyword, regex]
+          pattern: "APPROVED|REJECTED"
+          result_path: $.security_decision
+        timeout_seconds: 180
+        retry: 2
+
+    result_path: $.reviews
+    min_success: 2
+    next: done
+
+  done:
+    type: pass
+    end: true

--- a/src/fdsx/models/init.py
+++ b/src/fdsx/models/init.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from fdsx.models.validators import validate_llm_provider
+
+
+class TemplateInfo(BaseModel):
+    """Template information for init discovery."""
+
+    name: str = Field(..., description="Template name, e.g. 'linear-basic'")
+    path: Path = Field(..., description="Absolute path to template directory")
+    source: Literal["builtin", "user"] = Field(
+        ..., description="Origin of the template"
+    )
+
+
+class ProviderSelection(BaseModel):
+    """Provider and model selected during init."""
+
+    provider: str = Field(..., description="LLM provider name")
+    model: str = Field(..., description="Model name")
+
+    @model_validator(mode="after")
+    def validate_provider(self) -> "ProviderSelection":
+        validate_llm_provider(self.provider, "ProviderSelection")
+        return self
+
+
+class InitConfig(BaseModel):
+    """Configuration produced during init."""
+
+    providers: list[ProviderSelection] = Field(
+        ..., min_length=1, description="Selected providers and models"
+    )
+    templates: list[TemplateInfo] = Field(
+        default_factory=list, description="Available templates"
+    )

--- a/src/fdsx/models/init.py
+++ b/src/fdsx/models/init.py
@@ -37,3 +37,18 @@ class InitConfig(BaseModel):
     templates: list[TemplateInfo] = Field(
         default_factory=list, description="Available templates"
     )
+
+
+class ScaffoldResult(BaseModel):
+    """Result from scaffold() operation."""
+
+    created: list[str] = Field(
+        default_factory=list, description="Relative paths of created files"
+    )
+    skipped_config: bool = Field(
+        default=False, description="True if config.yaml was skipped (already existed)"
+    )
+    skipped_workflows: list[str] = Field(
+        default_factory=list,
+        description="Workflow names that were skipped (conflicted)",
+    )

--- a/tests/e2e/cli_test_utils.py
+++ b/tests/e2e/cli_test_utils.py
@@ -32,6 +32,7 @@ def run_fdsx(
         )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
+        Path(tmp_dir, ".fdsx").mkdir()
         return subprocess.run(
             command,
             cwd=tmp_dir,

--- a/tests/e2e/test_auto_init.py
+++ b/tests/e2e/test_auto_init.py
@@ -14,25 +14,12 @@ class TestAutoInit:
             assert result.stdout == ""
 
             fdsx_dir = tmp_path / ".fdsx"
-            assert fdsx_dir.is_dir()
+            assert not fdsx_dir.exists()
 
-            config_path = fdsx_dir / "config.yaml"
-            assert config_path.is_file()
-
-            workflows_dir = fdsx_dir / "workflows"
-            assert workflows_dir.is_dir()
-
-            workflow_dir = workflows_dir / "plan-implement-review"
-            assert workflow_dir.is_dir()
-            assert (workflow_dir / "workflow.yaml").is_file()
-            assert (workflow_dir / "plan-prompt.txt").is_file()
-            assert (workflow_dir / "implement-prompt.txt").is_file()
-
-            stderr = result.stderr
-            assert "Initialized .fdsx/" in stderr
-            assert "Created:" in stderr
-            assert "Next steps:" in stderr
-            assert "config.yaml" in stderr
+            assert "No .fdsx/ directory found" in result.stderr
+            assert "Run 'fdsx init'" in result.stderr
+            assert "Initialized .fdsx/" not in result.stderr
+            assert "Created:" not in result.stderr
 
     def test_noop_when_fdsx_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -55,6 +42,7 @@ class TestAutoInit:
             assert not (tmp_path / ".fdsx").exists()
 
             assert "Initialized .fdsx/" not in result.stderr
+            assert "No .fdsx/ directory found" in result.stderr
+            assert "Run 'fdsx init'" in result.stderr
 
-            assert result.returncode == 2
-            assert "Error: workflow argument is required" in result.stderr
+            assert result.returncode == 0

--- a/tests/e2e/test_batch_edge_cases.py
+++ b/tests/e2e/test_batch_edge_cases.py
@@ -15,6 +15,7 @@ class TestEdgeCases:
 
     def test_empty_tasks_dir_error_via_cli(self, tmp_path):
         """Empty tasks directory should produce a clear error via CLI."""
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
 
@@ -98,6 +99,7 @@ class TestEdgeCases:
 
     def test_mix_valid_and_invalid_yaml_files(self, tmp_path):
         """Mix of valid and invalid YAML files should error clearly."""
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
 

--- a/tests/e2e/test_batch_error_messages.py
+++ b/tests/e2e/test_batch_error_messages.py
@@ -13,6 +13,7 @@ class TestErrorMessages:
 
     def test_invalid_yaml_task_file_via_cli(self, tmp_path):
         """Invalid YAML in task file should produce a clear error via CLI."""
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         (tasks_dir / "001-bad.yaml").write_text(": [broken yaml\n")

--- a/tests/e2e/test_batch_full_pipeline.py
+++ b/tests/e2e/test_batch_full_pipeline.py
@@ -365,8 +365,9 @@ class TestFullPipelineE2E:
 class TestHelpText:
     """Verify help text is descriptive (T41/T27)."""
 
-    def test_run_command_help_includes_batch_modes(self):
+    def test_run_command_help_includes_batch_modes(self, tmp_path):
         """Verify run command help mentions batch and tasks-dir modes."""
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["run", "--help"])
 
@@ -374,8 +375,9 @@ class TestHelpText:
         assert "in-memory batch" in result.stdout
         assert "persistent batch" in result.stdout
 
-    def test_tasks_option_help_is_descriptive(self):
+    def test_tasks_option_help_is_descriptive(self, tmp_path):
         """Verify --tasks option help is descriptive."""
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["run", "--help"])
 
@@ -383,8 +385,9 @@ class TestHelpText:
         assert "in-memory splitting and" in result.stdout
         assert "execution" in result.stdout
 
-    def test_tasks_dir_option_help_mentions_resume(self):
+    def test_tasks_dir_option_help_mentions_resume(self, tmp_path):
         """Verify --tasks-dir option help mentions resume capability."""
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["run", "--help"])
 
@@ -392,8 +395,9 @@ class TestHelpText:
         assert "persistent" in result.stdout
         assert "resume support" in result.stdout
 
-    def test_run_help_mentions_spinner_and_cui(self):
+    def test_run_help_mentions_spinner_and_cui(self, tmp_path):
         """Verify run command help mentions spinner, CUI, and non-TTY behavior (T027)."""
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["run", "--help"])
 
@@ -405,8 +409,9 @@ class TestHelpText:
             or "noninteractive" in result.stdout.lower()
         )
 
-    def test_run_help_mentions_auto_workflow_and_cui(self):
+    def test_run_help_mentions_auto_workflow_and_cui(self, tmp_path):
         """Verify --auto-workflow and --confirm-workflow mention CUI behavior (T027)."""
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["run", "--help"])
 
@@ -415,8 +420,9 @@ class TestHelpText:
         assert "skip" in help_lower and "confirmation" in help_lower
         assert "interactive" in help_lower or "workflow" in help_lower
 
-    def test_split_help_mentions_spinner(self):
+    def test_split_help_mentions_spinner(self, tmp_path):
         """Verify split command help mentions spinner and non-TTY fallback (T027)."""
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["split", "--help"])
 
@@ -436,6 +442,7 @@ class TestSecuritySanitization:
         to the terminal.  A crafted .yaml filename with embedded escape bytes was the
         reported attack vector (security finding - unsanitized validation errors).
         """
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         # Create a YAML file with broken content so load_tasks_dir raises FlowValidationError

--- a/tests/e2e/test_cli_batch_tasks.py
+++ b/tests/e2e/test_cli_batch_tasks.py
@@ -75,6 +75,7 @@ class TestBatchCLIE2E:
     def test_batch_missing_description(self):
         """Test --tasks with flow missing description → exit code 2 with actionable error."""
         with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / ".fdsx").mkdir()
             flow_path = Path(tmpdir) / "no_description_flow.yaml"
             flow_path.write_text(
                 "name: No Description Flow\n"

--- a/tests/e2e/test_cli_signal_handling.py
+++ b/tests/e2e/test_cli_signal_handling.py
@@ -122,6 +122,8 @@ def _run_fdsx_and_signal(
     flow_path = tmp_path / "sleep_flow.yaml"
     flow_path.write_text(_SLEEP_FLOW_YAML)
 
+    (tmp_path / ".fdsx").mkdir(exist_ok=True)
+
     proc = subprocess.Popen(
         [_fdsx_bin(), "run", str(flow_path), "--thread-id", _THREAD_ID],
         cwd=str(tmp_path),

--- a/tests/e2e/test_cli_thread_id.py
+++ b/tests/e2e/test_cli_thread_id.py
@@ -18,6 +18,7 @@ def run_fdsx_run(cwd: str | Path) -> subprocess.CompletedProcess[str]:
         "run",
         fixture_path("simple_flow.yaml"),
     ]
+    Path(cwd, ".fdsx").mkdir(exist_ok=True)
     return subprocess.run(
         command,
         cwd=cwd,

--- a/tests/e2e/test_cli_wait_and_resume.py
+++ b/tests/e2e/test_cli_wait_and_resume.py
@@ -23,9 +23,11 @@ class TestCLIE2EPhase3:
     def test_resume_interrupted_flow(self):
         """Test fdsx resume --thread-id with previously interrupted flow."""
         with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            (tmp_path / ".fdsx").mkdir()
             flow_path = fixture_path("wait_approval.yaml")
             thread_id = "test-resume-interrupted"
-            base_dir = str(Path(tmp_dir) / ".fdsx")
+            base_dir = str(tmp_path / ".fdsx")
 
             first_run = run_fdsx(
                 ["run", flow_path, "--thread-id", thread_id],
@@ -79,7 +81,9 @@ class TestCLIE2EPhase3:
     def test_list_shows_threads(self):
         """Test fdsx list shows table output with known thread."""
         with tempfile.TemporaryDirectory() as tmp_dir:
-            base_dir = Path(tmp_dir) / ".fdsx"
+            tmp_path = Path(tmp_dir)
+            (tmp_path / ".fdsx").mkdir()
+            base_dir = tmp_path / ".fdsx"
             thread_id = "test-list-thread"
             flow_path = fixture_path("simple_flow.yaml")
 
@@ -115,7 +119,9 @@ class TestCLIE2EPhase3:
     def test_list_empty(self):
         """Test fdsx list with no threads shows empty message."""
         with tempfile.TemporaryDirectory() as tmp_dir:
-            base_dir = Path(tmp_dir) / ".fdsx"
+            tmp_path = Path(tmp_dir)
+            (tmp_path / ".fdsx").mkdir()
+            base_dir = tmp_path / ".fdsx"
 
             result = run_fdsx(
                 [
@@ -162,7 +168,9 @@ class TestCLIE2EPhase3:
     def test_prompt_file_missing_fails(self):
         """Test fdsx run with missing prompt_file fails with exit code 2 and clear error."""
         with tempfile.TemporaryDirectory() as tmp_dir:
-            flow_path = Path(tmp_dir) / "flow.yaml"
+            tmp_path = Path(tmp_dir)
+            (tmp_path / ".fdsx").mkdir()
+            flow_path = tmp_path / "flow.yaml"
             flow_path.write_text(
                 "name: Missing Prompt File Test\n"
                 "description: Test missing prompt file\n"

--- a/tests/integration/test_auto_init.py
+++ b/tests/integration/test_auto_init.py
@@ -61,6 +61,12 @@ class TestAutoInit:
         assert result == sorted(result)
         expected = [
             ".fdsx/config.yaml",
+            ".fdsx/workflows/linear-basic/implement-prompt.txt",
+            ".fdsx/workflows/linear-basic/plan-prompt.txt",
+            ".fdsx/workflows/linear-basic/review-prompt.txt",
+            ".fdsx/workflows/linear-basic/workflow.yaml",
+            ".fdsx/workflows/parallel-basic/plan-prompt.txt",
+            ".fdsx/workflows/parallel-basic/workflow.yaml",
             ".fdsx/workflows/plan-implement-review/implement-prompt.txt",
             ".fdsx/workflows/plan-implement-review/plan-prompt.txt",
             ".fdsx/workflows/plan-implement-review/workflow.yaml",

--- a/tests/integration/test_auto_init.py
+++ b/tests/integration/test_auto_init.py
@@ -3,7 +3,14 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from fdsx.core.init import CONFIG_TEMPLATE, needs_init, scaffold
+from fdsx.core.init import (
+    check_conflicts,
+    discover_templates,
+    generate_config_yaml,
+    needs_init,
+    scaffold,
+)
+from fdsx.models.init import InitConfig, ProviderSelection
 
 
 class TestAutoInit:
@@ -21,32 +28,21 @@ class TestAutoInit:
         result = needs_init(tmp_path)
         assert result is False
 
-    def test_config_template_valid_yaml(self):
-        lines = CONFIG_TEMPLATE.splitlines()
-        uncommented = []
-        for line in lines:
-            if line.startswith("# "):
-                uncommented.append(line[2:])
-            elif line == "#":
-                uncommented.append("")
-            else:
-                uncommented.append(line)
-        uncommented_yaml = "\n".join(uncommented)
-        parsed = yaml.safe_load(uncommented_yaml)
+    def test_generate_config_yaml_valid(self):
+        providers = [ProviderSelection(provider="claude", model="claude-sonnet-4-7")]
+        config_yaml = generate_config_yaml(providers)
+        parsed = yaml.safe_load(config_yaml)
         assert isinstance(parsed, dict)
-        expected_keys = {
-            "workflows_dir",
-            "auto_workflow",
-            "profiles",
-            "providers",
-            "task_splitter",
-            "workflow_selector",
-            "hooks",
-        }
-        assert expected_keys.issubset(parsed.keys())
+        assert "profiles" in parsed
+        assert "providers" in parsed
 
     def test_scaffold_creates_complete_structure(self, tmp_path):
-        scaffold(tmp_path)
+        templates = discover_templates()
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=templates,
+        )
+        scaffold(tmp_path, config)
         expected = [
             ".fdsx/config.yaml",
             ".fdsx/workflows/plan-implement-review/implement-prompt.txt",
@@ -57,8 +53,13 @@ class TestAutoInit:
             assert (tmp_path / path).exists(), f"Missing: {path}"
 
     def test_scaffold_returns_sorted_file_list(self, tmp_path):
-        result = scaffold(tmp_path)
-        assert result == sorted(result)
+        templates = discover_templates()
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=templates,
+        )
+        result = scaffold(tmp_path, config)
+        assert result.created == sorted(result.created)
         expected = [
             ".fdsx/config.yaml",
             ".fdsx/workflows/linear-basic/implement-prompt.txt",
@@ -71,14 +72,116 @@ class TestAutoInit:
             ".fdsx/workflows/plan-implement-review/plan-prompt.txt",
             ".fdsx/workflows/plan-implement-review/workflow.yaml",
         ]
-        assert result == expected
+        assert result.created == expected
 
     def test_scaffold_permission_error(self, tmp_path):
+        templates = discover_templates()
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=templates,
+        )
         with (
-            patch("os.makedirs", side_effect=PermissionError("mocked")),
-            patch("pathlib.Path.mkdir", side_effect=PermissionError("mocked")),
-            patch("builtins.open", side_effect=PermissionError("mocked")),
-            patch("importlib.resources.files"),
+            patch("os.rename", side_effect=PermissionError("mocked")),
+            patch("tempfile.mkdtemp", side_effect=PermissionError("mocked")),
             pytest.raises(PermissionError),
         ):
-            scaffold(tmp_path)
+            scaffold(tmp_path, config)
+
+    def test_fresh_scaffold_cleans_up_temp_dir_on_failure(self, tmp_path):
+        """If scaffold fails mid-creation, no partial temp dir remains."""
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=discover_templates(),
+        )
+        with (
+            patch(
+                "fdsx.core.init.Path.rename",
+                side_effect=OSError("mocked rename failure"),
+            ),
+            pytest.raises(OSError),
+        ):
+            scaffold(tmp_path, config)
+
+        # No .fdsx or .fdsx.tmp.* directories should remain
+        assert not (tmp_path / ".fdsx").exists()
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".fdsx.tmp.")]
+        assert leftover == []
+
+
+class TestCheckConflicts:
+    def test_no_conflicts_when_no_fdsx_dir(self, tmp_path):
+        templates = discover_templates()
+        conflicts = check_conflicts(tmp_path, templates)
+        assert conflicts == []
+
+    def test_no_conflicts_when_no_matching_workflows(self, tmp_path):
+        (tmp_path / ".fdsx" / "workflows").mkdir(parents=True)
+        templates = discover_templates()
+        conflicts = check_conflicts(tmp_path, templates)
+        assert conflicts == []
+
+    def test_detects_existing_workflow_conflict(self, tmp_path):
+        workflows_dir = tmp_path / ".fdsx" / "workflows" / "linear-basic"
+        workflows_dir.mkdir(parents=True)
+        templates = discover_templates()
+        conflicts = check_conflicts(tmp_path, templates)
+        assert "linear-basic" in conflicts
+
+
+class TestScaffoldExistingProtection:
+    def _make_config(self):
+        return InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=discover_templates(),
+        )
+
+    def test_skips_config_yaml_when_present(self, tmp_path):
+        """scaffold() into existing .fdsx/ skips config.yaml if already present."""
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_path = fdsx_dir / "config.yaml"
+        config_path.write_text("original: true\n")
+
+        result = scaffold(tmp_path, self._make_config())
+
+        assert result.skipped_config is True
+        assert config_path.read_text() == "original: true\n"
+        assert ".fdsx/config.yaml" not in result.created
+
+    def test_creates_config_yaml_when_missing_in_existing(self, tmp_path):
+        """scaffold() into existing .fdsx/ creates config.yaml if not present."""
+        (tmp_path / ".fdsx").mkdir()
+
+        result = scaffold(tmp_path, self._make_config())
+
+        assert result.skipped_config is False
+        assert (tmp_path / ".fdsx" / "config.yaml").exists()
+        assert ".fdsx/config.yaml" in result.created
+
+    def test_skipped_workflows_lists_conflicts(self, tmp_path):
+        """scaffold() reports conflicting workflows in skipped_workflows."""
+        fdsx_dir = tmp_path / ".fdsx"
+        workflows_dir = fdsx_dir / "workflows" / "linear-basic"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "workflow.yaml").write_text("existing: true\n")
+
+        result = scaffold(tmp_path, self._make_config())
+
+        assert "linear-basic" in result.skipped_workflows
+        # Original file preserved
+        assert (workflows_dir / "workflow.yaml").read_text() == "existing: true\n"
+
+    def test_allow_overwrite_replaces_approved_workflow(self, tmp_path):
+        """scaffold() with allow_overwrite overwrites approved conflicting workflows."""
+        fdsx_dir = tmp_path / ".fdsx"
+        workflows_dir = fdsx_dir / "workflows" / "linear-basic"
+        workflows_dir.mkdir(parents=True)
+        (workflows_dir / "workflow.yaml").write_text("old: true\n")
+
+        result = scaffold(
+            tmp_path, self._make_config(), allow_overwrite={"linear-basic"}
+        )
+
+        assert "linear-basic" not in result.skipped_workflows
+        content = (workflows_dir / "workflow.yaml").read_text()
+        assert content != "old: true\n"  # overwritten with template content

--- a/tests/integration/test_auto_init_cli.py
+++ b/tests/integration/test_auto_init_cli.py
@@ -13,8 +13,6 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from fdsx.cli import main
-from fdsx.models.init import ScaffoldResult
-from fdsx.providers.base import ProviderResult
 
 
 class TestCiInteractiveFlags:
@@ -68,22 +66,12 @@ class TestInitGuard:
     """T019-T022: Init guard tests for operational subcommands."""
 
     def test_init_triggers_on_run_without_fdsx(self, tmp_path, monkeypatch):
-        """Init triggers when running 'run' without .fdsx/ directory."""
+        """Guide message shown when running 'run' without .fdsx/ directory."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_result = ScaffoldResult(
-            created=[".fdsx/config.yaml", ".fdsx/workflows/example/main.yaml"],
-            skipped_config=False,
-            skipped_workflows=[],
-        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_result),
-            patch(
-                "fdsx.providers.claude._run_subprocess",
-                return_value=ProviderResult(exit_code=0, stdout="", stderr=""),
-            ),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "run", "dummy.yaml"], catch_exceptions=False
@@ -92,22 +80,16 @@ class TestInitGuard:
         assert result.exit_code == 0, (
             f"Expected exit 0, got {result.exit_code}. output: {result.output}"
         )
-        assert "Initialized .fdsx/" in result.output
-        assert ".fdsx/config.yaml" in result.output
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
     def test_init_triggers_on_validate_without_fdsx(self, tmp_path, monkeypatch):
-        """Init triggers when running 'validate' without .fdsx/ directory."""
+        """Guide message shown when running 'validate' without .fdsx/ directory."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_result = ScaffoldResult(
-            created=[".fdsx/config.yaml"],
-            skipped_config=False,
-            skipped_workflows=[],
-        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app,
@@ -118,21 +100,16 @@ class TestInitGuard:
         assert result.exit_code == 0, (
             f"Expected exit 0, got {result.exit_code}. output: {result.output}"
         )
-        assert "Initialized .fdsx/" in result.output
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
     def test_init_triggers_on_list_without_fdsx(self, tmp_path, monkeypatch):
-        """Init triggers when running 'list' without .fdsx/ directory."""
+        """Guide message shown when running 'list' without .fdsx/ directory."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_result = ScaffoldResult(
-            created=[".fdsx/config.yaml"],
-            skipped_config=False,
-            skipped_workflows=[],
-        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "list"], catch_exceptions=False
@@ -141,8 +118,8 @@ class TestInitGuard:
         assert result.exit_code == 0, (
             f"Expected exit 0, got {result.exit_code}. output: {result.output}"
         )
-        assert "Initialized .fdsx/" in result.output
-        assert ".fdsx/config.yaml" in result.output
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
     def test_init_skipped_when_fdsx_exists(self, tmp_path, monkeypatch):
         """Init is skipped when .fdsx/ directory already exists."""
@@ -198,20 +175,14 @@ class TestInitGuard:
 
         mock_scaffold.assert_not_called()
 
-    def test_interactive_flag_forces_init_in_non_tty(self, tmp_path, monkeypatch):
-        """--interactive forces init even in non-TTY environment."""
+    def test_interactive_flag_shows_guide_in_non_tty(self, tmp_path, monkeypatch):
+        """--interactive shows guide message even in non-TTY environment."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
         runner = CliRunner()
 
-        fake_result = ScaffoldResult(
-            created=[".fdsx/config.yaml"],
-            skipped_config=False,
-            skipped_workflows=[],
-        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "run", "dummy.yaml"], catch_exceptions=False
@@ -220,38 +191,21 @@ class TestInitGuard:
         assert result.exit_code == 0, (
             f"Expected exit 0, got {result.exit_code}. output: {result.output}"
         )
-        assert "Initialized .fdsx/" in result.output
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
-    def test_stderr_output_format(self, tmp_path, monkeypatch):
-        """Init guard stderr output contains header, file list, and next steps sections."""
+    def test_guide_message_format(self, tmp_path, monkeypatch):
+        """Guide message is displayed correctly when .fdsx/ is missing."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_created = [
-            ".fdsx/config.yaml",
-            ".fdsx/workflows/example/main.yaml",
-            ".fdsx/workflows/review/main.yaml",
-        ]
-        fake_result = ScaffoldResult(
-            created=fake_created,
-            skipped_config=False,
-            skipped_workflows=[],
-        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "run", "dummy.yaml"], catch_exceptions=False
             )
 
         assert result.exit_code == 0
-
-        assert "Initialized .fdsx/" in result.output
-        assert "Created:" in result.output
-        for f in fake_created:
-            assert f"  {f}" in result.output
-        assert "Next steps:" in result.output
-        assert "1. Edit .fdsx/config.yaml" in result.output
-        assert "2. Customize workflows in .fdsx/workflows/" in result.output
-        assert "3. Re-run your command: fdsx run" in result.output
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init' to set up your project" in result.output

--- a/tests/integration/test_auto_init_cli.py
+++ b/tests/integration/test_auto_init_cli.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from fdsx.cli import main
+from fdsx.models.init import ScaffoldResult
 from fdsx.providers.base import ProviderResult
 
 
@@ -71,10 +72,14 @@ class TestInitGuard:
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_created = [".fdsx/config.yaml", ".fdsx/workflows/example/main.yaml"]
+        fake_result = ScaffoldResult(
+            created=[".fdsx/config.yaml", ".fdsx/workflows/example/main.yaml"],
+            skipped_config=False,
+            skipped_workflows=[],
+        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_created),
+            patch("fdsx.cli.main.scaffold", return_value=fake_result),
             patch(
                 "fdsx.providers.claude._run_subprocess",
                 return_value=ProviderResult(exit_code=0, stdout="", stderr=""),
@@ -95,10 +100,14 @@ class TestInitGuard:
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_created = [".fdsx/config.yaml"]
+        fake_result = ScaffoldResult(
+            created=[".fdsx/config.yaml"],
+            skipped_config=False,
+            skipped_workflows=[],
+        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_created),
+            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app,
@@ -116,10 +125,14 @@ class TestInitGuard:
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
 
-        fake_created = [".fdsx/config.yaml"]
+        fake_result = ScaffoldResult(
+            created=[".fdsx/config.yaml"],
+            skipped_config=False,
+            skipped_workflows=[],
+        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_created),
+            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "list"], catch_exceptions=False
@@ -191,10 +204,14 @@ class TestInitGuard:
         monkeypatch.setattr("sys.stdin.isatty", lambda: False)
         runner = CliRunner()
 
-        fake_created = [".fdsx/config.yaml"]
+        fake_result = ScaffoldResult(
+            created=[".fdsx/config.yaml"],
+            skipped_config=False,
+            skipped_workflows=[],
+        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_created),
+            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "run", "dummy.yaml"], catch_exceptions=False
@@ -215,9 +232,14 @@ class TestInitGuard:
             ".fdsx/workflows/example/main.yaml",
             ".fdsx/workflows/review/main.yaml",
         ]
+        fake_result = ScaffoldResult(
+            created=fake_created,
+            skipped_config=False,
+            skipped_workflows=[],
+        )
         with (
             patch("fdsx.cli.main.needs_init", return_value=True),
-            patch("fdsx.cli.main.scaffold", return_value=fake_created),
+            patch("fdsx.cli.main.scaffold", return_value=fake_result),
         ):
             result = runner.invoke(
                 main.app, ["--interactive", "run", "dummy.yaml"], catch_exceptions=False

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -1,0 +1,307 @@
+"""Integration tests for the init module (src/fdsx/core/init.py).
+
+Covers template discovery, config.yaml content validation, selective template
+copying, and atomic generation (interrupt safety).  Does not duplicate coverage
+already in tests/integration/test_auto_init.py or
+tests/integration/test_scaffold_gitignore.py.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from fdsx.core.init import (
+    _resolve_xdg_templates_dir,
+    discover_templates,
+    generate_config_yaml,
+    scaffold,
+)
+from fdsx.models.init import InitConfig, ProviderSelection
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _known_builtin_template_names() -> set[str]:
+    return {"linear-basic", "parallel-basic", "plan-implement-review"}
+
+
+# ---------------------------------------------------------------------------
+# TestDiscoverTemplates
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverTemplates:
+    def test_returns_builtin_templates(self):
+        """discover_templates() returns known builtins with source='builtin'."""
+        templates = discover_templates()
+        builtin_names = {t.name for t in templates if t.source == "builtin"}
+        assert builtin_names == _known_builtin_template_names()
+
+    def test_builtin_templates_have_workflow_yaml(self):
+        """Each builtin template has a workflow.yaml file at its path."""
+        templates = discover_templates()
+        for t in templates:
+            if t.source == "builtin":
+                assert (t.path / "workflow.yaml").is_file(), (
+                    f"Builtin template {t.name!r} is missing workflow.yaml"
+                )
+
+    def test_discovers_user_templates_from_xdg_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """User template dir set via XDG_CONFIG_HOME is scanned with source='user'."""
+        xdg_templates = tmp_path / "user_templates" / "fdsx" / "templates" / "workflows"
+        xdg_templates.mkdir(parents=True)
+        (xdg_templates / "my-workflow").mkdir()
+        (xdg_templates / "my-workflow" / "workflow.yaml").write_text(
+            "name: my-workflow\n"
+        )
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "fdsx.core.init._resolve_xdg_templates_dir",
+            lambda: xdg_templates,
+        )
+
+        templates = discover_templates()
+        user_names = {t.name for t in templates if t.source == "user"}
+        assert "my-workflow" in user_names
+
+    def test_ignores_non_template_dirs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Subdirectories without workflow.yaml are skipped."""
+        user_templates_root = tmp_path / "user_templates"
+        user_templates_root.mkdir()
+        (user_templates_root / "not-a-template").mkdir()
+        (user_templates_root / "also-invalid").mkdir()
+        (user_templates_root / "also-invalid" / "README.txt").write_text("doc")
+
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            "fdsx.core.init._resolve_xdg_templates_dir",
+            lambda: user_templates_root,
+        )
+
+        templates = discover_templates()
+        user_names = {t.name for t in templates if t.source == "user"}
+        assert "not-a-template" not in user_names
+        assert "also-invalid" not in user_names
+
+    def test_no_user_templates_when_dir_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """When XDG dir does not exist, only builtin templates are returned."""
+        nonexistent = tmp_path / "does_not_exist"
+        monkeypatch.setattr(
+            "fdsx.core.init._resolve_xdg_templates_dir",
+            lambda: nonexistent,
+        )
+
+        templates = discover_templates()
+        assert all(t.source == "builtin" for t in templates)
+
+    def test_resolves_xdg_config_home(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """_resolve_xdg_templates_dir respects XDG_CONFIG_HOME."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        result = _resolve_xdg_templates_dir()
+        expected = tmp_path / "fdsx" / "templates" / "workflows"
+        assert result == expected
+
+    def test_resolves_default_xdg_when_unset(self, monkeypatch: pytest.MonkeyPatch):
+        """When XDG_CONFIG_HOME is unset, defaults to ~/.config/fdsx/templates/workflows."""
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        result = _resolve_xdg_templates_dir()
+        expected = Path.home() / ".config" / "fdsx" / "templates" / "workflows"
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# TestConfigYamlContent
+# ---------------------------------------------------------------------------
+
+
+class TestConfigYamlContent:
+    def test_single_provider_profiles_and_options(self):
+        """claude-only config: correct profile name, model, and dangerously_skip_permissions."""
+        providers = [ProviderSelection(provider="claude", model="claude-sonnet-4-7")]
+        config_yaml = generate_config_yaml(providers)
+        parsed = yaml.safe_load(config_yaml)
+
+        assert parsed["profiles"] == {
+            "default-claude": {
+                "provider": "claude",
+                "model": "claude-sonnet-4-7",
+            }
+        }
+        assert parsed["providers"]["claude"]["dangerously_skip_permissions"] is True
+
+    def test_multiple_providers_all_profiles(self):
+        """claude + codex: both profiles present and both providers sections."""
+        providers = [
+            ProviderSelection(provider="claude", model="claude-sonnet-4-7"),
+            ProviderSelection(provider="codex", model="codex-model"),
+        ]
+        config_yaml = generate_config_yaml(providers)
+        parsed = yaml.safe_load(config_yaml)
+
+        assert "default-claude" in parsed["profiles"]
+        assert "default-codex" in parsed["profiles"]
+        assert "claude" in parsed["providers"]
+        assert "codex" in parsed["providers"]
+
+    def test_all_providers_max_permissions(self):
+        """All four providers get their respective max-permission keys."""
+        providers = [
+            ProviderSelection(provider="claude", model="claude-sonnet-4-7"),
+            ProviderSelection(provider="codex", model="codex-model"),
+            ProviderSelection(provider="gemini", model="gemini-model"),
+            ProviderSelection(provider="opencode", model="opencode-model"),
+        ]
+        config_yaml = generate_config_yaml(providers)
+        parsed = yaml.safe_load(config_yaml)
+
+        assert parsed["providers"]["claude"]["dangerously_skip_permissions"] is True
+        assert (
+            parsed["providers"]["codex"]["dangerously_bypass_approvals_and_sandbox"]
+            is True
+        )
+        assert parsed["providers"]["gemini"]["yolo"] is True
+        assert parsed["providers"]["opencode"]["permission"] == "auto-edit"
+
+    def test_generated_yaml_is_parseable(self):
+        """Round-trip: generate -> yaml.safe_load returns a valid dict."""
+        providers = [ProviderSelection(provider="claude", model="claude-sonnet-4-7")]
+        config_yaml = generate_config_yaml(providers)
+        parsed = yaml.safe_load(config_yaml)
+        assert isinstance(parsed, dict)
+        assert "profiles" in parsed
+
+    def test_no_extra_providers_in_output(self):
+        """Only selected providers appear in the providers section."""
+        providers = [ProviderSelection(provider="claude", model="claude-sonnet-4-7")]
+        config_yaml = generate_config_yaml(providers)
+        parsed = yaml.safe_load(config_yaml)
+        assert set(parsed["providers"].keys()) == {"claude"}
+
+
+# ---------------------------------------------------------------------------
+# TestSelectiveTemplateCopy
+# ---------------------------------------------------------------------------
+
+
+class TestSelectiveTemplateCopy:
+    def test_only_selected_templates_copied(self, tmp_path: Path):
+        """Only the templates passed to InitConfig are created in .fdsx/workflows/."""
+        all_templates = discover_templates()
+        selected = [t for t in all_templates if t.name == "linear-basic"]
+
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=selected,
+        )
+        scaffold(tmp_path, config)
+
+        workflows_dir = tmp_path / ".fdsx" / "workflows"
+        created_workflow_names = {d.name for d in workflows_dir.iterdir() if d.is_dir()}
+        assert created_workflow_names == {"linear-basic"}
+
+    def test_no_templates_creates_empty_workflows_dir(self, tmp_path: Path):
+        """Empty templates list still creates workflows/ and config.yaml."""
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=[],
+        )
+        result = scaffold(tmp_path, config)
+
+        assert (tmp_path / ".fdsx" / "workflows").is_dir()
+        assert ".fdsx/config.yaml" in result.created
+        workflows_dir = tmp_path / ".fdsx" / "workflows"
+        assert list(workflows_dir.iterdir()) == []
+
+    def test_template_files_content_matches_source(self, tmp_path: Path):
+        """Files copied from a selected template have identical content to source."""
+        all_templates = discover_templates()
+        selected = [t for t in all_templates if t.name == "linear-basic"]
+        assert selected, "linear-basic must be available as a builtin template"
+
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=selected,
+        )
+        scaffold(tmp_path, config)
+
+        source_dir = selected[0].path
+        dest_dir = tmp_path / ".fdsx" / "workflows" / "linear-basic"
+
+        for source_file in source_dir.iterdir():
+            if source_file.name == "__init__.py" or not source_file.is_file():
+                continue
+            dest_file = dest_dir / source_file.name
+            assert dest_file.read_text() == source_file.read_text(), (
+                f"Content mismatch for {source_file.name}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TestAtomicGeneration
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicGeneration:
+    def test_no_partial_fdsx_on_write_failure(self, tmp_path: Path):
+        """If Path.write_text fails mid-template-copy, no .fdsx/ dir remains."""
+        all_templates = discover_templates()
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=all_templates,
+        )
+
+        original_write = Path.write_text
+
+        def bad_write_text(self, data):
+            if "workflow.yaml" in str(self):
+                raise OSError("simulated write failure")
+            return original_write(self, data)
+
+        with patch.object(Path, "write_text", bad_write_text), pytest.raises(OSError):
+            scaffold(tmp_path, config)
+
+        assert not (tmp_path / ".fdsx").exists()
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".fdsx.tmp.")]
+        assert leftover == []
+
+    def test_successful_scaffold_no_temp_dirs(self, tmp_path: Path):
+        """After a successful scaffold, no .fdsx.tmp.* directories remain."""
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=discover_templates(),
+        )
+        scaffold(tmp_path, config)
+
+        leftover = [p for p in tmp_path.iterdir() if p.name.startswith(".fdsx.tmp.")]
+        assert leftover == []
+
+    def test_existing_fdsx_not_atomic(self, tmp_path: Path):
+        """Scaffolding into an existing .fdsx/ writes files incrementally (non-atomic)."""
+        (tmp_path / ".fdsx").mkdir()
+
+        config = InitConfig(
+            providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+            templates=[],
+        )
+
+        with patch(
+            "fdsx.core.init.Path.rename",
+            side_effect=AssertionError("rename should not be called"),
+        ):
+            result = scaffold(tmp_path, config)
+
+        assert result.created
+        assert (tmp_path / ".fdsx" / "config.yaml").exists()

--- a/tests/integration/test_init_cli.py
+++ b/tests/integration/test_init_cli.py
@@ -59,6 +59,22 @@ class TestInitHappyPath:
         assert "config.yaml" in result.output
         assert "Next steps" in result.output
 
+    def test_no_templates_selected(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=[]),
+            patch("fdsx.cli.main.scaffold", return_value=FAKE_RESULT) as mock_scaffold,
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_scaffold.assert_called_once()
+
 
 class TestInitKeyboardInterrupt:
     def test_keyboard_interrupt_exits_130(self, tmp_path, monkeypatch):
@@ -126,3 +142,96 @@ class TestInitConflicts:
         assert result.exit_code == 0
         call_args = mock_scaffold.call_args
         assert "linear-basic" in call_args[0][2]  # allow_overwrite set
+
+    def test_conflicts_declined_skips_overwrite(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.check_conflicts", return_value=["linear-basic"]),
+            patch("fdsx.cli.main.confirm_overwrite", return_value=False),
+            patch("fdsx.cli.main.scaffold", return_value=FAKE_RESULT) as mock_scaffold,
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        call_args = mock_scaffold.call_args
+        assert call_args[0][2] == set()  # allow_overwrite empty
+
+    def test_multiple_conflicts_mixed_decisions(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        extra_template = TemplateInfo(
+            name="parallel-basic", path=Path("/fake/parallel-basic"), source="builtin"
+        )
+        all_templates = [*FAKE_TEMPLATES, extra_template]
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=all_templates),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=all_templates),
+            patch(
+                "fdsx.cli.main.check_conflicts",
+                return_value=["linear-basic", "parallel-basic"],
+            ),
+            patch("fdsx.cli.main.confirm_overwrite", side_effect=[True, False]),
+            patch("fdsx.cli.main.scaffold", return_value=FAKE_RESULT) as mock_scaffold,
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        call_args = mock_scaffold.call_args
+        assert call_args[0][2] == {"linear-basic"}  # only first approved
+
+
+class TestInitOutputFormat:
+    def test_skipped_config_shown(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result_with_skip = ScaffoldResult(
+            created=[".fdsx/workflows/linear-basic/workflow.yaml"],
+            skipped_config=True,
+            skipped_workflows=[],
+        )
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.check_conflicts", return_value=[]),
+            patch("fdsx.cli.main.scaffold", return_value=result_with_skip),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "preserved" in result.output
+
+    def test_skipped_workflows_shown(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        result_with_skipped = ScaffoldResult(
+            created=[".fdsx/config.yaml"],
+            skipped_config=False,
+            skipped_workflows=["linear-basic", "parallel-basic"],
+        )
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.check_conflicts", return_value=[]),
+            patch("fdsx.cli.main.scaffold", return_value=result_with_skipped),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        assert "Skipped (already exist)" in result.output
+        assert "linear-basic" in result.output
+        assert "parallel-basic" in result.output

--- a/tests/integration/test_init_cli.py
+++ b/tests/integration/test_init_cli.py
@@ -1,0 +1,128 @@
+"""Integration tests for fdsx init CLI command (T009)."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from fdsx.cli import main
+from fdsx.models.init import (
+    ProviderSelection,
+    ScaffoldResult,
+    TemplateInfo,
+)
+
+runner = CliRunner()
+
+FAKE_TEMPLATES = [
+    TemplateInfo(
+        name="linear-basic", path=Path("/fake/linear-basic"), source="builtin"
+    ),
+]
+FAKE_PROVIDERS = ["claude"]
+FAKE_SELECTIONS = [ProviderSelection(provider="claude", model="sonnet")]
+FAKE_RESULT = ScaffoldResult(
+    created=[".fdsx/config.yaml", ".fdsx/workflows/linear-basic/workflow.yaml"],
+    skipped_config=False,
+    skipped_workflows=[],
+)
+
+
+class TestInitNonTTY:
+    def test_non_tty_exits_2(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with patch("fdsx.cli.main.sys") as mock_sys:
+            mock_sys.stdin.isatty.return_value = False
+            result = runner.invoke(main.app, ["init"])
+        assert result.exit_code == 2
+        assert "interactive terminal" in result.output
+
+
+class TestInitHappyPath:
+    def test_successful_init(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.check_conflicts", return_value=[]),
+            patch("fdsx.cli.main.scaffold", return_value=FAKE_RESULT) as mock_scaffold,
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_scaffold.assert_called_once()
+        assert "Initialized .fdsx/ directory" in result.output
+        assert "config.yaml" in result.output
+        assert "Next steps" in result.output
+
+
+class TestInitKeyboardInterrupt:
+    def test_keyboard_interrupt_exits_130(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", side_effect=KeyboardInterrupt),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"])
+        assert result.exit_code == 130
+
+
+class TestInitExistingProject:
+    def test_existing_project_declined(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=False),
+            patch("fdsx.cli.main.confirm_existing_project", return_value=False),
+            patch("fdsx.cli.main.ensure_gitignore"),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+
+    def test_existing_project_confirmed_proceeds(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=False),
+            patch("fdsx.cli.main.confirm_existing_project", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.check_conflicts", return_value=[]),
+            patch("fdsx.cli.main.scaffold", return_value=FAKE_RESULT) as mock_scaffold,
+            patch("fdsx.cli.main.ensure_gitignore"),
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        mock_scaffold.assert_called_once()
+
+
+class TestInitConflicts:
+    def test_conflicts_with_overwrite(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch("fdsx.cli.main.sys") as mock_sys,
+            patch("fdsx.cli.main.discover_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.needs_init", return_value=True),
+            patch("fdsx.cli.main.select_providers", return_value=FAKE_PROVIDERS),
+            patch("fdsx.cli.main.select_models", return_value=FAKE_SELECTIONS),
+            patch("fdsx.cli.main.select_templates", return_value=FAKE_TEMPLATES),
+            patch("fdsx.cli.main.check_conflicts", return_value=["linear-basic"]),
+            patch("fdsx.cli.main.confirm_overwrite", return_value=True),
+            patch("fdsx.cli.main.scaffold", return_value=FAKE_RESULT) as mock_scaffold,
+        ):
+            mock_sys.stdin.isatty.return_value = True
+            result = runner.invoke(main.app, ["init"], catch_exceptions=False)
+        assert result.exit_code == 0
+        call_args = mock_scaffold.call_args
+        assert "linear-basic" in call_args[0][2]  # allow_overwrite set

--- a/tests/integration/test_init_interactive.py
+++ b/tests/integration/test_init_interactive.py
@@ -153,9 +153,7 @@ class TestSelectModels:
             _patch_console(_mock_console()),
         ):
             result = select_models(["opencode"])
-        assert result == [
-            ProviderSelection(provider="opencode", model="my-model")
-        ]
+        assert result == [ProviderSelection(provider="opencode", model="my-model")]
 
     def test_multiple_providers_sequential_inputs(self):
         """Sequential inputs for each provider are correctly mapped."""

--- a/tests/integration/test_init_interactive.py
+++ b/tests/integration/test_init_interactive.py
@@ -1,0 +1,342 @@
+"""Integration tests for interactive UI functions in src/fdsx/cli/init_interactive.py.
+
+Mocks _input (the module-level input wrapper) and _console to test behavioral
+logic of select_providers, select_models, select_templates,
+confirm_existing_project, and confirm_overwrite.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.cli.init_interactive import (
+    _console,
+    confirm_existing_project,
+    confirm_overwrite,
+    select_models,
+    select_providers,
+    select_templates,
+)
+from fdsx.models.init import ProviderSelection, TemplateInfo
+
+
+def _mock_console() -> MagicMock:
+    return MagicMock(spec=type(_console))
+
+
+def _patch_console(mocker: MagicMock):
+    return patch("fdsx.cli.init_interactive._console", mocker)
+
+
+class TestSelectProviders:
+    def test_valid_single_selection(self):
+        """Input '1' returns the first provider from sorted VALID_PROVIDERS."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="1"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_providers()
+        assert result == ["claude"]
+
+    def test_valid_multi_selection(self):
+        """Input '1,3' returns 1st and 3rd providers."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="1,3"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_providers()
+        assert result == ["claude", "gemini"]
+
+    def test_empty_input_retries_then_succeeds(self):
+        """Empty input triggers retry; '1' on second attempt returns first provider."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_providers()
+        assert result == ["claude"]
+        assert mock_input.call_count == 2
+
+    def test_out_of_range_retries(self):
+        """Out-of-range number triggers retry; '1' on third attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["0", "5", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_providers()
+        assert result == ["claude"]
+        assert mock_input.call_count == 3
+
+    def test_non_numeric_input_retries(self):
+        """Non-numeric input triggers retry; '1' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["abc", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_providers()
+        assert result == ["claude"]
+        assert mock_input.call_count == 2
+
+    def test_duplicate_selection_retries(self):
+        """Duplicate indices trigger retry; '1,2' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["1,1", "1,2"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_providers()
+        assert result == ["claude", "codex"]
+        assert mock_input.call_count == 2
+
+
+class TestSelectModels:
+    def test_preset_selection_by_number(self):
+        """Provider 'claude' with input '1' returns claude-sonnet-4-6."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="1"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_models(["claude"])
+        assert result == [
+            ProviderSelection(provider="claude", model="claude-sonnet-4-6")
+        ]
+
+    def test_custom_model_by_name(self):
+        """Non-numeric input is returned as the custom model name."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="my-custom-model"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_models(["claude"])
+        assert result == [ProviderSelection(provider="claude", model="my-custom-model")]
+
+    def test_empty_input_retries(self):
+        """Empty input triggers retry; '1' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_models(["claude"])
+        assert result == [
+            ProviderSelection(provider="claude", model="claude-sonnet-4-6")
+        ]
+        assert mock_input.call_count == 2
+
+    def test_out_of_range_number_retries(self):
+        """Out-of-range number triggers retry; '1' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["99", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_models(["claude"])
+        assert result == [
+            ProviderSelection(provider="claude", model="claude-sonnet-4-6")
+        ]
+        assert mock_input.call_count == 2
+
+    def test_provider_without_presets_prompts_free_text(self):
+        """Provider without presets (opencode) prompts for free-text model name."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="my-model"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_models(["opencode"])
+        assert result == [
+            ProviderSelection(provider="opencode", model="my-model")
+        ]
+
+    def test_multiple_providers_sequential_inputs(self):
+        """Sequential inputs for each provider are correctly mapped."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["1", "2"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_models(["claude", "codex"])
+        assert result == [
+            ProviderSelection(provider="claude", model="claude-sonnet-4-6"),
+            ProviderSelection(provider="codex", model="o3"),
+        ]
+        assert mock_input.call_count == 2
+
+
+class TestSelectTemplates:
+    @pytest.fixture
+    def template_fixtures(self, tmp_path: Path) -> list[TemplateInfo]:
+        return [
+            TemplateInfo(
+                name="linear-basic", path=tmp_path / "linear", source="builtin"
+            ),
+            TemplateInfo(
+                name="parallel-basic", path=tmp_path / "parallel", source="builtin"
+            ),
+            TemplateInfo(
+                name="plan-implement-review", path=tmp_path / "pir", source="builtin"
+            ),
+        ]
+
+    def test_valid_selection(self, template_fixtures: list[TemplateInfo]):
+        """Input '1' returns the first template."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="1"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates(template_fixtures)
+        assert result == [template_fixtures[0]]
+
+    def test_multi_selection(self, template_fixtures: list[TemplateInfo]):
+        """Input '1,2' returns first two templates."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="1,2"),
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates(template_fixtures)
+        assert result == [template_fixtures[0], template_fixtures[1]]
+
+    def test_empty_input_returns_empty_list(
+        self, template_fixtures: list[TemplateInfo]
+    ):
+        """Empty input (Enter for none) returns an empty list."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value=""),
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates(template_fixtures)
+        assert result == []
+
+    def test_empty_available_list_returns_immediately(self):
+        """Empty available list returns [] without prompting."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["should-not-be-called"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates([])
+        assert result == []
+        assert mock_input.call_count == 0
+
+    def test_out_of_range_retries(self, template_fixtures: list[TemplateInfo]):
+        """Out-of-range input triggers retry; '1' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["99", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates(template_fixtures)
+        assert result == [template_fixtures[0]]
+        assert mock_input.call_count == 2
+
+    def test_duplicate_retries(self, template_fixtures: list[TemplateInfo]):
+        """Duplicate selections trigger retry; '1' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["1,1", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates(template_fixtures)
+        assert result == [template_fixtures[0]]
+        assert mock_input.call_count == 2
+
+    def test_non_numeric_retries(self, template_fixtures: list[TemplateInfo]):
+        """Non-numeric input triggers retry; '1' on second attempt succeeds."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["abc", "1"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = select_templates(template_fixtures)
+        assert result == [template_fixtures[0]]
+        assert mock_input.call_count == 2
+
+
+class TestConfirmExistingProject:
+    def test_yes_returns_true(self):
+        """'y' input returns True."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="y"),
+            _patch_console(_mock_console()),
+        ):
+            assert confirm_existing_project() is True
+
+    def test_yes_variant_returns_true(self):
+        """'yes' input returns True."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="yes"),
+            _patch_console(_mock_console()),
+        ):
+            assert confirm_existing_project() is True
+
+    def test_no_returns_false(self):
+        """'n' input returns False."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="n"),
+            _patch_console(_mock_console()),
+        ):
+            assert confirm_existing_project() is False
+
+    def test_no_variant_returns_false(self):
+        """'no' input returns False."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="no"),
+            _patch_console(_mock_console()),
+        ):
+            assert confirm_existing_project() is False
+
+    def test_invalid_then_valid_retries(self):
+        """Invalid input 'maybe' triggers retry; 'y' on second attempt returns True."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["maybe", "y"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = confirm_existing_project()
+        assert result is True
+        assert mock_input.call_count == 2
+
+
+class TestConfirmOverwrite:
+    def test_yes_returns_true(self):
+        """'y' input returns True."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="y"),
+            _patch_console(_mock_console()),
+        ):
+            assert confirm_overwrite("my-workflow") is True
+
+    def test_no_returns_false(self):
+        """'n' input returns False."""
+        with (
+            patch("fdsx.cli.init_interactive._input", return_value="n"),
+            _patch_console(_mock_console()),
+        ):
+            assert confirm_overwrite("my-workflow") is False
+
+    def test_invalid_then_valid_retries(self):
+        """Invalid input triggers retry; 'n' on second attempt returns False."""
+        with (
+            patch(
+                "fdsx.cli.init_interactive._input", side_effect=["maybe", "n"]
+            ) as mock_input,
+            _patch_console(_mock_console()),
+        ):
+            result = confirm_overwrite("my-workflow")
+        assert result is False
+        assert mock_input.call_count == 2

--- a/tests/integration/test_quiet_mode.py
+++ b/tests/integration/test_quiet_mode.py
@@ -23,6 +23,7 @@ class TestQuietModeE2E:
             Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
         )
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
 
         result = runner.invoke(app, ["run", flow_path, "--quiet"])
@@ -41,6 +42,7 @@ class TestQuietModeE2E:
             Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
         )
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
 
         result = runner.invoke(app, ["run", flow_path, "--quiet"])
@@ -57,6 +59,7 @@ class TestQuietModeE2E:
             Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"
         )
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
 
         result = runner.invoke(app, ["run", flow_path])
@@ -74,6 +77,7 @@ class TestQuietModeE2E:
     def test_quiet_log_files_still_written(self, tmp_path, monkeypatch):
         """--quiet still writes per-state log files (FR-5.3)."""
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
 
         src_fixture = (
             Path(__file__).resolve().parent.parent / "fixtures" / "simple_flow.yaml"

--- a/tests/integration/test_resume_interrupt.py
+++ b/tests/integration/test_resume_interrupt.py
@@ -12,6 +12,7 @@ class TestResumeCommandOnError:
     def test_runtime_error_displays_resume_command(self, tmp_path, monkeypatch):
         """RuntimeError from engine displays resume command with correct thread_id."""
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
 
         workflow_yaml = yaml.dump(
             {
@@ -45,6 +46,7 @@ class TestResumeCommandOnError:
     def test_exception_displays_resume_command(self, tmp_path, monkeypatch):
         """Generic Exception from engine displays resume command."""
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
 
         workflow_yaml = yaml.dump(
             {
@@ -81,6 +83,7 @@ class TestResumeCommandOnKeyboardInterrupt:
     def test_keyboard_interrupt_displays_resume_command(self, tmp_path, monkeypatch):
         """KeyboardInterrupt from engine displays resume command."""
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
 
         workflow_yaml = yaml.dump(
             {
@@ -240,6 +243,7 @@ class TestResumeCommandWithThreadId:
     def test_explicit_thread_id_in_resume_command(self, tmp_path, monkeypatch):
         """When --thread-id is provided, it appears in the resume command."""
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
 
         workflow_yaml = yaml.dump(
             {

--- a/tests/integration/test_scaffold_gitignore.py
+++ b/tests/integration/test_scaffold_gitignore.py
@@ -13,21 +13,36 @@ import pytest
 from typer.testing import CliRunner
 
 from fdsx.cli import main
-from fdsx.core.init import GITIGNORE_TEMPLATE, ensure_gitignore, scaffold
+from fdsx.core.init import (
+    GITIGNORE_TEMPLATE,
+    discover_templates,
+    ensure_gitignore,
+    scaffold,
+)
+from fdsx.models.init import InitConfig, ProviderSelection
+
+
+def _make_default_config() -> InitConfig:
+    return InitConfig(
+        providers=[ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+        templates=discover_templates(),
+    )
 
 
 class TestScaffoldCreatesGitignore:
     """Tests for .fdsx/.gitignore creation during scaffold()."""
 
     def test_scaffold_creates_gitignore(self, tmp_path: Path) -> None:
-        """scaffold(tmp_path) creates .fdsx/.gitignore file."""
-        scaffold(tmp_path)
+        """scaffold(tmp_path, config) creates .fdsx/.gitignore file."""
+        config = _make_default_config()
+        scaffold(tmp_path, config)
         gitignore_path = tmp_path / ".fdsx" / ".gitignore"
         assert gitignore_path.exists(), ".fdsx/.gitignore was not created by scaffold()"
 
     def test_gitignore_has_header_comment(self, tmp_path: Path) -> None:
         """The first line of .fdsx/.gitignore starts with #."""
-        scaffold(tmp_path)
+        config = _make_default_config()
+        scaffold(tmp_path, config)
         gitignore_path = tmp_path / ".fdsx" / ".gitignore"
         content = gitignore_path.read_text()
         first_line = content.splitlines()[0]
@@ -39,7 +54,8 @@ class TestScaffoldCreatesGitignore:
         self, tmp_path: Path
     ) -> None:
         """config.yaml and workflows/ are NOT in .gitignore patterns."""
-        scaffold(tmp_path)
+        config = _make_default_config()
+        scaffold(tmp_path, config)
         gitignore_path = tmp_path / ".fdsx" / ".gitignore"
         content = gitignore_path.read_text()
         assert "config.yaml" not in content, "config.yaml should not be in .gitignore"
@@ -64,7 +80,6 @@ class TestRetroactiveGitignore:
         assert gitignore_path.exists(), (
             ".fdsx/.gitignore should be created retroactively"
         )
-        # Verify silent creation — no gitignore-related message in stderr
         assert "gitignore" not in (result.stderr_bytes or b"").decode().lower()
 
     def test_retroactive_no_overwrite(

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -131,6 +131,7 @@ class TestSplitCliIntegration:
         )
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         # Config has no task_splitter — should fall back to built-in TaskSplitterConfig()
         with (
@@ -155,6 +156,8 @@ class TestSplitCliIntegration:
         from typer.testing import CliRunner
 
         from fdsx.cli.main import app
+
+        (tmp_path / ".fdsx").mkdir()
 
         with patch(
             "fdsx.cli.main.load_config",
@@ -184,6 +187,7 @@ class TestSplitCliIntegration:
             return FdsxConfig(task_splitter=TaskSplitterConfig())
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
             runner = CliRunner()
@@ -254,6 +258,7 @@ class TestSplitCliIntegration:
         task_file.write_text("Task 1")
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with patch(
             "fdsx.cli.main.load_config",
@@ -328,6 +333,7 @@ class TestSplitCliIntegration:
             return FdsxConfig(task_splitter=TaskSplitterConfig())
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch("fdsx.cli.main.load_config", side_effect=mock_load_config),
@@ -366,6 +372,7 @@ class TestSplitCliIntegration:
             return FdsxConfig(task_splitter=TaskSplitterConfig())
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch("fdsx.cli.main.load_config", side_effect=mock_load_config),
@@ -414,6 +421,7 @@ class TestSplitCliIntegration:
         )
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch(
@@ -507,6 +515,7 @@ class TestSplitCliIntegration:
         )
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch(
@@ -543,6 +552,7 @@ class TestSplitCliIntegration:
         task_file.write_text("New feature")
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with patch(
             "fdsx.cli.main.load_config",
@@ -624,6 +634,7 @@ class TestSplitCliIntegration:
         )
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch(

--- a/tests/integration/test_split_spinner.py
+++ b/tests/integration/test_split_spinner.py
@@ -52,6 +52,7 @@ class TestSplitSpinner:
         )
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch(
@@ -82,6 +83,7 @@ class TestSplitSpinner:
         )
 
         monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
 
         with (
             patch(

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -585,6 +585,7 @@ class TestTasksDirCli:
         )
 
     def test_run_tasks_dir_mutual_exclusion(self, tmp_path):
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         (tasks_dir / "001-test.yaml").write_text("description: dummy\n")
@@ -605,6 +606,7 @@ class TestTasksDirCli:
         assert "mutually exclusive" in result.stderr.lower()
 
     def test_run_tasks_dir_without_workflow_requires_auto_workflow(self, tmp_path):
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         (tasks_dir / "001-test.yaml").write_text("description: dummy\n")
@@ -618,6 +620,7 @@ class TestTasksDirCli:
         assert "No workflows found" in result.stderr
 
     def test_run_tasks_dir_rejects_symlink_dir(self, tmp_path):
+        (tmp_path / ".fdsx").mkdir()
         real_dir = tmp_path / "real"
         real_dir.mkdir()
         save_task_file(
@@ -636,6 +639,7 @@ class TestTasksDirCli:
         assert "symlink" in result.stderr.lower()
 
     def test_auto_and_confirm_workflow_mutually_exclusive(self, tmp_path):
+        (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"
         tasks_dir.mkdir()
         (tasks_dir / "001-test.yaml").write_text("description: dummy\n")

--- a/tests/integration/test_universal_scaffold_trigger.py
+++ b/tests/integration/test_universal_scaffold_trigger.py
@@ -1,6 +1,6 @@
 """Integration tests for universal scaffold trigger (FR-2).
 
-Tests verify that scaffold is triggered for ANY command in interactive mode
+Tests verify that guide message is shown for ANY command in interactive mode
 when .fdsx/ does not exist, and skipped in CI mode.
 """
 
@@ -15,56 +15,58 @@ from fdsx.cli import main
 class TestUniversalScaffoldTrigger:
     """Tests for universal scaffold trigger behavior."""
 
-    def test_version_flag_triggers_scaffold_when_uninitialized(
+    def test_version_flag_shows_guide_when_uninitialized(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """--version in uninitialized dir triggers scaffold."""
+        """--version in uninitialized dir shows guide message."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
         result = runner.invoke(main.app, ["--interactive", "--version"])
         assert result.exit_code == 0
-        assert (tmp_path / ".fdsx").exists(), ".fdsx/ should be created"
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
-    def test_bare_fdsx_triggers_scaffold_when_uninitialized(
+    def test_bare_fdsx_shows_guide_when_uninitialized(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Bare fdsx (no args) in uninitialized dir triggers scaffold."""
+        """Bare fdsx (no args) in uninitialized dir shows guide message."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
         result = runner.invoke(main.app, ["--interactive"])
         assert result.exit_code == 0
-        assert (tmp_path / ".fdsx").exists(), ".fdsx/ should be created"
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
-    def test_subcommand_triggers_scaffold_when_uninitialized(
+    def test_subcommand_shows_guide_when_uninitialized(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Subcommand in uninitialized dir triggers scaffold."""
+        """Subcommand in uninitialized dir shows guide message."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
-        # validate will fail after scaffold, but scaffold should still happen
-        runner.invoke(main.app, ["--interactive", "validate", "dummy.yaml"])
-        assert (tmp_path / ".fdsx").exists(), ".fdsx/ should be created"
+        result = runner.invoke(main.app, ["--interactive", "validate", "dummy.yaml"])
+        assert result.exit_code == 0
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
-    def test_ci_mode_skips_scaffold(
+    def test_ci_mode_shows_guide_when_uninitialized(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """--ci mode does not trigger scaffold."""
+        """--ci mode shows guide message even when .fdsx/ is missing."""
         monkeypatch.chdir(tmp_path)
         runner = CliRunner()
         result = runner.invoke(main.app, ["--ci", "--version"])
         assert result.exit_code == 0
-        assert not (tmp_path / ".fdsx").exists(), (
-            ".fdsx/ should NOT be created in CI mode"
-        )
+        assert "No .fdsx/ directory found" in result.output
+        assert "Run 'fdsx init'" in result.output
 
-    def test_existing_fdsx_no_scaffold_message(
+    def test_existing_fdsx_no_guide_message(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Pre-existing .fdsx/ dir does not trigger scaffold message."""
+        """Pre-existing .fdsx/ dir does not trigger guide message."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / ".fdsx").mkdir()
         (tmp_path / ".fdsx" / ".gitignore").write_text("# existing\n")
         runner = CliRunner()
         result = runner.invoke(main.app, ["--interactive", "--version"])
         assert result.exit_code == 0
-        assert "Initialized" not in result.output
+        assert "No .fdsx/ directory found" not in result.output

--- a/tests/unit/test_cli_version.py
+++ b/tests/unit/test_cli_version.py
@@ -6,7 +6,11 @@ from fdsx.cli.main import app
 
 
 class TestCliVersion:
-    def test_version_flag_outputs_version_and_exits(self) -> None:
+    def test_version_flag_outputs_version_and_exits(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
         result = runner.invoke(app, ["--version"])
 


### PR DESCRIPTION
## Summary

- **ruff format**: Reformatted `tests/integration/test_init_interactive.py`
- **mypy**: Removed stale `# type: ignore[arg-type]` from `src/fdsx/core/compiler/compile.py:403` (type now resolves correctly without suppression)
- **pytest (53 failures)**: Updated tests to create `.fdsx/` in temp working directories — required by the `needs_init()` guard introduced in T008 (commit `8fd1d6f`), which blocks all subcommands except `init` when `.fdsx/` doesn't exist

## What changed and why

The T008 phase wired a `needs_init()` guard into the CLI `main()` callback to redirect users to `fdsx init` when a project isn't initialized. This was intentional and verified by `test_universal_scaffold_trigger.py`. However, pre-existing tests were never updated: they relied on CLI commands working from bare temp directories (via the autouse `_isolate_cwd` fixture in `tests/conftest.py`), which now all trigger the guard.

**Approach:** Update tests only — no changes to `main.py` or `conftest.py`:
- `tests/e2e/cli_test_utils.py`: create `.fdsx/` in `run_fdsx()` default tmpdir (fixes ~35 e2e tests in one change)
- `tests/e2e/test_batch_*.py`, `test_cli_*.py`: create `.fdsx/` in per-test explicit `cwd=` directories
- `tests/integration/test_quiet_mode.py`, `test_resume_interrupt.py`, `test_split.py`, `test_split_spinner.py`, `test_tasks_dir.py`: add `.fdsx/` mkdir after `monkeypatch.chdir(tmp_path)`
- `tests/unit/test_cli_version.py`: create `.fdsx/` before invoking `CliRunner`

## How to test

```bash
uv run ruff format --check .
uv run ruff check src/ tests/
uv run mypy src/
uv run pytest tests/ -v
```

All four gates should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)