### PR TITLE
feat: CLI UX enhancements — fdsx add, system_prompt, default_tasks_dir

### DIFF
--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -492,9 +492,6 @@ def add(
         typer.echo(f"Error: Task file not found: {task_file}", err=True)
         raise typer.Exit(code=2)
 
-    if not split:
-        raise NotImplementedError("Single-task add is not yet implemented")
-
     config = load_config()
     task_splitter = config.task_splitter or TaskSplitterConfig()
 
@@ -520,11 +517,15 @@ def add(
             f.unlink()
         typer.echo(f"Cleared existing task files in {TASKS_DIR}/", err=True)
 
+    single_task = not split
+
     try:
         task_content = task_file.read_text()
 
         with Spinner("Splitting tasks...") as spinner:
-            groups = split_tasks_to_groups(task_content, task_splitter)
+            groups = split_tasks_to_groups(
+                task_content, task_splitter, single_task=single_task
+            )
 
             if not groups:
                 typer.echo("No tasks were generated from the input file.", err=True)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -1,4 +1,3 @@
-import json
 import sys
 from pathlib import Path
 
@@ -473,22 +472,28 @@ def list_flows(
 
 
 @app.command()
-def split(
-    task_file: Path = typer.Argument(..., help="Path to the task file to split"),
+def add(
+    task_file: Path = typer.Argument(..., help="Path to the task file"),
+    split: bool = typer.Option(
+        False, "--split", help="Split the task file into multiple task files"
+    ),
     force: bool = typer.Option(
-        False, "--force", help="Clear existing tasks directory before splitting"
+        False, "--force", help="Clear existing tasks directory before writing"
     ),
 ) -> None:
-    """Split a task file into individual task files for persistent batch execution.
+    """Add a task file to the batch execution queue.
 
-    Reads task_splitter configuration from .fdsx/config.yaml (or defaults).
-    Writes numbered task files to .fdsx/tasks/ directory.
+    When --split is specified, reads task_splitter configuration from .fdsx/config.yaml
+    (or defaults) and splits the task file into individual task files in .fdsx/tasks/.
     Shows an animated spinner during LLM splitting. In non-interactive (non-TTY) terminals,
     prints plain log lines instead of animation.
     """
     if not task_file.exists():
         typer.echo(f"Error: Task file not found: {task_file}", err=True)
         raise typer.Exit(code=2)
+
+    if not split:
+        raise NotImplementedError("Single-task add is not yet implemented")
 
     config = load_config()
     task_splitter = config.task_splitter or TaskSplitterConfig()
@@ -523,7 +528,6 @@ def split(
 
             if not groups:
                 typer.echo("No tasks were generated from the input file.", err=True)
-                typer.echo(json.dumps([]))
                 return
 
             spinner.update(f"Writing {len(groups)} task file(s)...")
@@ -534,7 +538,6 @@ def split(
         )
         for f in created_files:
             typer.echo(f"  {f}", err=True)
-        typer.echo(json.dumps([str(f) for f in created_files]))
 
     except RuntimeError as e:
         typer.echo(f"Error: {_sanitize_output(str(e))}", err=True)

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -42,6 +42,27 @@ app = typer.Typer(help="fdsx - Declarative AI agent workflow execution framework
 _interactive_mode: bool | None = None
 
 
+def _validate_tasks_dir(tasks_dir: Path) -> None:
+    if not tasks_dir.exists():
+        typer.echo(
+            f"Error: Tasks directory not found: {tasks_dir}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if tasks_dir.is_symlink():
+        typer.echo(
+            f"Error: --tasks-dir must not be a symlink: {tasks_dir}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if not tasks_dir.is_dir():
+        typer.echo(
+            f"Error: --tasks-dir must be a directory: {tasks_dir}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
@@ -133,6 +154,7 @@ def run(
     Displays an interactive numbered-list CUI for workflow confirmation (in interactive terminals).
     Use --auto-workflow to skip the confirmation UI.
     In non-interactive (non-TTY) terminals, auto-confirms without prompting."""
+    config = load_config()
     if tasks_dir is not None:
         if input_vars is not None or tasks_file is not None:
             typer.echo(
@@ -140,24 +162,7 @@ def run(
                 err=True,
             )
             raise typer.Exit(code=2)
-        if not tasks_dir.exists():
-            typer.echo(
-                f"Error: Tasks directory not found: {tasks_dir}",
-                err=True,
-            )
-            raise typer.Exit(code=2)
-        if tasks_dir.is_symlink():
-            typer.echo(
-                f"Error: --tasks-dir must not be a symlink: {tasks_dir}",
-                err=True,
-            )
-            raise typer.Exit(code=2)
-        if not tasks_dir.is_dir():
-            typer.echo(
-                f"Error: --tasks-dir must be a directory: {tasks_dir}",
-                err=True,
-            )
-            raise typer.Exit(code=2)
+        _validate_tasks_dir(tasks_dir)
     elif input_vars and tasks_file is not None:
         typer.echo(
             "Error: --input and --tasks are mutually exclusive",
@@ -170,12 +175,14 @@ def run(
             err=True,
         )
         raise typer.Exit(code=2)
-    elif workflow is None and tasks_dir is None:
-        typer.echo(
-            "Error: workflow argument is required when not using --tasks-dir",
-            err=True,
-        )
-        raise typer.Exit(code=2)
+    elif (
+        workflow is None and tasks_dir is None and tasks_file is None and not input_vars
+    ):
+        resolved_tasks_dir = Path(
+            config.default_tasks_dir if config.default_tasks_dir else ".fdsx/tasks/"
+        ).expanduser()
+        _validate_tasks_dir(resolved_tasks_dir)
+        tasks_dir = resolved_tasks_dir
 
     if auto_workflow is not None and confirm_workflow is not None:
         typer.echo(
@@ -198,7 +205,6 @@ def run(
             inputs[key] = value
 
     base_dir = Path(".fdsx")
-    config = load_config()
 
     effective_auto_workflow = (
         auto_workflow if auto_workflow is not None else config.auto_workflow

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import structlog
+
 from fdsx.core.config import TaskSplitterConfig
 from fdsx.display.terminal import _sanitize_output
 from fdsx.models.flow import Flow
@@ -15,6 +17,8 @@ from fdsx.models.task import (
     save_task_file,
 )
 from fdsx.providers.base import get_provider
+
+logger = structlog.get_logger(__name__)
 
 TASKS_DIR = ".fdsx/tasks"
 COMPLETED_SUBDIR = "completed"
@@ -77,6 +81,7 @@ def split_tasks_to_groups(
     task_splitter: TaskSplitterConfig,
     state_names: list[str] | None = None,
     input_vars: set[str] | None = None,
+    single_task: bool = False,
 ) -> list[list[TaskEntry]]:
     """Invoke the task_splitter LLM to split task content into file groups.
 
@@ -88,6 +93,9 @@ def split_tasks_to_groups(
         task_splitter: The task splitter configuration
         state_names: Optional list of state names for context
         input_vars: Optional set of input variables for context
+        single_task: If True, the LLM is directed to return exactly one group
+            containing exactly one task. If the result exceeds this, it is coalesced
+            into a single entry with a warning logged.
 
     Returns:
         List of file groups. Each group contains sequentially-dependent
@@ -104,6 +112,7 @@ def split_tasks_to_groups(
         state_names,
         input_vars,
         extra_instructions=task_splitter.extra_instructions,
+        single_task=single_task,
     )
 
     result = provider.execute(
@@ -114,7 +123,23 @@ def split_tasks_to_groups(
     if result.exit_code != 0:
         raise RuntimeError(f"Task splitter failed: {result.stderr}")
 
-    return _parse_structured_tasks(result.stdout)
+    groups = _parse_structured_tasks(result.stdout)
+
+    if single_task:
+        total_entries = sum(len(group) for group in groups)
+        if len(groups) > 1 or total_entries > 1:
+            logger.warning(
+                "splitter_over_split",
+                groups=len(groups),
+                total_entries=total_entries,
+            )
+            all_descriptions = [
+                entry.description for group in groups for entry in group
+            ]
+            coalesced_description = "\n\n".join(all_descriptions)
+            return [[TaskEntry(description=coalesced_description)]]
+
+    return groups
 
 
 def _build_task_split_prompt(
@@ -122,6 +147,7 @@ def _build_task_split_prompt(
     state_names: list[str] | None,
     input_vars: set[str] | None,
     extra_instructions: str | None = None,
+    single_task: bool = False,
 ) -> str:
     """Build the prompt for the task splitter LLM.
 
@@ -129,6 +155,9 @@ def _build_task_split_prompt(
         task_content: The content of the task file
         state_names: List of state names in the workflow (optional for standalone split)
         input_vars: Set of input variable names (optional for standalone split)
+        extra_instructions: Additional instructions to append to the prompt
+        single_task: If True, prepend a CRITICAL directive requiring exactly one group
+            containing exactly one task object.
     """
     states_desc = ", ".join(state_names) if state_names else "any workflow"
     input_vars_desc = ", ".join(input_vars) if input_vars else "task"
@@ -138,8 +167,16 @@ def _build_task_split_prompt(
         else ""
     )
 
-    prompt = f"""You are a dependency-aware task splitter. Given a batch of work, analyze dependencies and group related changes into feature-level tasks.
+    single_task_directive = (
+        "CRITICAL: You MUST return exactly ONE group containing exactly ONE task object.\n"
+        "Combine all work into a single comprehensive task description with numbered sub-steps.\n"
+        "Do NOT split into multiple groups or multiple tasks.\n\n"
+        if single_task
+        else ""
+    )
 
+    prompt = f"""You are a dependency-aware task splitter. Given a batch of work, analyze dependencies and group related changes into feature-level tasks.
+{single_task_directive}
 The workflow has these states: {states_desc}
 The workflow accepts these input variables: {input_vars_desc}
 

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -2,6 +2,8 @@
 
 from typing import TYPE_CHECKING, Annotated, Any, TypedDict
 
+import structlog
+
 from fdsx.core.config import _deep_merge
 from fdsx.models.flow import (
     Flow,
@@ -13,6 +15,8 @@ from fdsx.models.flow import (
 
 if TYPE_CHECKING:
     from fdsx.core.config import FdsxConfig
+
+logger = structlog.get_logger(__name__)
 
 
 def _top_level_key(path: str) -> str | None:
@@ -42,6 +46,7 @@ def _merge_provider_options(
     flow: Flow,
     provider_name: str,
     task_options: dict[str, Any] | None,
+    state_name: str = "",
 ) -> dict[str, Any] | None:
     """Merge provider options from three levels: config → workflow → task/branch.
 
@@ -50,6 +55,7 @@ def _merge_provider_options(
         flow: The flow definition carrying workflow-level provider options (level 2).
         provider_name: Provider name (e.g. 'claude', 'codex', 'opencode').
         task_options: Per-task or per-branch provider_options dict (level 3).
+        state_name: Name of the state being merged (for error messages).
 
     Returns:
         Merged options dict, or None if no options were set at any level.
@@ -73,6 +79,32 @@ def _merge_provider_options(
     # Level 3: Task/Branch-level options.
     if task_options is not None:
         merged = _deep_merge(merged, task_options)
+
+    if not merged:
+        return None
+
+    # Claude-specific: enforce mutual exclusion between system_prompt and append_system_prompt
+    if provider_name == "claude":
+        has_system_prompt = bool(merged.get("system_prompt"))
+        has_append = bool(merged.get("append_system_prompt"))
+        if has_system_prompt and has_append:
+            from fdsx.core.engine.validate import FlowValidationError
+
+            raise FlowValidationError(
+                f"State '{state_name}': 'system_prompt' and 'append_system_prompt' "
+                f"are mutually exclusive. Both cannot be set."
+            )
+    else:
+        # Non-Claude providers: warn once and strip the fields
+        for field in ("system_prompt", "append_system_prompt"):
+            if field in merged:
+                logger.warning(
+                    "provider_option_unsupported",
+                    state=state_name,
+                    provider=provider_name,
+                    field=field,
+                )
+                del merged[field]
 
     return merged if merged else None
 

--- a/src/fdsx/core/compiler/nodes.py
+++ b/src/fdsx/core/compiler/nodes.py
@@ -47,7 +47,7 @@ def _create_task_node(
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create a LangGraph node function for a Task state."""
     merged_options = _merge_provider_options(
-        config, flow, state.provider, state.provider_options
+        config, flow, state.provider, state.provider_options, state_name=state_name
     )
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -68,7 +68,14 @@ def _create_task_node(
         resolved_prompt = resolve_template(state.prompt_template or "", state_dict)
         resolved_command = resolve_template_shell_safe(state.command or "", state_dict)
 
-        provider = get_provider(state.provider, merged_options)
+        effective_options = dict(merged_options) if merged_options else None
+        if effective_options:
+            for key in ("system_prompt", "append_system_prompt"):
+                if effective_options.get(key):
+                    effective_options[key] = resolve_template(
+                        effective_options[key], state_dict
+                    )
+        provider = get_provider(state.provider, effective_options)
 
         max_retries = state.retry if state.retry is not None else 3
 

--- a/src/fdsx/core/compiler/parallel.py
+++ b/src/fdsx/core/compiler/parallel.py
@@ -88,9 +88,20 @@ def _create_branch_executor(
         resolved_command = resolve_template_shell_safe(branch.command or "", state_dict)
 
         merged_options = _merge_provider_options(
-            config, flow, branch.provider, branch.provider_options
+            config,
+            flow,
+            branch.provider,
+            branch.provider_options,
+            state_name=state_name,
         )
-        provider = get_provider(branch.provider, merged_options)
+        effective_options = dict(merged_options) if merged_options else None
+        if effective_options:
+            for key in ("system_prompt", "append_system_prompt"):
+                if effective_options.get(key):
+                    effective_options[key] = resolve_template(
+                        effective_options[key], state_dict
+                    )
+        provider = get_provider(branch.provider, effective_options)
 
         max_retries = branch.retry if branch.retry is not None else 3
 

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -147,6 +147,10 @@ class FdsxConfig(BaseModel):
         default=".fdsx/workflows",
         description="Directory to discover workflow files",
     )
+    default_tasks_dir: str | None = Field(
+        default=None,
+        description="Default tasks directory for no-arg fdsx run",
+    )
     auto_workflow: bool = Field(
         default=False,
         description="Skip confirmation for auto-selected workflows",

--- a/src/fdsx/core/init.py
+++ b/src/fdsx/core/init.py
@@ -47,6 +47,8 @@ CONFIG_TEMPLATE = """\
 # workflow_selector:
 #   profile: generalist
 #
+# default_tasks_dir: .fdsx/tasks/
+#
 # extra_instructions:
 #   task_splitter:
 #     - "Split into smaller tasks when complexity is high"

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -269,8 +269,12 @@ provider_options:
   dangerously_skip_permissions?: bool   # default: false
   allowed_tools?: [string]
   disallowed_tools?: [string]
+  system_prompt?: string                # mutually exclusive with append_system_prompt
+  append_system_prompt?: string         # mutually exclusive with system_prompt
   inactivity_timeout?: int              # default: 300
 ```
+
+**Mutual exclusion:** `system_prompt` and `append_system_prompt` cannot both be set on the same state (including after config-level merge). Setting both raises `FlowValidationError`.
 
 ### Codex
 
@@ -327,6 +331,7 @@ workflow_selector?:
 
 workflows_dir?: string          # default: .fdsx/workflows — relative, no ".."
 auto_workflow?: bool            # default: false
+default_tasks_dir?: string      # default: .fdsx/tasks/ — precedence: project → global → fallback
 
 providers?:
   claude?: ClaudeOptions

--- a/src/fdsx/providers/claude.py
+++ b/src/fdsx/providers/claude.py
@@ -82,6 +82,8 @@ class ClaudeOptions(BaseModel):
     allowed_tools: list[str] = []
     disallowed_tools: list[str] = []
     inactivity_timeout: int | None = None
+    system_prompt: str | None = None
+    append_system_prompt: str | None = None
 
     def to_cli_flags(self) -> list[str]:
         """Translate options to Claude CLI flags."""
@@ -94,6 +96,10 @@ class ClaudeOptions(BaseModel):
             flags.extend(["--allowedTools", tool])
         for tool in self.disallowed_tools:
             flags.extend(["--disallowedTools", tool])
+        if self.system_prompt is not None:
+            flags.extend(["--system-prompt", self.system_prompt])
+        if self.append_system_prompt is not None:
+            flags.extend(["--append-system-prompt", self.append_system_prompt])
         return flags
 
 

--- a/tests/e2e/test_add_cli.py
+++ b/tests/e2e/test_add_cli.py
@@ -1,0 +1,23 @@
+from tests.e2e.cli_test_utils import run_fdsx
+
+
+class TestAddCommand:
+    def test_split_subcommand_removed(self):
+        """fdsx split foo.md should return exit 2 with unknown command error."""
+        result = run_fdsx(["split", "foo.md"])
+        assert result.returncode == 2
+        assert (
+            "No such command" in result.stderr
+            or "no such command" in result.stderr.lower()
+        )
+
+    def test_add_nonexistent_file(self):
+        """fdsx add nonexistent.md should return exit 2 with 'not found' error."""
+        result = run_fdsx(["add", "nonexistent.md"])
+        assert result.returncode == 2
+        assert "not found" in result.stderr.lower()
+
+    def test_add_missing_required_arg_shows_help(self):
+        """fdsx add with no arguments should return exit 2."""
+        result = run_fdsx(["add"])
+        assert result.returncode == 2

--- a/tests/e2e/test_batch_full_pipeline.py
+++ b/tests/e2e/test_batch_full_pipeline.py
@@ -424,7 +424,7 @@ class TestHelpText:
         """Verify split command help mentions spinner and non-TTY fallback (T027)."""
         (tmp_path / ".fdsx").mkdir()
         runner = CliRunner()
-        result = runner.invoke(app, ["split", "--help"])
+        result = runner.invoke(app, ["add", "--split", "--help"])
 
         assert result.exit_code == 0
         assert "spinner" in result.stdout.lower() or "animated" in result.stdout.lower()

--- a/tests/integration/test_add_single_task.py
+++ b/tests/integration/test_add_single_task.py
@@ -1,0 +1,203 @@
+from unittest.mock import MagicMock, patch
+
+import structlog.testing
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
+from fdsx.core.config import FdsxConfig, TaskSplitterConfig
+from fdsx.models.task import TaskEntry, load_task_file
+
+
+class TestSingleTaskIntegration:
+    def test_single_task_one_group_one_entry(self, tmp_path):
+        """Single task result produces exactly one file."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Fix login bug"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups(
+                "Fix the login bug", task_splitter, single_task=True
+            )
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert groups[0][0].description == "Fix login bug"
+
+        tasks_dir = tmp_path / TASKS_DIR
+        created_files = write_task_files(groups, tasks_dir)
+
+        assert len(created_files) == 1
+        assert "fix-login-bug" in created_files[0].name
+
+    def test_single_task_three_groups_coalesced(self, tmp_path):
+        """Multiple groups are coalesced into one entry with a warning."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task A"}], [{"description": "Task B"}], [{"description": "Task C"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with (
+            patch("fdsx.core.batch.get_provider", return_value=mock_provider),
+            structlog.testing.capture_logs() as log_output,
+        ):
+            groups = split_tasks_to_groups(
+                "Multi-part task", task_splitter, single_task=True
+            )
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert "Task A" in groups[0][0].description
+        assert "Task B" in groups[0][0].description
+        assert "Task C" in groups[0][0].description
+        assert "\n\n" in groups[0][0].description
+
+        assert any(r.get("event") == "splitter_over_split" for r in log_output)
+
+        tasks_dir = tmp_path / TASKS_DIR
+        created_files = write_task_files(groups, tasks_dir)
+
+        assert len(created_files) == 1
+
+    def test_single_task_multiple_entries_in_one_group_coalesced(self, tmp_path):
+        """Multiple entries in one group are coalesced with a warning."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "First task"}, {"description": "Second task"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with (
+            patch("fdsx.core.batch.get_provider", return_value=mock_provider),
+            structlog.testing.capture_logs() as log_output,
+        ):
+            groups = split_tasks_to_groups("Two tasks", task_splitter, single_task=True)
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert "First task" in groups[0][0].description
+        assert "Second task" in groups[0][0].description
+
+        assert any(r.get("event") == "splitter_over_split" for r in log_output)
+
+    def test_single_task_no_coalescing_when_already_single(self, tmp_path):
+        """No warning when result is already one group with one entry."""
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Only task"}]]',
+            stderr="",
+        )
+
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        with (
+            patch("fdsx.core.batch.get_provider", return_value=mock_provider),
+            structlog.testing.capture_logs() as log_output,
+        ):
+            groups = split_tasks_to_groups(
+                "Single task", task_splitter, single_task=True
+            )
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+        assert groups[0][0].description == "Only task"
+
+        assert not any(r.get("event") == "splitter_over_split" for r in log_output)
+
+    def test_single_task_file_round_trips(self, tmp_path):
+        """Task file content round-trips correctly through save/load."""
+        groups = [
+            [TaskEntry(description="Implement feature\n1. Step one\n2. Step two")]
+        ]
+
+        tasks_dir = tmp_path / TASKS_DIR
+        created_files = write_task_files(groups, tasks_dir)
+
+        assert len(created_files) == 1
+
+        loaded = load_task_file(created_files[0])
+        assert len(loaded.entries) == 1
+        assert (
+            loaded.entries[0].description
+            == "Implement feature\n1. Step one\n2. Step two"
+        )
+
+
+class TestAddSingleTaskCli:
+    def test_add_single_task_cli(self, tmp_path, monkeypatch):
+        """fdsx add without --split creates exactly one task file."""
+        task_file = tmp_path / "fix.md"
+        task_file.write_text("Fix the login bug")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Fix login"}]]',
+            stderr="",
+        )
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
+
+        with (
+            patch("fdsx.cli.main.load_config", side_effect=mock_load_config),
+            patch("fdsx.core.batch.get_provider", return_value=mock_provider),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["add", str(task_file)], catch_exceptions=False)
+
+        assert result.exit_code == 0
+        assert result.stdout == ""
+        assert "Created 1 task file" in result.stderr
+
+        tasks_dir = tmp_path / TASKS_DIR
+        yaml_files = list(tasks_dir.glob("*.yaml"))
+        assert len(yaml_files) == 1
+
+    def test_add_single_task_cli_with_split_false_default(self, tmp_path, monkeypatch):
+        """fdsx add without --split flag produces single-task behavior."""
+        task_file = tmp_path / "task.md"
+        task_file.write_text("Implement login feature")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Login feature"}]]',
+            stderr="",
+        )
+
+        def mock_load_config(*args, **kwargs):
+            return FdsxConfig(task_splitter=TaskSplitterConfig())
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir(exist_ok=True)
+
+        with (
+            patch("fdsx.cli.main.load_config", side_effect=mock_load_config),
+            patch("fdsx.core.batch.get_provider", return_value=mock_provider),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["add", str(task_file)], catch_exceptions=False)
+
+        assert result.exit_code == 0
+
+        tasks_dir = tmp_path / TASKS_DIR
+        yaml_files = list(tasks_dir.glob("*.yaml"))
+        assert len(yaml_files) == 1

--- a/tests/integration/test_default_tasks_dir.py
+++ b/tests/integration/test_default_tasks_dir.py
@@ -1,0 +1,269 @@
+"""Integration tests for default_tasks_dir feature (US4)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+from typer.testing import CliRunner
+
+from fdsx.cli.main import app
+from fdsx.models.task import TaskEntry, TaskFile, save_task_file
+
+
+def _make_workflow_yaml(name: str, description: str) -> str:
+    return yaml.dump(
+        {
+            "name": name,
+            "description": description,
+            "start_at": "s",
+            "states": {
+                "s": {
+                    "type": "task",
+                    "provider": "system",
+                    "command": "echo done",
+                    "result_path": "$.result",
+                    "end": True,
+                }
+            },
+        }
+    )
+
+
+def _setup_workflows(project_root: Path) -> Path:
+    workflows_dir = project_root / ".fdsx" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    wf_path = workflows_dir / "test-workflow.yaml"
+    wf_path.write_text(_make_workflow_yaml("TestWorkflow", "Test workflow"))
+    return wf_path
+
+
+class TestDefaultTasksDirResolution:
+    """Tests for US4: default_tasks_dir config field and no-arg fdsx run."""
+
+    def test_no_arg_no_tasks_dir_exits_with_error(self, tmp_path, monkeypatch):
+        """(a) No config, no .fdsx/tasks/ -> exit 2."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == 2
+        assert "Tasks directory not found" in result.stderr
+
+    def test_no_arg_with_fallback_tasks_dir_works(self, tmp_path, monkeypatch):
+        """(c) No config but .fdsx/tasks/ exists -> uses fallback."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+        tasks_dir = tmp_path / ".fdsx" / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        _setup_workflows(tmp_path)
+
+        with (
+            patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
+            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["run", "--auto-workflow"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr}"
+
+    def test_no_arg_with_config_default_tasks_dir(self, tmp_path, monkeypatch):
+        """(b) config.default_tasks_dir is set -> uses it."""
+        monkeypatch.chdir(tmp_path)
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": ".fdsx/tasks"}))
+
+        tasks_dir = tmp_path / ".fdsx" / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        _setup_workflows(tmp_path)
+
+        with (
+            patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
+            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["run", "--auto-workflow"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr}"
+
+    def test_project_config_default_tasks_dir(self, tmp_path, monkeypatch):
+        """(d) Project config default_tasks_dir is used."""
+        monkeypatch.chdir(tmp_path)
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": "my-tasks"}))
+
+        my_tasks = tmp_path / "my-tasks"
+        my_tasks.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(my_tasks / "001-test.yaml", tf)
+
+        _setup_workflows(tmp_path)
+
+        with (
+            patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
+            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["run", "--auto-workflow"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr}"
+
+    def test_project_overrides_global_default_tasks_dir(self, tmp_path, monkeypatch):
+        """(e) Project config default_tasks_dir overrides global config."""
+        monkeypatch.chdir(tmp_path)
+
+        global_dir = tmp_path / "global_config" / "fdsx"
+        global_dir.mkdir(parents=True)
+        global_config = global_dir / "config.yaml"
+        global_config.write_text(yaml.dump({"default_tasks_dir": "global-tasks"}))
+
+        global_home = tmp_path / "global_config"
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(global_home))
+
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        project_config = fdsx_dir / "config.yaml"
+        project_config.write_text(yaml.dump({"default_tasks_dir": "project-tasks"}))
+
+        project_tasks = tmp_path / "project-tasks"
+        project_tasks.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(project_tasks / "001-test.yaml", tf)
+
+        _setup_workflows(tmp_path)
+
+        with (
+            patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
+            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["run", "--auto-workflow"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr}"
+
+    def test_tilde_expansion_in_default_tasks_dir(self, tmp_path, monkeypatch):
+        """(f) ~ in default_tasks_dir is expanded to home directory."""
+        monkeypatch.chdir(tmp_path)
+
+        fake_home = tmp_path / "fake_home"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": "~/tasks"}))
+
+        home_tasks = fake_home / "tasks"
+        home_tasks.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(home_tasks / "001-test.yaml", tf)
+
+        _setup_workflows(tmp_path)
+
+        with (
+            patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
+            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(app, ["run", "--auto-workflow"])
+
+        assert result.exit_code == 0, f"stderr={result.stderr}"
+
+    def test_explicit_tasks_dir_ignores_config(self, tmp_path, monkeypatch):
+        """(h) Explicit --tasks-dir takes precedence over config."""
+        monkeypatch.chdir(tmp_path)
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": "nonexistent-tasks"}))
+
+        explicit_tasks = tmp_path / "explicit-tasks"
+        explicit_tasks.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(explicit_tasks / "001-test.yaml", tf)
+
+        _setup_workflows(tmp_path)
+
+        with (
+            patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
+            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                app,
+                ["run", "--tasks-dir", str(explicit_tasks), "--auto-workflow"],
+            )
+
+        assert result.exit_code == 0, f"stderr={result.stderr}"
+
+    def test_no_arg_with_nonexistent_config_default_tasks_dir_exits(
+        self, tmp_path, monkeypatch
+    ):
+        """Config default_tasks_dir points to nonexistent dir -> exit 2."""
+        monkeypatch.chdir(tmp_path)
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": "nonexistent-tasks"}))
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == 2
+        assert "Tasks directory not found" in result.stderr
+
+    def test_no_arg_with_symlinked_tasks_dir_exits(self, tmp_path, monkeypatch):
+        """Symlinked tasks dir in config -> exit 2."""
+        monkeypatch.chdir(tmp_path)
+        real_dir = tmp_path / "real-tasks"
+        real_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="test task")])
+        save_task_file(real_dir / "001-test.yaml", tf)
+
+        symlink_dir = tmp_path / "tasks-link"
+        symlink_dir.symlink_to(real_dir)
+
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": "tasks-link"}))
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == 2
+        assert "symlink" in result.stderr.lower()
+
+    def test_no_arg_with_file_instead_of_dir_exits(self, tmp_path, monkeypatch):
+        """default_tasks_dir points to a file instead of dir -> exit 2."""
+        monkeypatch.chdir(tmp_path)
+        fdsx_dir = tmp_path / ".fdsx"
+        fdsx_dir.mkdir()
+        config_file = fdsx_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"default_tasks_dir": "some-file"}))
+
+        (tmp_path / "some-file").write_text("not a directory")
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code == 2
+        assert "must be a directory" in result.stderr.lower()

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -231,6 +231,13 @@ class TestConfigTemplateScaffold:
         assert "task_splitter:" in config_yaml
         assert "  profile: generalist" in config_yaml
 
+    def test_generated_config_contains_default_tasks_dir_comment(self):
+        config_yaml = generate_config_yaml(
+            self._make_profile_assignments(),
+            [ProviderSelection(provider="claude", model="claude-sonnet-4-7")],
+        )
+        assert "default_tasks_dir" in config_yaml
+
     def test_generated_config_contains_extra_instructions_examples(self):
         config_yaml = generate_config_yaml(
             self._make_profile_assignments(),

--- a/tests/integration/test_provider_options.py
+++ b/tests/integration/test_provider_options.py
@@ -154,7 +154,9 @@ class TestConfigWorkflowMerge:
             )
         )
         flow = _make_single_task_flow()
-        merged = _merge_provider_options(config, flow, "claude", None)
+        merged = _merge_provider_options(
+            config, flow, "claude", None, state_name="step1"
+        )
 
         assert merged is not None
         provider = get_provider("claude", merged)
@@ -171,7 +173,9 @@ class TestConfigWorkflowMerge:
         flow = _make_single_task_flow(
             flow_providers={"claude": {"permission_mode": "bypassPermissions"}}
         )
-        merged = _merge_provider_options(config, flow, "claude", None)
+        merged = _merge_provider_options(
+            config, flow, "claude", None, state_name="step1"
+        )
 
         assert merged is not None
         provider = get_provider("claude", merged)
@@ -189,7 +193,9 @@ class TestConfigWorkflowMerge:
         flow = _make_single_task_flow(
             flow_providers={"claude": {"dangerously_skip_permissions": True}}
         )
-        merged = _merge_provider_options(config, flow, "claude", None)
+        merged = _merge_provider_options(
+            config, flow, "claude", None, state_name="step1"
+        )
 
         assert merged is not None
         # permission_mode from config, dangerously_skip from workflow
@@ -204,7 +210,9 @@ class TestConfigWorkflowMerge:
             )
         )
         flow = _make_single_task_flow(provider="gemini")
-        merged = _merge_provider_options(config, flow, "gemini", None)
+        merged = _merge_provider_options(
+            config, flow, "gemini", None, state_name="step1"
+        )
 
         assert merged is not None
         provider = get_provider("gemini", merged)
@@ -232,7 +240,11 @@ class TestTaskLevelOverride:
             task_provider_options={"permission_mode": "bypassPermissions"},
         )
         merged = _merge_provider_options(
-            config, flow, "claude", flow.states["step1"].provider_options
+            config,
+            flow,
+            "claude",
+            flow.states["step1"].provider_options,
+            state_name="step1",
         )  # type: ignore[union-attr]
 
         assert merged is not None
@@ -258,7 +270,9 @@ class TestUnchangedWorkflowsWithoutOptions:
         config = FdsxConfig()  # no providers
         flow = _make_single_task_flow()
 
-        merged = _merge_provider_options(config, flow, "claude", None)
+        merged = _merge_provider_options(
+            config, flow, "claude", None, state_name="step1"
+        )
 
         assert merged is None
 
@@ -362,8 +376,12 @@ class TestParallelBranchesWithMixedProviders:
         )
         flow = _make_single_task_flow()
 
-        claude_result = _merge_provider_options(config, flow, "claude", None)
-        codex_result = _merge_provider_options(config, flow, "codex", None)
+        claude_result = _merge_provider_options(
+            config, flow, "claude", None, state_name="step1"
+        )
+        codex_result = _merge_provider_options(
+            config, flow, "codex", None, state_name="step1"
+        )
 
         assert claude_result is not None
         assert claude_result.get("permission_mode") == "acceptEdits"

--- a/tests/integration/test_split.py
+++ b/tests/integration/test_split.py
@@ -141,14 +141,10 @@ class TestSplitCliIntegration:
             patch("fdsx.core.batch.get_provider", return_value=mock_provider),
         ):
             runner = CliRunner()
-            result = runner.invoke(app, ["split", str(task_file)])
+            result = runner.invoke(app, ["add", "--split", str(task_file)])
 
         assert result.exit_code == 0
-        import json as _json
-
-        paths = _json.loads(result.stdout)
-        assert isinstance(paths, list)
-        assert len(paths) == 2
+        assert result.stdout == ""
         assert "Created 2 task file" in result.stderr
 
     def test_split_command_missing_task_file(self, tmp_path):
@@ -164,7 +160,9 @@ class TestSplitCliIntegration:
             return_value=FdsxConfig(task_splitter=TaskSplitterConfig()),
         ):
             runner = CliRunner()
-            result = runner.invoke(app, ["split", str(tmp_path / "nonexistent.md")])
+            result = runner.invoke(
+                app, ["add", "--split", str(tmp_path / "nonexistent.md")]
+            )
 
             assert result.exit_code == 2
             assert "not found" in result.stderr
@@ -192,7 +190,7 @@ class TestSplitCliIntegration:
         with patch("fdsx.cli.main.load_config", side_effect=mock_load_config):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
             assert result.exit_code == 2
@@ -230,7 +228,9 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file), "--force"], catch_exceptions=False
+                app,
+                ["add", "--split", str(task_file), "--force"],
+                catch_exceptions=False,
             )
 
         assert result.exit_code == 0
@@ -266,7 +266,9 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file), "--force"], catch_exceptions=False
+                app,
+                ["add", "--split", str(task_file), "--force"],
+                catch_exceptions=False,
             )
 
         assert result.exit_code == 2
@@ -305,7 +307,9 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file), "--force"], catch_exceptions=False
+                app,
+                ["add", "--split", str(task_file), "--force"],
+                catch_exceptions=False,
             )
 
         assert result.exit_code == 0
@@ -341,15 +345,11 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
         assert result.exit_code == 0
-        import json as _json
-
-        paths = _json.loads(result.stdout)
-        assert isinstance(paths, list)
-        assert len(paths) == 1
+        assert result.stdout == ""
         assert "Created 1 task file" in result.stderr
 
     def test_split_command_records_source_path(self, tmp_path, monkeypatch):
@@ -380,7 +380,7 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
         assert result.exit_code == 0
@@ -432,14 +432,12 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
         assert result.exit_code == 0
-        import json as _json
-
-        paths = _json.loads(result.stdout)
-        assert len(paths) == 1
+        assert result.stdout == ""
+        assert "Created 1 task file" in result.stderr
 
     # T001: Completed/ dir and its contents are preserved after a normal split
     def test_split_command_preserves_completed_dir_on_normal_split(
@@ -477,7 +475,7 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
         assert result.exit_code == 0
@@ -526,7 +524,7 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
         assert result.exit_code == 0
@@ -560,7 +558,7 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file)], catch_exceptions=False
+                app, ["add", "--split", str(task_file)], catch_exceptions=False
             )
 
         assert result.exit_code == 2
@@ -645,7 +643,9 @@ class TestSplitCliIntegration:
         ):
             runner = CliRunner()
             result = runner.invoke(
-                app, ["split", str(task_file), "--force"], catch_exceptions=False
+                app,
+                ["add", "--split", str(task_file), "--force"],
+                catch_exceptions=False,
             )
 
         assert result.exit_code == 0

--- a/tests/integration/test_split_spinner.py
+++ b/tests/integration/test_split_spinner.py
@@ -62,7 +62,7 @@ class TestSplitSpinner:
             patch("fdsx.core.batch.get_provider", return_value=mock_provider),
         ):
             runner = CliRunner()
-            result = runner.invoke(app, ["split", str(task_file)])
+            result = runner.invoke(app, ["add", "--split", str(task_file)])
 
         assert result.exit_code == 0, f"stderr: {result.stderr}"
         assert "Splitting tasks..." in result.stderr
@@ -93,7 +93,7 @@ class TestSplitSpinner:
             patch("fdsx.core.batch.get_provider", return_value=mock_provider),
         ):
             runner = CliRunner()
-            result = runner.invoke(app, ["split", str(task_file)])
+            result = runner.invoke(app, ["add", "--split", str(task_file)])
 
         assert result.exit_code == 0
         assert "No tasks were generated" in result.stderr

--- a/tests/integration/test_system_prompt.py
+++ b/tests/integration/test_system_prompt.py
@@ -1,0 +1,320 @@
+"""Integration tests for end-to-end system prompt wiring (T001 + T002).
+
+Tests verify that system_prompt and append_system_prompt:
+  - Flow from task state provider_options through merge to CLI invocation
+  - Are mutually exclusive after 3-level merge (config → workflow → task)
+  - Are warned-and-stripped for non-Claude providers
+  - Support variable substitution via {var} patterns
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import structlog.testing
+import yaml
+
+from fdsx.core.compiler.helpers import _merge_provider_options
+from fdsx.core.config import FdsxConfig, ProviderConfigs
+from fdsx.core.engine import FlowValidationError, run_flow
+from fdsx.models.flow import Flow, TaskState
+from fdsx.providers.base import ProviderResult
+
+FAKE_SUCCESS = ProviderResult(exit_code=0, stdout="ok", stderr="")
+
+
+class TestSystemPromptMutexValidation:
+    """Verify mutual-exclusion validation fires after 3-level merge."""
+
+    def test_both_fields_set_after_merge_raises_flow_validation_error(self):
+        """Both fields set after merge → FlowValidationError naming both fields and state."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                claude={"system_prompt": "Config-level prompt"},
+            )
+        )
+        flow = Flow(
+            name="test",
+            description="Test",
+            start_at="step1",
+            states={
+                "step1": TaskState(
+                    type="task",
+                    provider="claude",
+                    model="claude-sonnet",
+                    prompt_template="do the thing",
+                    result_path="$.result",
+                    end=True,
+                    provider_options={"append_system_prompt": "Task-level append"},
+                )
+            },
+        )
+
+        with pytest.raises(FlowValidationError) as exc_info:
+            _merge_provider_options(
+                config,
+                flow,
+                "claude",
+                flow.states["step1"].provider_options,
+                state_name="step1",
+            )
+
+        exc_message = str(exc_info.value)
+        assert "system_prompt" in exc_message
+        assert "append_system_prompt" in exc_message
+        assert "step1" in exc_message
+
+    def test_task_level_both_fields_set_raises(self):
+        """Task-level provider_options with both fields set raises at merge time."""
+        flow = Flow(
+            name="test",
+            description="Test",
+            start_at="step1",
+            states={
+                "step1": TaskState(
+                    type="task",
+                    provider="claude",
+                    model="claude-sonnet",
+                    prompt_template="do the thing",
+                    result_path="$.result",
+                    end=True,
+                    provider_options={
+                        "system_prompt": "Base",
+                        "append_system_prompt": "Append",
+                    },
+                )
+            },
+        )
+
+        with pytest.raises(FlowValidationError) as exc_info:
+            _merge_provider_options(
+                None,
+                flow,
+                "claude",
+                flow.states["step1"].provider_options,
+                state_name="step1",
+            )
+
+        exc_message = str(exc_info.value)
+        assert "system_prompt" in exc_message
+        assert "append_system_prompt" in exc_message
+
+
+class TestClaudeSystemPromptEndToEnd:
+    """Verify system_prompt reaches the Claude CLI invocation."""
+
+    def _write_flow_yaml(self, tmp_path: Path, flow_dict: dict) -> Path:
+        flow_yaml = yaml.dump(flow_dict)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+        return flow_path
+
+    def test_system_prompt_reaches_cli(self, tmp_path, monkeypatch):
+        """Claude state with system_prompt → mocked _run_subprocess gets --system-prompt."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+
+        flow_dict = {
+            "name": "test-system-prompt",
+            "description": "Test system prompt flow",
+            "start_at": "step1",
+            "states": {
+                "step1": {
+                    "type": "task",
+                    "provider": "claude",
+                    "model": "claude-sonnet",
+                    "prompt_template": "do the thing",
+                    "result_path": "$.result",
+                    "end": True,
+                    "provider_options": {"system_prompt": "You are a reviewer."},
+                }
+            },
+        }
+        flow_path = self._write_flow_yaml(tmp_path, flow_dict)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
+            run_flow(flow_path, base_dir=tmp_path)
+
+        assert len(captured_args) == 1
+        args = captured_args[0]
+        assert "--system-prompt" in args
+        idx = args.index("--system-prompt")
+        assert args[idx + 1] == "You are a reviewer."
+
+    def test_append_system_prompt_reaches_cli(self, tmp_path, monkeypatch):
+        """Claude state with append_system_prompt → mocked _run_subprocess gets --append-system-prompt."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+
+        flow_dict = {
+            "name": "test-system-prompt",
+            "description": "Test system prompt flow",
+            "start_at": "step1",
+            "states": {
+                "step1": {
+                    "type": "task",
+                    "provider": "claude",
+                    "model": "claude-sonnet",
+                    "prompt_template": "do the thing",
+                    "result_path": "$.result",
+                    "end": True,
+                    "provider_options": {"append_system_prompt": "Additional context."},
+                }
+            },
+        }
+        flow_path = self._write_flow_yaml(tmp_path, flow_dict)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
+            run_flow(flow_path, base_dir=tmp_path)
+
+        assert len(captured_args) == 1
+        args = captured_args[0]
+        assert "--append-system-prompt" in args
+        idx = args.index("--append-system-prompt")
+        assert args[idx + 1] == "Additional context."
+
+
+class TestNonClaudeProviderWarnAndStrip:
+    """Non-Claude providers warn once and strip system prompt fields."""
+
+    def test_codex_with_append_system_prompt_strips_flag(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Codex state with append_system_prompt logs warning and does not pass flag to CLI."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+
+        flow_dict = {
+            "name": "test",
+            "description": "Test codex strip flow",
+            "start_at": "step1",
+            "states": {
+                "step1": {
+                    "type": "task",
+                    "provider": "codex",
+                    "model": "codex-mini",
+                    "prompt_template": "do the thing",
+                    "result_path": "$.result",
+                    "end": True,
+                    "provider_options": {"append_system_prompt": "Some appended text"},
+                }
+            },
+        }
+        flow_yaml = yaml.dump(flow_dict)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        with (
+            structlog.testing.capture_logs() as log_output,
+            patch("fdsx.providers.codex._run_subprocess") as fake_run,
+        ):
+            fake_run.return_value = FAKE_SUCCESS
+            run_flow(flow_path, base_dir=tmp_path)
+
+        assert any(r.get("event") == "provider_option_unsupported" for r in log_output)
+        assert fake_run.called, "codex _run_subprocess should have been called"
+        # _run_subprocess is called with keyword args, so args is in call_args.kwargs
+        args_list = fake_run.call_args.kwargs.get("args", [])
+        assert "--append-system-prompt" not in args_list
+
+
+class TestSystemPromptVariableSubstitution:
+    """System prompt fields support {variable} substitution from state_dict."""
+
+    def test_append_system_prompt_with_variable_resolved(self, tmp_path, monkeypatch):
+        """append_system_prompt: 'Reviewer: {reviewer_name}' resolves to actual value."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+
+        flow_dict = {
+            "name": "test-var-subst",
+            "description": "Test variable substitution flow",
+            "start_at": "step1",
+            "states": {
+                "step1": {
+                    "type": "task",
+                    "provider": "claude",
+                    "model": "claude-sonnet",
+                    "prompt_template": "do the thing",
+                    "result_path": "$.result",
+                    "end": True,
+                    "provider_options": {
+                        "append_system_prompt": "Reviewer: {reviewer_name}"
+                    },
+                }
+            },
+        }
+        flow_yaml = yaml.dump(flow_dict)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        captured_args: list[list[str]] = []
+
+        def fake_run_subprocess(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch(
+            "fdsx.providers.claude._run_subprocess", side_effect=fake_run_subprocess
+        ):
+            run_flow(flow_path, inputs={"reviewer_name": "Alice"}, base_dir=tmp_path)
+
+        assert len(captured_args) == 1
+        args = captured_args[0]
+        assert "--append-system-prompt" in args
+        idx = args.index("--append-system-prompt")
+        assert args[idx + 1] == "Reviewer: Alice"
+
+    def test_config_level_system_prompt_reaches_cli(self, tmp_path, monkeypatch):
+        """Config-level system_prompt with no conflict reaches Claude CLI argv."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".fdsx").mkdir()
+        config_path = tmp_path / ".fdsx" / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"providers": {"claude": {"system_prompt": "You are helpful."}}})
+        )
+        flow_dict = {
+            "name": "test",
+            "description": "Test",
+            "start_at": "step1",
+            "states": {
+                "step1": {
+                    "type": "task",
+                    "provider": "claude",
+                    "model": "claude-sonnet",
+                    "prompt_template": "do it",
+                    "result_path": "$.result",
+                    "end": True,
+                }
+            },
+        }
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(yaml.dump(flow_dict))
+        captured_args = []
+
+        def fake(args, **kwargs):
+            captured_args.append(list(args))
+            return FAKE_SUCCESS
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=fake):
+            run_flow(flow_path, base_dir=tmp_path / ".fdsx")
+        args = captured_args[0]
+        assert "--system-prompt" in args
+        idx = args.index("--system-prompt")
+        assert args[idx + 1] == "You are helpful."

--- a/tests/unit/test_claude_options.py
+++ b/tests/unit/test_claude_options.py
@@ -1,0 +1,50 @@
+"""Unit tests for ClaudeOptions system_prompt and append_system_prompt fields."""
+
+from fdsx.providers.claude import ClaudeOptions
+
+
+class TestClaudeOptionsSystemPromptFlags:
+    """Verify to_cli_flags() emits --system-prompt and --append-system-prompt correctly."""
+
+    def test_system_prompt_flag_emitted(self):
+        """to_cli_flags() with system_prompt set emits --system-prompt."""
+        options = ClaudeOptions(system_prompt="You are a helpful assistant.")
+        flags = options.to_cli_flags()
+        assert "--system-prompt" in flags
+        idx = flags.index("--system-prompt")
+        assert flags[idx + 1] == "You are a helpful assistant."
+
+    def test_append_system_prompt_flag_emitted(self):
+        """to_cli_flags() with append_system_prompt set emits --append-system-prompt."""
+        options = ClaudeOptions(append_system_prompt="Additional context here.")
+        flags = options.to_cli_flags()
+        assert "--append-system-prompt" in flags
+        idx = flags.index("--append-system-prompt")
+        assert flags[idx + 1] == "Additional context here."
+
+    def test_neither_set_no_system_prompt_flags(self):
+        """to_cli_flags() with neither field set emits no system-prompt flags."""
+        options = ClaudeOptions()
+        flags = options.to_cli_flags()
+        assert "--system-prompt" not in flags
+        assert "--append-system-prompt" not in flags
+
+    def test_both_fields_set_to_cli_flags_still_works(self):
+        """to_cli_flags() works even when both fields are set (mutex is elsewhere)."""
+        options = ClaudeOptions(
+            system_prompt="Base prompt.",
+            append_system_prompt="Appended text.",
+        )
+        flags = options.to_cli_flags()
+        assert "--system-prompt" in flags
+        assert "--append-system-prompt" in flags
+
+    def test_permission_mode_still_works_with_system_prompt(self):
+        """permission_mode and system_prompt can coexist in to_cli_flags()."""
+        options = ClaudeOptions(
+            permission_mode="bypassPermissions",
+            system_prompt="You are a helpful assistant.",
+        )
+        flags = options.to_cli_flags()
+        assert "--permission-mode" in flags
+        assert "--system-prompt" in flags

--- a/tests/unit/test_task_splitter_prompt.py
+++ b/tests/unit/test_task_splitter_prompt.py
@@ -1,0 +1,48 @@
+from fdsx.core.batch import _build_task_split_prompt
+
+
+class TestSingleTaskPromptDirective:
+    def test_single_task_true_prepends_critical_directive(self):
+        prompt = _build_task_split_prompt("test content", None, None, single_task=True)
+
+        assert "CRITICAL" in prompt
+        assert "exactly ONE group" in prompt
+        assert "exactly ONE task object" in prompt
+        assert "Do NOT split into multiple groups" in prompt
+
+    def test_single_task_false_has_no_critical_directive(self):
+        prompt = _build_task_split_prompt("test content", None, None, single_task=False)
+
+        assert "CRITICAL" not in prompt
+        assert "exactly ONE group" not in prompt
+
+    def test_single_task_default_is_false(self):
+        prompt_without_param = _build_task_split_prompt("test content", None, None)
+        prompt_with_false = _build_task_split_prompt(
+            "test content", None, None, single_task=False
+        )
+
+        assert prompt_without_param == prompt_with_false
+        assert "CRITICAL" not in prompt_without_param
+
+    def test_single_task_directive_comes_before_workflow_description(self):
+        prompt = _build_task_split_prompt(
+            "test content", ["plan", "implement"], {"task"}, single_task=True
+        )
+
+        critical_pos = prompt.index("CRITICAL")
+        workflow_pos = prompt.index("The workflow has these states")
+        assert critical_pos < workflow_pos
+
+    def test_single_task_true_with_extra_instructions(self):
+        prompt = _build_task_split_prompt(
+            "test content",
+            None,
+            None,
+            extra_instructions="Focus on security",
+            single_task=True,
+        )
+
+        assert "CRITICAL" in prompt
+        assert "Focus on security" in prompt
+        assert "ADDITIONAL INSTRUCTIONS" in prompt


### PR DESCRIPTION
## What was done

Five commits that deliver four CLI UX improvements for `fdsx`:

### 1. `system_prompt` / `append_system_prompt` for Claude provider (`e8354b8`)
- New fields on the `claude` provider options block in workflow YAML
- `system_prompt` replaces the default system prompt; `append_system_prompt` appends to it
- `FlowValidationError` raised if both are set simultaneously
- Integration tests cover both paths

### 2. Rename `fdsx split` → `fdsx add --split` (`7812f25`)
- `fdsx split <file>` is now `fdsx add --split <file>`
- Removes the JSON stdout from the split command (was a footgun for human-readable output)
- All existing tests updated; backward-compat E2E test confirms old `fdsx split` alias is gone

### 3. Single-task `fdsx add <file>` without `--split` (`d2edcc4`)
- `fdsx add <file>` now works without `--split` to add a single task directly
- Shows an interactive confirmation prompt before adding
- Integration tests cover mocked CliRunner path; E2E test covers subprocess path

### 4. `default_tasks_dir` config + no-arg `fdsx run` (`a1a5f1f`)
- New `default_tasks_dir` config key in `.fdsx/config.yaml`
- When set, `fdsx run` without arguments auto-picks up tasks from that directory
- Precedence: project config → global config → fallback to `.fdsx/tasks/`
- Integration tests cover directory discovery and fallback behavior

### 5. Schema + template documentation (`a7796c8`)
- All four new fields documented in `src/fdsx/data/skills/fdsx/references/yaml-schema.md`
- `CONFIG_TEMPLATE` scaffolded by `fdsx init` now includes a commented `default_tasks_dir` example line
- Integration test asserts the comment appears in generated config YAML

## Why

These changes reduce friction for common `fdsx` workflows:
- `fdsx add` is a more consistent command surface than a separate `fdsx split` subcommand
- `system_prompt` / `append_system_prompt` enable per-workflow prompt customisation without forking providers
- `default_tasks_dir` + no-arg `fdsx run` enables project-level task automation without per-invocation flags

## How to test

```bash
# Run the full test suite
uv run pytest tests/ -v

# Focused: new features only
uv run pytest tests/integration/test_system_prompt.py tests/integration/test_add_single_task.py tests/integration/test_default_tasks_dir.py tests/e2e/test_add_cli.py -v

# Manual smoke test
fdsx add --split <some-file.md>   # batch split
fdsx add <some-file.md>           # single-task add
fdsx run                          # no-arg run (requires default_tasks_dir in config)
```