### PR TITLE
feat: strengthen splitter prompt and add retry-with-feedback in batch.py

### DIFF
--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -530,7 +530,10 @@ def add(
 
         with Spinner("Splitting tasks...") as spinner:
             groups = split_tasks_to_groups(
-                task_content, task_splitter, single_task=single_task
+                task_content,
+                task_splitter,
+                single_task=single_task,
+                progress=spinner.update,
             )
 
             if not groups:

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -2,6 +2,7 @@ import json
 import re as _re
 import shutil
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +17,7 @@ from fdsx.models.task import (
     _ensure_no_symlink_ancestors,
     save_task_file,
 )
-from fdsx.providers.base import get_provider
+from fdsx.providers.base import ProviderBase, get_provider
 
 logger = structlog.get_logger(__name__)
 
@@ -76,12 +77,52 @@ def split_tasks(
         return _parse_task_list(result.stdout)
 
 
+def _invoke_splitter_and_parse(
+    provider: "ProviderBase", prompt: str, model: str | None
+) -> tuple[list[list[TaskEntry]], str]:
+    """Invoke the task splitter and parse its JSON response.
+
+    Args:
+        provider: The provider instance to use for execution
+        prompt: The prompt to send to the provider
+        model: Optional model override
+
+    Returns:
+        Tuple of (parsed groups, raw stdout) for logging purposes
+
+    Raises:
+        RuntimeError: If the provider call fails
+        ValueError: If the JSON parsing fails (raised with response_preview attached)
+    """
+    result = provider.execute(prompt=prompt, model=model)
+    if result.exit_code != 0:
+        raise RuntimeError(f"Task splitter failed: {result.stderr}")
+    try:
+        groups = _parse_structured_tasks(result.stdout)
+        return groups, result.stdout
+    except ValueError as e:
+        setattr(e, "response_preview", result.stdout[:500])
+        raise
+
+
+def _build_corrective_suffix(first_err: ValueError, response_preview: str) -> str:
+    """Build a corrective prompt suffix for retry on parse failure."""
+    return f"""---
+CORRECTION REQUIRED
+Your previous response could not be parsed as valid JSON.
+Parse error: {first_err}
+Previous response preview: {response_preview}
+Please output ONLY a valid JSON array of file groups with no additional text or explanations.
+"""
+
+
 def split_tasks_to_groups(
     task_content: str,
     task_splitter: TaskSplitterConfig,
     state_names: list[str] | None = None,
     input_vars: set[str] | None = None,
     single_task: bool = False,
+    progress: Callable[[str], None] | None = None,
 ) -> list[list[TaskEntry]]:
     """Invoke the task_splitter LLM to split task content into file groups.
 
@@ -96,6 +137,7 @@ def split_tasks_to_groups(
         single_task: If True, the LLM is directed to return exactly one group
             containing exactly one task. If the result exceeds this, it is coalesced
             into a single entry with a warning logged.
+        progress: Optional callback for progress messages
 
     Returns:
         List of file groups. Each group contains sequentially-dependent
@@ -115,15 +157,39 @@ def split_tasks_to_groups(
         single_task=single_task,
     )
 
-    result = provider.execute(
-        prompt=prompt,
-        model=task_splitter.model,
-    )
+    if progress:
+        progress("Calling task splitter (this may take a while)...")
 
-    if result.exit_code != 0:
-        raise RuntimeError(f"Task splitter failed: {result.stderr}")
+    try:
+        groups, _raw_stdout = _invoke_splitter_and_parse(
+            provider, prompt, task_splitter.model
+        )
+    except ValueError as first_err:
+        response_preview = getattr(first_err, "response_preview", "")
+        logger.warning(
+            "task_splitter_invalid_json",
+            error=str(first_err),
+            response_preview=response_preview,
+        )
+        if progress:
+            progress(
+                "Splitter returned invalid JSON, retrying with corrective prompt..."
+            )
 
-    groups = _parse_structured_tasks(result.stdout)
+        corrective_prompt = (
+            prompt + "\n\n" + _build_corrective_suffix(first_err, response_preview)
+        )
+        try:
+            groups, _raw_stdout = _invoke_splitter_and_parse(
+                provider, corrective_prompt, task_splitter.model
+            )
+        except ValueError as second_err:
+            raise ValueError(
+                f"Attempt 1: {first_err} | Attempt 2: {second_err}"
+            ) from second_err
+
+    if progress:
+        progress("Parsing splitter response...")
 
     if single_task:
         total_entries = sum(len(group) for group in groups)
@@ -138,6 +204,9 @@ def split_tasks_to_groups(
             ]
             coalesced_description = "\n\n".join(all_descriptions)
             return [[TaskEntry(description=coalesced_description)]]
+
+    if progress:
+        progress(f"Splitter produced {len(groups)} task group(s)")
 
     return groups
 
@@ -243,6 +312,12 @@ GOOD (dependency-aware with foundational task first — shared types → then co
   ]
 ]
 {extra_section}
+JSON HYGIENE:
+- Escape special characters: use \\" for quotes, \\\\ for backslashes, \\n for newlines
+- Keep code snippets short and single-line; avoid multi-line blocks that can break JSON
+- Prefer concise prose + step bullets over reproducing code verbatim
+- Always output valid JSON (arrays and objects only, no trailing commas)
+
 OUTPUT FORMAT:
 Return a JSON array of file groups. Each group is an array of task objects that belong in the same file.
 ```json

--- a/src/fdsx/core/batch.py
+++ b/src/fdsx/core/batch.py
@@ -101,7 +101,7 @@ def _invoke_splitter_and_parse(
         groups = _parse_structured_tasks(result.stdout)
         return groups, result.stdout
     except ValueError as e:
-        setattr(e, "response_preview", result.stdout[:500])
+        e.response_preview = result.stdout[:500]  # type: ignore[attr-defined]
         raise
 
 

--- a/tests/unit/test_batch.py
+++ b/tests/unit/test_batch.py
@@ -217,6 +217,96 @@ class TestSplitTasksToGroups:
         ):
             split_tasks_to_groups("test content", task_splitter)
 
+    def test_retry_success_on_invalid_json(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.side_effect = [
+            MagicMock(exit_code=0, stdout="not valid json", stderr=""),
+            MagicMock(
+                exit_code=0,
+                stdout='[[{"description": "Task A"}, {"description": "Task B"}]]',
+                stderr="",
+            ),
+        ]
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups("test content", task_splitter)
+
+        assert len(groups) == 1
+        assert len(groups[0]) == 2
+        assert groups[0][0].description == "Task A"
+        assert groups[0][1].description == "Task B"
+        assert mock_provider.execute.call_count == 2
+
+    def test_retry_fail_raises_both_errors(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.side_effect = [
+            MagicMock(exit_code=0, stdout="first invalid json", stderr=""),
+            MagicMock(exit_code=0, stdout="second invalid json", stderr=""),
+        ]
+
+        with (
+            patch("fdsx.core.batch.get_provider", return_value=mock_provider),
+            pytest.raises(ValueError, match="Attempt 1") as exc_info,
+        ):
+            split_tasks_to_groups("test content", task_splitter)
+
+        assert "Attempt 2" in str(exc_info.value)
+        assert mock_provider.execute.call_count == 2
+
+    def test_progress_callback_messages(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.return_value = MagicMock(
+            exit_code=0,
+            stdout='[[{"description": "Task A"}]]',
+            stderr="",
+        )
+
+        progress_messages = []
+        progress_callback = progress_messages.append
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            groups = split_tasks_to_groups(
+                "test content",
+                task_splitter,
+                progress=progress_callback,
+            )
+
+        assert "Calling task splitter" in progress_messages[0]
+        assert f"Splitter produced {len(groups)} task group(s)" in progress_messages[-1]
+        assert mock_provider.execute.call_count == 1
+
+    def test_progress_callback_retry_messages(self):
+        task_splitter = TaskSplitterConfig(provider="claude", model="claude-sonnet-4-6")
+
+        mock_provider = MagicMock()
+        mock_provider.execute.side_effect = [
+            MagicMock(exit_code=0, stdout="invalid json", stderr=""),
+            MagicMock(
+                exit_code=0,
+                stdout='[[{"description": "Task A"}]]',
+                stderr="",
+            ),
+        ]
+
+        progress_messages = []
+        progress_callback = progress_messages.append
+
+        with patch("fdsx.core.batch.get_provider", return_value=mock_provider):
+            split_tasks_to_groups(
+                "test content",
+                task_splitter,
+                progress=progress_callback,
+            )
+
+        assert any("retrying" in msg.lower() for msg in progress_messages)
+        assert mock_provider.execute.call_count == 2
+
 
 class TestDisplayTaskList:
     def test_display_task_list_approve(self):


### PR DESCRIPTION
## What was done

- **JSON HYGIENE prompt block**: Added a `JSON HYGIENE:` section to `_build_task_split_prompt` instructing the LLM to escape special characters, keep code snippets short/single-line, and always emit valid JSON. Reduces parse failures at the source.

- **`_invoke_splitter_and_parse` helper**: Extracted a private helper that runs `provider.execute` and calls `_parse_structured_tasks`, attaching `response_preview` to any `ValueError` for downstream logging.

- **Retry-with-corrective-prompt in `split_tasks_to_groups`**: When the first parse fails, logs a warning with `response_preview`, builds a corrective suffix (including the parse error and truncated bad response), and retries once. If the retry also fails, raises a combined `ValueError` with both error messages.

- **`progress` callback parameter**: `split_tasks_to_groups` now accepts an optional `Callable[[str], None]`. The CLI `add --split` path passes `spinner.update` so users see real-time status during splitting.

- **Minor cleanup**: Replaced `setattr(e, "response_preview", ...)` with direct attribute assignment + `# type: ignore[attr-defined]` for cleaner style.

## Why

The task splitter LLM occasionally returns malformed JSON (unescaped quotes, multi-line code blocks, trailing commas). Rather than silently failing, this change:
1. Guides the model toward valid output upfront (prompt hygiene)
2. Recovers automatically from a single parse failure (retry with corrective prompt)
3. Surfaces progress to the user instead of showing a static spinner

## How to test

```bash
# Unit tests (retry, progress callback, prompt hygiene)
uv run pytest tests/unit/test_batch.py -v
```

Key test scenarios:
- `test_retry_success_on_invalid_json` — first call returns bad JSON, second returns valid; asserts 2 provider calls and correct groups
- `test_retry_fail_raises_both_errors` — both calls return bad JSON; asserts `ValueError` with "Attempt 1" and "Attempt 2"
- `test_progress_callback_messages` — success path emits expected progress messages
- `test_progress_callback_retry_messages` — retry path emits a "retrying" message