### PR TITLE
feat: Map state implementation (T003-T023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,33 @@ states:
     # end: true
 
   # ----------------------------------------------------------
+  # map — iterate over a list, executing an iterator sub-graph
+  # ----------------------------------------------------------
+  process_items:
+    type: map                            # (REQUIRED) literal "map"
+    items_path: $.items                  # (string, REQUIRED) JSONPath to the array to iterate over
+    iterator:                            # (map, REQUIRED) sub-graph run once per item
+      states:                           # (list, REQUIRED) ordered list of states in the iterator
+        - name: step1
+          type: task
+          provider: system
+          command: "echo {item}"         # {item} references the current array element
+          result_path: $.iter.step1
+          retry: 0
+        - name: step2
+          type: task
+          provider: system
+          command: "echo {item}"
+          result_path: $.iter.step2
+          retry: 0
+    fail_fast: true                     # (bool, default: true) stop all iterations on first failure
+    result_path: $.map_results           # (string, optional) JSONPath for the results array
+    max_iterations: 10                  # (int, optional) max times this state can be re-entered
+    hooks:                              # (optional)
+    next: after_map                     # next / end — same rules as task
+    # end: true
+
+  # ----------------------------------------------------------
   # pass — data transformation / aggregation (no execution)
   # ----------------------------------------------------------
   aggregate_reviews:
@@ -340,6 +367,16 @@ choices:
     operator: equals
     value: "approved"
     next: done
+
+# Map iteration — {item} and {item.field} reference the current element
+# {item} is the raw array element; {item.field} accesses a field on it
+iterator:
+  states:
+    - name: step1
+      type: task
+      command: "echo {item}"      # current item from the items array
+      prompt_template: |
+        Process this record: {item.name}
 ```
 
 ## Project Configuration (`.fdsx/config.yaml`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ constraint-dependencies = [
 
 [dependency-groups]
 dev = [
+    "mypy>=1.19.1",
+    "pytest>=9.0.2",
+    "ruff>=0.15.6",
     "types-pyyaml>=6.0.12.20250915",
 ]
 

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -19,6 +19,7 @@ from fdsx.models.flow import (
     ChoiceState,
     Flow,
     HookEntry,
+    MapState,
     ParallelState,
     TaskState,
     WaitState,
@@ -29,6 +30,7 @@ from .helpers import (
     _extract_result_paths,
     _get_next_state,
 )
+from .map_iteration import _create_map_node
 from .nodes import (
     _create_choice_node,
     _create_pass_node,
@@ -356,6 +358,29 @@ def compile_flow(
                 ),
             )  # type: ignore[call-overload]
             graph.add_edge(state_name, f"_{state_name}_int")
+        elif isinstance(state, MapState):
+            on_start, on_complete = _collect_state_hooks(state)
+            node = _create_map_node(
+                state_name,
+                state,
+                flow,
+                recorder,
+                config,
+                log_dir,
+                quiet,
+                on_process_start=on_process_start,
+            )
+            graph.add_node(
+                state_name,
+                _wrap_with_hooks(
+                    node,
+                    state_name,
+                    on_start,
+                    on_complete,
+                    recorder=recorder,
+                    fdsx_base_dir=fdsx_base_dir,
+                ),
+            )  # type: ignore[call-overload]
 
     for state_name, state in flow.states.items():
         if isinstance(state, ParallelState):

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -126,7 +126,7 @@ def _extract_result_paths(flow: Flow) -> list[str]:
                 paths.append(state.result_file)
         elif isinstance(state, PassState) and state.aggregate:
             paths.append(state.aggregate.result_path)
-        elif (isinstance(state, (WaitState, MapState)) and state.result_path):
+        elif isinstance(state, (WaitState, MapState)) and state.result_path:
             paths.append(state.result_path)
     return paths
 
@@ -234,7 +234,7 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
                     k = _top_level_key(str(target))
                     if k:
                         annotations.setdefault(k, Any)
-        elif (isinstance(state, (WaitState, MapState)) and state.result_path):
+        elif isinstance(state, (WaitState, MapState)) and state.result_path:
             k = _top_level_key(state.result_path)
             if k:
                 annotations.setdefault(k, Any)

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -7,6 +7,7 @@ import structlog
 from fdsx.core.config import _deep_merge
 from fdsx.models.flow import (
     Flow,
+    MapState,
     ParallelState,
     PassState,
     TaskState,
@@ -127,6 +128,8 @@ def _extract_result_paths(flow: Flow) -> list[str]:
             paths.append(state.aggregate.result_path)
         elif isinstance(state, WaitState) and state.result_path:
             paths.append(state.result_path)
+        elif isinstance(state, MapState) and state.result_path:
+            paths.append(state.result_path)
     return paths
 
 
@@ -234,6 +237,10 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
                     if k:
                         annotations.setdefault(k, Any)
         elif isinstance(state, WaitState) and state.result_path:
+            k = _top_level_key(state.result_path)
+            if k:
+                annotations.setdefault(k, Any)
+        elif isinstance(state, MapState) and state.result_path:
             k = _top_level_key(state.result_path)
             if k:
                 annotations.setdefault(k, Any)

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -126,9 +126,7 @@ def _extract_result_paths(flow: Flow) -> list[str]:
                 paths.append(state.result_file)
         elif isinstance(state, PassState) and state.aggregate:
             paths.append(state.aggregate.result_path)
-        elif isinstance(state, WaitState) and state.result_path:
-            paths.append(state.result_path)
-        elif isinstance(state, MapState) and state.result_path:
+        elif (isinstance(state, (WaitState, MapState)) and state.result_path):
             paths.append(state.result_path)
     return paths
 
@@ -236,11 +234,7 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
                     k = _top_level_key(str(target))
                     if k:
                         annotations.setdefault(k, Any)
-        elif isinstance(state, WaitState) and state.result_path:
-            k = _top_level_key(state.result_path)
-            if k:
-                annotations.setdefault(k, Any)
-        elif isinstance(state, MapState) and state.result_path:
+        elif (isinstance(state, (WaitState, MapState)) and state.result_path):
             k = _top_level_key(state.result_path)
             if k:
                 annotations.setdefault(k, Any)

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -1,0 +1,246 @@
+"""Map state iteration node factory for the compiler package."""
+
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from fdsx.core.variables import (
+    resolve_jsonpath,
+    resolve_template,
+    resolve_template_shell_safe,
+    set_jsonpath,
+)
+from fdsx.display.terminal import _sanitize_output
+from fdsx.models.flow import (
+    Flow,
+    MapState,
+)
+from fdsx.providers.base import get_provider
+
+from .helpers import (
+    _check_max_iterations,
+    _merge_provider_options,
+    _set_next_state_meta,
+)
+
+if TYPE_CHECKING:
+    from fdsx.core.config import FdsxConfig
+
+
+def _create_map_node(
+    state_name: str,
+    state: MapState,
+    flow: Flow,
+    recorder: Any = None,
+    config: "FdsxConfig | None" = None,
+    log_dir: Path | None = None,
+    quiet: bool = False,
+    on_process_start: Callable[[subprocess.Popen[str]], None] | None = None,
+) -> Callable[[dict[str, Any]], dict[str, Any]]:
+    """Create a LangGraph node function for a Map state.
+
+    Iterates over an array resolved via items_path, executing the sub-workflow
+    for each item with ${item} scoping. Results are collected in order at result_path.
+    """
+
+    def node(state_dict: dict[str, Any]) -> dict[str, Any]:
+        from fdsx.core.compiler.execution import ExecutionConfig, execute_with_retry
+        from fdsx.logging.stream_logger import StreamLogger
+
+        start_time = time.time()
+        from fdsx.display import terminal
+
+        terminal.display_state_start(
+            state_name=state_name,
+            state_type="map",
+            provider="",
+            model=None,
+        )
+
+        if recorder is not None:
+            recorder.record_state_start(state_name, "map")
+
+        items = resolve_jsonpath(state.items_path, state_dict)
+        if items is None:
+            raise RuntimeError(
+                f"Map state '{state_name}': items_path '{state.items_path}' did not resolve to a value"
+            )
+        if not isinstance(items, list):
+            raise RuntimeError(
+                f"Map state '{state_name}': items_path resolved to {type(items).__name__}, expected list"
+            )
+
+        iters = dict(state_dict.get("_state_iterations", {}))
+        iteration = iters.get(state_name, 0) + 1
+        iters[state_name] = iteration
+        _check_max_iterations(state_name, state, iteration)
+
+        if len(items) == 0:
+            new_state = set_jsonpath(state.result_path, state_dict, [])
+            new_state = _set_next_state_meta(new_state, state)
+            new_state["_state_iterations"] = iters
+            duration = time.time() - start_time
+            terminal.display_state_complete(state_name, duration)
+            if recorder is not None:
+                recorder.record_state_complete(
+                    state_name,
+                    "success",
+                    "",
+                    [state.result_path],
+                )
+            return new_state
+
+        results: list[Any] = []
+        n_failed = 0
+
+        for idx, item in enumerate(items):
+            iter_context = {**state_dict, "item": item}
+            iter_steps: dict[str, Any] = {}
+
+            for iter_state in state.iterator.states:
+                merged_options = _merge_provider_options(
+                    config,
+                    flow,
+                    iter_state.provider,
+                    iter_state.provider_options,
+                    state_name=f"{state_name}.{iter_state.name}",
+                )
+
+                resolved_prompt = resolve_template(
+                    iter_state.prompt_template or "", iter_context
+                )
+                resolved_command = resolve_template_shell_safe(
+                    iter_state.command or "", iter_context
+                )
+
+                effective_options = dict(merged_options) if merged_options else None
+                if effective_options:
+                    for key in ("system_prompt", "append_system_prompt"):
+                        if effective_options.get(key):
+                            effective_options[key] = resolve_template(
+                                effective_options[key], iter_context
+                            )
+                provider = get_provider(iter_state.provider, effective_options)
+
+                max_retries = iter_state.retry if iter_state.retry is not None else 3
+
+                stream_logger = StreamLogger(
+                    f"{state_name}.{iter_state.name}",
+                    log_dir,
+                    quiet=quiet,
+                    iteration=iteration,
+                )
+                exec_config = ExecutionConfig(
+                    provider=provider,
+                    provider_name=iter_state.provider,
+                    prompt=resolved_prompt,
+                    command=resolved_command,
+                    model=iter_state.model,
+                    timeout_seconds=iter_state.timeout_seconds,
+                    max_retries=max_retries,
+                    extract=iter_state.extract,
+                    stream_logger=stream_logger,
+                    on_process_start=on_process_start,
+                    summary_callback=stream_logger.on_summary,
+                )
+                exec_result = execute_with_retry(exec_config)
+                result = exec_result.result
+                extracted = exec_result.extracted
+                last_error = exec_result.last_error
+
+                if result.exit_code != 0:
+                    stream_logger.close()
+                    if state.fail_fast:
+                        terminal.display_state_error(
+                            state_name,
+                            f"iteration {idx} failed: {_sanitize_output(last_error)}",
+                        )
+                        if recorder is not None:
+                            recorder.record_state_error(
+                                state_name,
+                                f"iteration {idx} failed: {_sanitize_output(last_error)}",
+                            )
+                        raise RuntimeError(
+                            f"Map state '{state_name}': iteration {idx} failed: {_sanitize_output(last_error)}"
+                        )
+                    else:
+                        results.append(None)
+                        n_failed += 1
+                        break
+
+                if iter_state.extract:
+                    if extracted is None:
+                        stream_logger.close()
+                        if state.fail_fast:
+                            terminal.display_state_error(
+                                state_name,
+                                f"iteration {idx} extraction failed",
+                            )
+                            if recorder is not None:
+                                recorder.record_state_error(
+                                    state_name,
+                                    f"iteration {idx} extraction failed",
+                                )
+                            raise RuntimeError(
+                                f"Map state '{state_name}': iteration {idx} extraction failed"
+                            )
+                        else:
+                            results.append(None)
+                            n_failed += 1
+                            break
+                    iter_result = extracted
+                    iter_context = set_jsonpath(
+                        iter_state.extract.result_path, iter_context, extracted
+                    )
+                    iter_context = set_jsonpath(
+                        iter_state.result_path, iter_context, result.stdout.strip()
+                    )
+                else:
+                    iter_result = result.stdout.strip()
+                    iter_context = set_jsonpath(
+                        iter_state.result_path, iter_context, iter_result
+                    )
+
+                iter_steps[iter_state.name] = {"results": iter_result}
+
+            else:
+                last_iter_state = state.iterator.states[-1]
+                if last_iter_state.extract:
+                    last_result = resolve_jsonpath(
+                        last_iter_state.extract.result_path, iter_context
+                    )
+                    if last_result is None:
+                        last_result = resolve_jsonpath(
+                            last_iter_state.result_path, iter_context
+                        )
+                else:
+                    last_result = resolve_jsonpath(
+                        last_iter_state.result_path, iter_context
+                    )
+                results.append(last_result)
+
+        new_state = set_jsonpath(state.result_path, state_dict, results)
+        new_state = _set_next_state_meta(new_state, state)
+        new_state["_state_iterations"] = iters
+
+        duration = time.time() - start_time
+        terminal.display_state_complete(state_name, duration)
+
+        if recorder is not None:
+            recorder.record_state_complete(
+                state_name,
+                "success",
+                "",
+                [state.result_path],
+            )
+
+        if n_failed > 0:
+            raise RuntimeError(
+                f"Map state '{state_name}': {n_failed} of {len(items)} iterations failed"
+            )
+
+        return new_state
+
+    return node

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -14,7 +14,14 @@ from fdsx.core.variables import (
     resolve_template_shell_safe,
     set_jsonpath,
 )
-from fdsx.display.terminal import _sanitize_output
+from fdsx.display.terminal import (
+    _sanitize_output,
+    display_map_complete,
+    display_map_iteration,
+    display_map_iteration_complete,
+    display_map_iteration_failed,
+    display_map_start,
+)
 from fdsx.models.flow import (
     Flow,
     MapState,
@@ -103,17 +110,6 @@ def _create_map_node(
         from fdsx.logging.stream_logger import StreamLogger
 
         start_time = time.time()
-        from fdsx.display import terminal
-
-        terminal.display_state_start(
-            state_name=state_name,
-            state_type="map",
-            provider="",
-            model=None,
-        )
-
-        if recorder is not None:
-            recorder.record_state_start(state_name, "map")
 
         items = resolve_jsonpath(state.items_path, state_dict)
         if items is None:
@@ -130,18 +126,22 @@ def _create_map_node(
         iters[state_name] = iteration
         _check_max_iterations(state_name, state, iteration)
 
+        display_map_start(state_name, len(items))
+        if recorder is not None:
+            recorder.record_map_start(state_name, len(items))
+
         if len(items) == 0:
             new_state = set_jsonpath(state.result_path, state_dict, [])
             new_state = _set_next_state_meta(new_state, state)
             new_state["_state_iterations"] = iters
             duration = time.time() - start_time
-            terminal.display_state_complete(state_name, duration)
+            display_map_complete(state_name, 0, 0, duration)
             if recorder is not None:
-                recorder.record_state_complete(
+                recorder.record_map_complete(
                     state_name,
                     "success",
-                    "",
-                    [state.result_path],
+                    0,
+                    0,
                 )
             return new_state
 
@@ -160,6 +160,8 @@ def _create_map_node(
         for idx, item in enumerate(items):
             if idx < start_idx:
                 continue
+            display_map_iteration(state_name, idx, len(items))
+            iter_start_time = time.time()
             iter_context = {**state_dict, "item": item}
             iter_steps: dict[str, Any] = {}
 
@@ -217,11 +219,19 @@ def _create_map_node(
                 if result.exit_code != 0:
                     stream_logger.close()
                     if state.fail_fast:
-                        terminal.display_state_error(
+                        display_map_iteration_failed(
                             state_name,
+                            idx,
+                            len(items),
                             f"iteration {idx} failed: {_sanitize_output(last_error)}",
                         )
                         if recorder is not None:
+                            recorder.record_map_iteration_complete(
+                                state_name,
+                                idx,
+                                "error",
+                                _sanitize_output(last_error) or "",
+                            )
                             recorder.record_state_error(
                                 state_name,
                                 f"iteration {idx} failed: {_sanitize_output(last_error)}",
@@ -230,6 +240,19 @@ def _create_map_node(
                             f"Map state '{state_name}': iteration {idx} failed: {_sanitize_output(last_error)}"
                         )
                     else:
+                        display_map_iteration_failed(
+                            state_name,
+                            idx,
+                            len(items),
+                            f"iteration {idx} failed: {_sanitize_output(last_error)}",
+                        )
+                        if recorder is not None:
+                            recorder.record_map_iteration_complete(
+                                state_name,
+                                idx,
+                                "error",
+                                _sanitize_output(last_error) or "",
+                            )
                         results.append(None)
                         n_failed += 1
                         _write_map_progress(run_dir, state_name, idx + 1, results)
@@ -239,11 +262,19 @@ def _create_map_node(
                     if extracted is None:
                         stream_logger.close()
                         if state.fail_fast:
-                            terminal.display_state_error(
+                            display_map_iteration_failed(
                                 state_name,
+                                idx,
+                                len(items),
                                 f"iteration {idx} extraction failed",
                             )
                             if recorder is not None:
+                                recorder.record_map_iteration_complete(
+                                    state_name,
+                                    idx,
+                                    "error",
+                                    "extraction failed",
+                                )
                                 recorder.record_state_error(
                                     state_name,
                                     f"iteration {idx} extraction failed",
@@ -252,6 +283,19 @@ def _create_map_node(
                                 f"Map state '{state_name}': iteration {idx} extraction failed"
                             )
                         else:
+                            display_map_iteration_failed(
+                                state_name,
+                                idx,
+                                len(items),
+                                f"iteration {idx} extraction failed",
+                            )
+                            if recorder is not None:
+                                recorder.record_map_iteration_complete(
+                                    state_name,
+                                    idx,
+                                    "error",
+                                    "extraction failed",
+                                )
                             results.append(None)
                             n_failed += 1
                             _write_map_progress(run_dir, state_name, idx + 1, results)
@@ -287,20 +331,28 @@ def _create_map_node(
                     )
                 results.append(last_result)
                 _write_map_progress(run_dir, state_name, idx + 1, results)
+                display_map_iteration_complete(state_name, idx, len(items), duration=time.time() - iter_start_time)
+                if recorder is not None:
+                    recorder.record_map_iteration_complete(
+                        state_name,
+                        idx,
+                        "success",
+                        str(last_result) if last_result is not None else "",
+                    )
 
         new_state = set_jsonpath(state.result_path, state_dict, results)
         new_state = _set_next_state_meta(new_state, state)
         new_state["_state_iterations"] = iters
 
         duration = time.time() - start_time
-        terminal.display_state_complete(state_name, duration)
+        display_map_complete(state_name, len(items), n_failed, duration)
 
         if recorder is not None:
-            recorder.record_state_complete(
+            recorder.record_map_complete(
                 state_name,
-                "success",
-                "",
-                [state.result_path],
+                "success" if n_failed == 0 else "error",
+                len(results),
+                n_failed,
             )
 
         if n_failed > 0:

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -331,7 +331,9 @@ def _create_map_node(
                     )
                 results.append(last_result)
                 _write_map_progress(run_dir, state_name, idx + 1, results)
-                display_map_iteration_complete(state_name, idx, len(items), duration=time.time() - iter_start_time)
+                display_map_iteration_complete(
+                    state_name, idx, len(items), duration=time.time() - iter_start_time
+                )
                 if recorder is not None:
                     recorder.record_map_iteration_complete(
                         state_name,

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -1,5 +1,7 @@
 """Map state iteration node factory for the compiler package."""
 
+import json
+import os
 import subprocess
 import time
 from collections.abc import Callable
@@ -27,6 +29,57 @@ from .helpers import (
 
 if TYPE_CHECKING:
     from fdsx.core.config import FdsxConfig
+
+_MAP_PROGRESS_FILENAME = "progress.json"
+
+
+def _safe_progress_dir(run_dir: str, state_name: str) -> Path | None:
+    """Return the progress directory, or None if the path escapes run_dir."""
+    if not run_dir:
+        return None
+    base = Path(run_dir).resolve()
+    candidate = (base / state_name).resolve()
+    if not str(candidate).startswith(str(base) + "/") and candidate != base:
+        return None
+    return candidate
+
+
+def _read_map_progress(run_dir: str, state_name: str) -> dict[str, Any] | None:
+    """Read map progress from checkpoint file.
+
+    Returns None if no progress file exists or reading fails.
+    """
+    progress_dir = _safe_progress_dir(run_dir, state_name)
+    if progress_dir is None:
+        return None
+    progress_file = progress_dir / _MAP_PROGRESS_FILENAME
+    try:
+        with progress_file.open() as f:
+            data = json.load(f)
+            if isinstance(data, dict):
+                return data
+            return None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _write_map_progress(
+    run_dir: str, state_name: str, completed_iterations: int, results: list[Any]
+) -> None:
+    """Write map progress to checkpoint file atomically."""
+    progress_dir = _safe_progress_dir(run_dir, state_name)
+    if progress_dir is None:
+        return
+    progress_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    temp_file = progress_dir / f"{_MAP_PROGRESS_FILENAME}.tmp"
+    progress_data = {
+        "completed_iterations": completed_iterations,
+        "results": results,
+    }
+    fd = os.open(str(temp_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump(progress_data, f)
+    temp_file.replace(progress_dir / _MAP_PROGRESS_FILENAME)
 
 
 def _create_map_node(
@@ -95,7 +148,18 @@ def _create_map_node(
         results: list[Any] = []
         n_failed = 0
 
+        run_dir = state_dict.get("_meta", {}).get("run_dir", "") or ""
+        progress = _read_map_progress(run_dir, state_name)
+        if progress and len(progress.get("results", [])) <= len(items):
+            start_idx = progress["completed_iterations"]
+            results = list(progress["results"])
+        else:
+            start_idx = 0
+            results = []
+
         for idx, item in enumerate(items):
+            if idx < start_idx:
+                continue
             iter_context = {**state_dict, "item": item}
             iter_steps: dict[str, Any] = {}
 
@@ -168,6 +232,7 @@ def _create_map_node(
                     else:
                         results.append(None)
                         n_failed += 1
+                        _write_map_progress(run_dir, state_name, idx + 1, results)
                         break
 
                 if iter_state.extract:
@@ -189,6 +254,7 @@ def _create_map_node(
                         else:
                             results.append(None)
                             n_failed += 1
+                            _write_map_progress(run_dir, state_name, idx + 1, results)
                             break
                     iter_result = extracted
                     iter_context = set_jsonpath(
@@ -220,6 +286,7 @@ def _create_map_node(
                         last_iter_state.result_path, iter_context
                     )
                 results.append(last_result)
+                _write_map_progress(run_dir, state_name, idx + 1, results)
 
         new_state = set_jsonpath(state.result_path, state_dict, results)
         new_state = _set_next_state_meta(new_state, state)

--- a/src/fdsx/core/engine/tasks_dir.py
+++ b/src/fdsx/core/engine/tasks_dir.py
@@ -31,16 +31,16 @@ def load_tasks_dir(tasks_dir: Path) -> list[tuple[Path, TaskFile]]:
 
     Raises:
         FileNotFoundError: If the tasks directory does not exist.
-        ValueError: If no .yaml files are found.
+        ValueError: If no .yaml or .yml files are found.
     """
     if not tasks_dir.exists():
         raise FileNotFoundError(f"Tasks directory not found: {tasks_dir}")
     if tasks_dir.is_symlink():
         raise ValueError(f"Tasks directory must not be a symlink: {tasks_dir}")
 
-    yaml_files = sorted(tasks_dir.glob("*.yaml"))
+    yaml_files = sorted([*tasks_dir.glob("*.yaml"), *tasks_dir.glob("*.yml")])
     if not yaml_files:
-        raise ValueError(f"No .yaml files found in {tasks_dir}")
+        raise ValueError(f"No .yaml or .yml files found in {tasks_dir}")
 
     result: list[tuple[Path, TaskFile]] = []
     for fp in yaml_files:

--- a/src/fdsx/core/graph_utils.py
+++ b/src/fdsx/core/graph_utils.py
@@ -1,5 +1,6 @@
 from fdsx.models.flow import (
     ChoiceState,
+    MapState,
     ParallelState,
     PassState,
     State,
@@ -33,7 +34,7 @@ def get_next_states(state: State, include_end_sentinel: bool = False) -> set[str
             result.add(state.default)
         if include_end_sentinel and state.default is None:
             result.add(END_SENTINEL)
-    elif isinstance(state, (ParallelState, PassState, WaitState)):
+    elif isinstance(state, (ParallelState, PassState, WaitState, MapState)):
         if state.next:
             result.add(state.next)
         if include_end_sentinel and state.end:

--- a/src/fdsx/core/loader.py
+++ b/src/fdsx/core/loader.py
@@ -168,6 +168,34 @@ def _resolve_prompt_files(flow: Flow, yaml_path: Path) -> tuple[Flow, list[str]]
                         errors.append(
                             f"Parallel branch {branch_idx}: failed to read prompt_file: {e}"
                         )
+        elif state_data.get("type") == "map":
+            for iter_state in state_data.get("iterator", {}).get("states", []):
+                if iter_state.get("prompt_file"):
+                    prompt_path = (yaml_dir / iter_state["prompt_file"]).resolve()
+                    path_error = _validate_prompt_file_path(
+                        iter_state["prompt_file"],
+                        prompt_path,
+                        yaml_dir,
+                        f"Map '{state_name}' iterator state '{iter_state['name']}'",
+                    )
+                    if path_error:
+                        errors.append(path_error)
+                        continue
+                    if not prompt_path.exists():
+                        errors.append(
+                            f"Map '{state_name}' iterator state '{iter_state['name']}': "
+                            f"prompt_file not found: {iter_state['prompt_file']}"
+                        )
+                        continue
+                    try:
+                        with prompt_path.open() as f:
+                            iter_state["prompt_template"] = f.read()
+                        del iter_state["prompt_file"]
+                    except Exception as e:
+                        errors.append(
+                            f"Map '{state_name}' iterator state '{iter_state['name']}': "
+                            f"failed to read prompt_file: {e}"
+                        )
 
     if errors:
         return flow, errors

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -405,7 +405,9 @@ def analyze_variable_references(
                     if var_path.startswith("$."):
                         var_path = var_path[2:]
                     iter_prompt_vars.add(var_path)
-            iter_prompt_vars = {v for v in iter_prompt_vars if v != "item" and not v.startswith("item.")}
+            iter_prompt_vars = {
+                v for v in iter_prompt_vars if v != "item" and not v.startswith("item.")
+            }
             prompt_vars = iter_prompt_vars
             items_path = state.items_path
             if items_path.startswith("$."):

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -238,7 +238,7 @@ def analyze_variable_references(
 
     def get_prompt_variables(state: State | Branch) -> set[str]:
         variables: set[str] = set()
-        from fdsx.models.flow import Branch, PassState, TaskState
+        from fdsx.models.flow import Branch, MapState, PassState, TaskState
 
         if isinstance(state, (TaskState, Branch)):
             prompt = state.prompt_template or ""
@@ -251,6 +251,18 @@ def analyze_variable_references(
                     if isinstance(val, str):
                         parts.append(val)
             prompt = " ".join(parts)
+        elif isinstance(state, MapState):
+            for iter_state in state.iterator.states:
+                iter_prompt = iter_state.prompt_template or ""
+                iter_command = iter_state.command or ""
+                prompt = iter_prompt + " " + iter_command
+                pattern = re.compile(r"\{([^}]+)\}")
+                for match in pattern.finditer(prompt):
+                    var_path = match.group(1)
+                    if var_path.startswith("$."):
+                        var_path = var_path[2:]
+                    variables.add(var_path)
+            return variables
         else:
             return variables
 
@@ -266,7 +278,7 @@ def analyze_variable_references(
 
     def get_result_paths(state: State) -> set[str]:
         result_paths: set[str] = set()
-        from fdsx.models.flow import ParallelState, PassState, TaskState
+        from fdsx.models.flow import MapState, ParallelState, PassState, TaskState
 
         if isinstance(state, TaskState):
             if state.result_path:
@@ -306,6 +318,12 @@ def analyze_variable_references(
                     result_paths.add(path)
             if state.aggregate and state.aggregate.result_path:
                 path = state.aggregate.result_path
+                if path.startswith("$."):
+                    path = path[2:]
+                result_paths.add(path)
+        elif isinstance(state, MapState):
+            if state.result_path:
+                path = state.result_path
                 if path.startswith("$."):
                     path = path[2:]
                 result_paths.add(path)
@@ -372,6 +390,34 @@ def analyze_variable_references(
         if isinstance(state, ParallelState):
             for branch in state.branches:
                 prompt_vars.update(get_prompt_variables(branch))
+
+        from fdsx.models.flow import MapState
+
+        if isinstance(state, MapState):
+            iter_prompt_vars: set[str] = set()
+            iter_pattern = re.compile(r"\{([^}]+)\}")
+            for iter_state in state.iterator.states:
+                iter_prompt = iter_state.prompt_template or ""
+                iter_command = iter_state.command or ""
+                iter_text = iter_prompt + " " + iter_command
+                for match in iter_pattern.finditer(iter_text):
+                    var_path = match.group(1)
+                    if var_path.startswith("$."):
+                        var_path = var_path[2:]
+                    iter_prompt_vars.add(var_path)
+            iter_prompt_vars = {v for v in iter_prompt_vars if v != "item" and not v.startswith("item.")}
+            prompt_vars = iter_prompt_vars
+            items_path = state.items_path
+            if items_path.startswith("$."):
+                items_path = items_path[2:]
+            items_root = items_path.split("[")[0].split(".")[0]
+            if items_root and not _is_var_satisfied(
+                items_root, available_vars.get(state_name, set())
+            ):
+                errors.append(
+                    f"State '{state_name}' references variable '{items_root}' "
+                    f"in items_path but no preceding state sets a result_path for it"
+                )
 
         for var in prompt_vars:
             if (

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -209,6 +209,95 @@ def display_branch_failed(
     print(line, file=sys.stderr)
 
 
+def display_map_start(state_name: str, item_count: int) -> None:
+    """Display map state start in terminal.
+
+    Args:
+        state_name: Name of the map state
+        item_count: Number of items to iterate over
+    """
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    line = f"[{timestamp}] ▶ {state_name} (map, {item_count} items)"
+    print(line, file=sys.stderr)
+
+
+def display_map_iteration(
+    state_name: str,
+    index: int,
+    total: int,
+) -> None:
+    """Display map iteration start in terminal.
+
+    Args:
+        state_name: Name of the parent map state
+        index: Index of the iteration (0-based)
+        total: Total number of iterations
+    """
+    display_index = index + 1
+    line = f"  [iter-{display_index}/{total}] ⏳ running..."
+    print(line, file=sys.stderr)
+
+
+def display_map_iteration_complete(
+    state_name: str,
+    index: int,
+    total: int,
+    duration: float | None = None,
+) -> None:
+    """Display map iteration completion in terminal.
+
+    Args:
+        state_name: Name of the parent map state
+        index: Index of the iteration (0-based)
+        total: Total number of iterations
+        duration: Duration in seconds (optional, for display)
+    """
+    display_index = index + 1
+    duration_info = f" ({int(duration)}s)" if duration is not None else ""
+    line = f"  [iter-{display_index}/{total}] ✓ completed{duration_info}"
+    print(line, file=sys.stderr)
+
+
+def display_map_iteration_failed(
+    state_name: str,
+    index: int,
+    total: int,
+    error: str,
+) -> None:
+    """Display map iteration failure in terminal.
+
+    Args:
+        state_name: Name of the parent map state
+        index: Index of the iteration (0-based)
+        total: Total number of iterations
+        error: Error message
+    """
+    display_index = index + 1
+    sanitized_error = _sanitize_output(error)
+    line = f"  [iter-{display_index}/{total}] ✗ failed"
+    print(line, file=sys.stderr)
+    print(f"  Error: {sanitized_error}", file=sys.stderr)
+
+
+def display_map_complete(
+    state_name: str,
+    total: int,
+    failed: int,
+    duration: float,
+) -> None:
+    """Display map state completion in terminal.
+
+    Args:
+        state_name: Name of the map state
+        total: Total number of items
+        failed: Number of failed iterations
+        duration: Duration of execution in seconds
+    """
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    line = f"[{timestamp}] ✓ {state_name} completed ({total} items, {failed} failed, {int(duration)}s)"
+    print(line, file=sys.stderr)
+
+
 def display_parallel_results(
     state_name: str,
     branch_results: list[dict[str, Any]],

--- a/src/fdsx/logging/recorder.py
+++ b/src/fdsx/logging/recorder.py
@@ -122,6 +122,96 @@ class RunRecorder:
 
         self._current_state = None
 
+    def record_map_start(self, state_name: str, item_count: int) -> None:
+        """Record map state start with item count metadata.
+
+        Args:
+            state_name: Name of the map state
+            item_count: Number of items to iterate over
+        """
+        self._current_state = {
+            "name": state_name,
+            "type": "map",
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "item_count": item_count,
+            "iterations": [],
+        }
+        self.states.append(self._current_state)
+
+    def record_map_iteration_complete(
+        self,
+        state_name: str,
+        index: int,
+        status: str,
+        output: str,
+    ) -> None:
+        """Record a single map iteration result.
+
+        Args:
+            state_name: Name of the parent map state
+            index: Index of the iteration (0-based)
+            status: Status of the iteration ("success" or "error")
+            output: Output from the iteration
+        """
+        state = self._find_state_by_name(state_name)
+        if state is None:
+            return
+
+        if "iterations" not in state:
+            state["iterations"] = []
+
+        output_preview = output[:OUTPUT_PREVIEW_MAX_LENGTH] if output else ""
+
+        state["iterations"].append(
+            {
+                "index": index,
+                "status": status,
+                "output_preview": output_preview,
+            }
+        )
+
+    def record_map_complete(
+        self,
+        state_name: str,
+        status: str,
+        results_count: int,
+        failed_count: int,
+    ) -> None:
+        """Finalize a map state entry with results summary.
+
+        Args:
+            state_name: Name of the map state
+            status: Overall status ("success" or "error")
+            results_count: Number of successful results
+            failed_count: Number of failed iterations
+        """
+        state = self._find_state_by_name(state_name)
+        if state is None:
+            state = {
+                "name": state_name,
+                "type": "map",
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self.states.append(state)
+
+        completed_at = datetime.now(timezone.utc).isoformat()
+        started_at = state.get("started_at", completed_at)
+
+        try:
+            start_dt = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+            end_dt = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+            duration_seconds = int((end_dt - start_dt).total_seconds())
+        except (ValueError, TypeError):
+            duration_seconds = 0
+
+        state["completed_at"] = completed_at
+        state["duration_seconds"] = duration_seconds
+        state["status"] = status
+        state["results_count"] = results_count
+        state["failed_count"] = failed_count
+
+        self._current_state = None
+
     def finalize(
         self, final_variables: dict[str, Any], status: str = "completed"
     ) -> None:

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -416,8 +416,140 @@ class WaitState(BaseModel):
         return self
 
 
+class IteratorTaskState(BaseModel):
+    """Task state for use inside iterator definitions."""
+
+    type: Literal["task"] = "task"
+    name: str = Field(..., description="State name within the iterator")
+    provider: str = Field(..., description="Provider: claude|opencode|codex|system")
+    model: str | None = Field(default=None, description="Model name")
+    prompt_template: str | None = Field(
+        default=None, description="Prompt template (exclusive with prompt_file)"
+    )
+    prompt_file: str | None = Field(
+        default=None, description="Prompt file path (exclusive with prompt_template)"
+    )
+    command: str | None = Field(default=None, description="Command for system provider")
+    result_path: str = Field(..., description="JSONPath for result")
+    result_file: str | None = Field(
+        default=None,
+        description="Top-level JSONPath variable to store the absolute path of a result file",
+    )
+    extract: ExtractRule | None = Field(default=None, description="Output extraction")
+    retry: int = Field(default=3, description="Retry count")
+    timeout_seconds: int | None = Field(default=None, description="Timeout in seconds")
+    provider_options: dict[str, Any] | None = Field(
+        default=None, description="Per-task provider option overrides"
+    )
+
+    @field_validator("result_file")
+    @classmethod
+    def validate_result_file(cls, v: str | None) -> str | None:
+        return _validate_result_file(v)
+
+    @model_validator(mode="after")
+    def validate_provider_fields(self) -> "IteratorTaskState":
+        _validate_provider_fields(
+            self.provider,
+            self.prompt_template,
+            self.prompt_file,
+            self.command,
+            self.model,
+        )
+        return self
+
+    @model_validator(mode="after")
+    def validate_prompt_exclusive(self) -> "IteratorTaskState":
+        if self.prompt_template is not None and self.prompt_file is not None:
+            raise ValueError("prompt_template and prompt_file are mutually exclusive")
+        return self
+
+    @model_validator(mode="after")
+    def validate_extract_path_no_overlap(self) -> "IteratorTaskState":
+        if self.extract is None:
+            return self
+        rp = self.result_path
+        if rp.startswith("$."):
+            rp = rp[2:]
+        ep = self.extract.result_path
+        if ep.startswith("$."):
+            ep = ep[2:]
+        rp_parts = parse_jsonpath(rp)
+        ep_parts = parse_jsonpath(ep)
+        min_len = min(len(rp_parts), len(ep_parts))
+        if rp_parts[:min_len] == ep_parts[:min_len]:
+            raise ValueError(
+                f"result_path '{self.result_path}' and extract.result_path "
+                f"'{self.extract.result_path}' must not overlap"
+            )
+        return self
+
+
+class IteratorDef(BaseModel):
+    """Iterator sub-workflow definition for Map state."""
+
+    states: list[IteratorTaskState] = Field(
+        ..., min_length=1, description="Ordered list of iterator states"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_non_task_types(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        states = values.get("states", [])
+        if not isinstance(states, list):
+            return values
+        for idx, state in enumerate(states):
+            if isinstance(state, dict):
+                state_type = state.get("type")
+                if state_type is not None and state_type != "task":
+                    raise ValueError(
+                        f"iterator states must have type 'task', "
+                        f"got type '{state_type}' at position {idx}"
+                    )
+        return values
+
+    @model_validator(mode="after")
+    def validate_unique_names(self) -> "IteratorDef":
+        names = [s.name for s in self.states]
+        if len(names) != len(set(names)):
+            seen: set[str] = set()
+            for name in names:
+                if name in seen:
+                    raise ValueError(f"duplicate iterator state name '{name}'")
+                seen.add(name)
+        return self
+
+
+class MapState(BaseModel):
+    """Map state - iterates over an array and executes a sub-workflow for each item."""
+
+    type: Literal["map"] = "map"
+    items_path: str = Field(..., description="JSONPath to input array")
+    iterator: IteratorDef = Field(
+        ..., description="Sub-workflow to execute for each item"
+    )
+    result_path: str = Field(..., description="JSONPath for results array")
+    fail_fast: bool = Field(default=True, description="Stop on first failure")
+    max_iterations: int | None = Field(
+        default=None, ge=1, description="Max times this state can be entered"
+    )
+    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
+    next: str | None = Field(
+        default=None, description="Next state (exclusive with end)"
+    )
+    end: bool | None = Field(default=None, description="End flow (exclusive with next)")
+
+    @model_validator(mode="after")
+    def validate_next_end_exclusive(self) -> "MapState":
+        if self.next is not None and self.end is not None:
+            raise ValueError("next and end are mutually exclusive")
+        return self
+
+
 State = Annotated[
-    TaskState | ChoiceState | ParallelState | PassState | WaitState,
+    TaskState | ChoiceState | ParallelState | PassState | WaitState | MapState,
     Field(discriminator="type"),
 ]
 

--- a/tests/e2e/test_cli_map_flow.py
+++ b/tests/e2e/test_cli_map_flow.py
@@ -1,0 +1,24 @@
+from tests.e2e.cli_test_utils import fixture_path, run_fdsx
+
+
+class TestCLIMapFlow:
+    """End-to-end CLI tests for map flow type."""
+
+    def test_map_basic_yaml_validates(self):
+        """Test map_basic.yaml validates successfully."""
+        result = run_fdsx(["validate", fixture_path("map_basic.yaml")])
+        assert result.returncode == 0
+
+    def test_map_basic_yaml_runs(self):
+        """Test map_basic.yaml runs successfully via CLI."""
+        result = run_fdsx(["run", fixture_path("map_basic.yaml")])
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        # FR-1.3: No JSON on stdout
+        assert result.stdout == ""
+        # FR-1.1: Completion message on stderr
+        assert "completed successfully" in result.stderr
+        # Map-specific: verify iteration actually happened
+        assert "map, 3 items" in result.stderr
+        assert "iter-1/3" in result.stderr
+        assert "iter-3/3" in result.stderr
+        assert "3 items, 0 failed" in result.stderr

--- a/tests/fixtures/map_basic.yaml
+++ b/tests/fixtures/map_basic.yaml
@@ -1,0 +1,42 @@
+name: Map Basic Flow
+description: Basic map state with 3 items and 2-state iterator
+start_at: setup_items
+version: '1.0'
+
+states:
+  setup_items:
+    type: pass
+    parameters:
+      $.items:
+        - item1
+        - item2
+        - item3
+    next: map_state
+
+  map_state:
+    type: map
+    items_path: $.items
+    iterator:
+      states:
+        - name: step1
+          type: task
+          provider: system
+          command: echo "step1-{item}"
+          result_path: $.iter.step1
+          retry: 0
+        - name: step2
+          type: task
+          provider: system
+          command: echo "step2-{item}"
+          result_path: $.iter.step2
+          retry: 0
+    result_path: $.map_results
+    fail_fast: true
+    next: after_map
+
+  after_map:
+    type: task
+    provider: system
+    command: echo "done"
+    result_path: $.after_result
+    end: true

--- a/tests/fixtures/map_empty_items.yaml
+++ b/tests/fixtures/map_empty_items.yaml
@@ -1,0 +1,33 @@
+name: Map Empty Items Flow
+description: Map state with empty items array - should continue to next state
+start_at: setup_items
+version: '1.0'
+
+states:
+  setup_items:
+    type: pass
+    parameters:
+      $.items: []
+    next: map_state
+
+  map_state:
+    type: map
+    items_path: $.items
+    iterator:
+      states:
+        - name: step1
+          type: task
+          provider: system
+          command: echo "should-not-run"
+          result_path: $.iter.step1
+          retry: 0
+    result_path: $.map_results
+    fail_fast: true
+    next: after_map
+
+  after_map:
+    type: task
+    provider: system
+    command: echo "map-completed"
+    result_path: $.after_result
+    end: true

--- a/tests/fixtures/map_fail_fast_false.yaml
+++ b/tests/fixtures/map_fail_fast_false.yaml
@@ -1,0 +1,38 @@
+name: Map Fail Fast False Flow
+description: Map state with fail_fast false to test partial failure handling
+start_at: setup_items
+version: '1.0'
+
+states:
+  setup_items:
+    type: pass
+    parameters:
+      $.items:
+        - ok1
+        - fail
+        - ok2
+    next: map_state
+
+  map_state:
+    type: map
+    items_path: $.items
+    iterator:
+      states:
+        - name: step1
+          type: task
+          provider: system
+          command: >
+            if [ "{item}" = "fail" ]; then exit 1; fi
+            echo "ok-{item}"
+          result_path: $.iter.step1
+          retry: 0
+    result_path: $.map_results
+    fail_fast: false
+    next: after_map
+
+  after_map:
+    type: task
+    provider: system
+    command: echo "done"
+    result_path: $.after_result
+    end: true

--- a/tests/fixtures/map_inside_parallel.yaml
+++ b/tests/fixtures/map_inside_parallel.yaml
@@ -1,0 +1,40 @@
+name: Map Inside Parallel Flow
+description: Map state used after parallel state - tests no interference between parallel and map
+start_at: setup_items
+version: '1.0'
+
+states:
+  setup_items:
+    type: pass
+    parameters:
+      $.items:
+        - x
+        - y
+    next: parallel_state
+
+  parallel_state:
+    type: parallel
+    branches:
+      - provider: system
+        command: echo "alpha"
+        retry: 0
+      - provider: system
+        command: echo "beta"
+        retry: 0
+    result_path: $.parallel_results
+    next: map_state
+
+  map_state:
+    type: map
+    items_path: $.items
+    iterator:
+      states:
+        - name: process
+          type: task
+          provider: system
+          command: echo "mapped-{item}"
+          result_path: $.iter.process
+          retry: 0
+    result_path: $.map_results
+    fail_fast: true
+    end: true

--- a/tests/integration/test_map_checkpoint.py
+++ b/tests/integration/test_map_checkpoint.py
@@ -1,0 +1,459 @@
+"""Integration tests for Map state checkpointing and resume."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from fdsx.core import engine
+from fdsx.providers.system import SystemProvider
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+def write_flow_to_file(flow_obj, path: Path):
+    """Serialize a Flow Pydantic model to a YAML file."""
+    data = flow_obj.model_dump(mode="json")
+    with path.open("w") as f:
+        yaml.safe_dump(data, f)
+
+
+class TestMapCheckpoint:
+    def test_map_progress_file_written_per_iteration(self, temp_dir):
+        """Progress file is written after each successful iteration."""
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+            PassState,
+        )
+
+        flow = Flow(
+            name="Map Progress Test",
+            description="Test progress file is written",
+            start_at="setup",
+            states={
+                "setup": PassState(
+                    type="pass",
+                    parameters={"$.items": ["item1", "item2", "item3"]},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo_item",
+                                provider="system",
+                                command='echo "result-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    fail_fast=True,
+                    next="after_map",
+                ),
+                "after_map": PassState(
+                    type="pass",
+                    parameters={"$.after_result": "done"},
+                    end=True,
+                ),
+            },
+        )
+
+        flow_path = temp_dir / "map_progress_test.yaml"
+        write_flow_to_file(flow, flow_path)
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-map-progress"
+
+        call_count = 0
+        original_execute = SystemProvider().execute
+
+        def stop_after_third_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                raise Exception("simulated interruption after 2 items")
+            return original_execute(*args, **kwargs)
+
+        with (
+            pytest.raises(RuntimeError, match="simulated interruption"),
+            patch.object(SystemProvider, "execute", side_effect=stop_after_third_call),
+        ):
+            engine.run_flow(
+                flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        progress_file = base_dir / "runs" / thread_id / "map_state" / "progress.json"
+        assert progress_file.exists(), f"Progress file not found at {progress_file}"
+
+        with progress_file.open() as f:
+            progress = json.load(f)
+
+        assert progress["completed_iterations"] == 2
+        assert len(progress["results"]) == 2
+        assert progress["results"][0] == "result-item1"
+        assert progress["results"][1] == "result-item2"
+
+    def test_map_resume_skips_completed_iterations(self, temp_dir):
+        """Resume re-runs only incomplete iterations, not already-completed ones."""
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+            PassState,
+        )
+
+        flow = Flow(
+            name="Map Resume Test",
+            description="Test resume skips completed",
+            start_at="setup",
+            states={
+                "setup": PassState(
+                    type="pass",
+                    parameters={"$.items": ["item1", "item2", "item3"]},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo_item",
+                                provider="system",
+                                command='echo "result-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    fail_fast=True,
+                    next="after_map",
+                ),
+                "after_map": PassState(
+                    type="pass",
+                    parameters={"$.after_result": "done"},
+                    end=True,
+                ),
+            },
+        )
+
+        flow_path = temp_dir / "map_resume_test.yaml"
+        write_flow_to_file(flow, flow_path)
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-map-resume"
+
+        call_count = 0
+        original_execute = SystemProvider().execute
+
+        def stop_after_third_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                raise Exception("simulated interruption after 2 items")
+            return original_execute(*args, **kwargs)
+
+        with (
+            pytest.raises(RuntimeError, match="simulated interruption"),
+            patch.object(SystemProvider, "execute", side_effect=stop_after_third_call),
+        ):
+            engine.run_flow(
+                flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        resume_call_count = 0
+        original_execute_2 = SystemProvider().execute
+
+        def count_resume_calls(*args, **kwargs):
+            nonlocal resume_call_count
+            resume_call_count += 1
+            return original_execute_2(*args, **kwargs)
+
+        with patch.object(SystemProvider, "execute", side_effect=count_resume_calls):
+            result = engine.resume_flow(
+                thread_id,
+                base_dir,
+                flow_path,
+            )
+
+        assert result["results"] is not None
+        assert len(result["results"]) == 3
+        assert result["results"][0] == "result-item1"
+        assert result["results"][1] == "result-item2"
+        assert result["results"][2] == "result-item3"
+
+        progress_file = base_dir / "runs" / thread_id / "map_state" / "progress.json"
+        assert progress_file.exists()
+        with progress_file.open() as f:
+            progress = json.load(f)
+        assert progress["completed_iterations"] == 3, (
+            "After resume, progress should show all 3 iterations completed"
+        )
+
+        assert resume_call_count == 1, (
+            f"Expected only 1 provider call on resume (item3), got {resume_call_count}"
+        )
+
+    def test_map_resume_merges_results_correctly(self, temp_dir):
+        """Resume produces correct final results combining completed and new."""
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+            PassState,
+        )
+
+        flow = Flow(
+            name="Map Merge Test",
+            description="Test results merge on resume",
+            start_at="setup",
+            states={
+                "setup": PassState(
+                    type="pass",
+                    parameters={"$.items": ["a", "b", "c", "d"]},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="process",
+                                provider="system",
+                                command='echo "out-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    fail_fast=True,
+                    end=True,
+                ),
+            },
+        )
+
+        flow_path = temp_dir / "map_merge_test.yaml"
+        write_flow_to_file(flow, flow_path)
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-map-merge"
+
+        call_count = 0
+        original_execute = SystemProvider().execute
+
+        def stop_after_fourth_call(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 4:
+                raise Exception("simulated interruption after 3 items")
+            return original_execute(*args, **kwargs)
+
+        with (
+            pytest.raises(RuntimeError, match="simulated interruption"),
+            patch.object(SystemProvider, "execute", side_effect=stop_after_fourth_call),
+        ):
+            engine.run_flow(
+                flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        result = engine.resume_flow(
+            thread_id,
+            base_dir,
+            flow_path,
+        )
+
+        assert result["results"] is not None
+        assert len(result["results"]) == 4
+        assert result["results"][0] == "out-a"
+        assert result["results"][1] == "out-b"
+        assert result["results"][2] == "out-c"
+        assert result["results"][3] == "out-d"
+
+    def test_map_progress_file_not_written_when_run_dir_empty(self, temp_dir):
+        """When run_dir is empty (direct invoke), no progress file is written."""
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+        )
+
+        flow = Flow(
+            name="Direct Invoke Test",
+            description="Test without run_dir",
+            start_at="map_state",
+            states={
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo",
+                                provider="system",
+                                command='echo "result-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+        initial_state = {
+            "items": ["x", "y"],
+            "_meta": {
+                "thread_id": "test",
+                "flow_path": "",
+                "flow_name": "test",
+                "run_dir": "",
+            },
+            "_state_iterations": {},
+        }
+
+        result = compiled.graph.invoke(initial_state)
+
+        assert result["results"] is not None
+        assert len(result["results"]) == 2
+        assert result["results"][0] == "result-x"
+        assert result["results"][1] == "result-y"
+
+    def test_map_progress_file_ignored_when_items_length_mismatch(self, temp_dir):
+        """Progress file is ignored when saved results length exceeds current items."""
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+            PassState,
+        )
+
+        flow = Flow(
+            name="Length Mismatch Test",
+            description="Test progress ignored when items changed",
+            start_at="setup",
+            states={
+                "setup": PassState(
+                    type="pass",
+                    parameters={"$.items": ["a", "b"]},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo",
+                                provider="system",
+                                command='echo "result-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    fail_fast=True,
+                    end=True,
+                ),
+            },
+        )
+
+        flow_path = temp_dir / "map_length_test.yaml"
+        write_flow_to_file(flow, flow_path)
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-map-length-mismatch"
+
+        engine.run_flow(
+            flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        progress_file = base_dir / "runs" / thread_id / "map_state" / "progress.json"
+        assert progress_file.exists()
+
+        with progress_file.open() as f:
+            progress = json.load(f)
+        assert progress["completed_iterations"] == 2
+
+        with progress_file.open("w") as f:
+            json.dump(
+                {
+                    "completed_iterations": 5,
+                    "results": ["old-a", "old-b", "old-c", "old-d", "old-e"],
+                },
+                f,
+            )
+
+        from fdsx.models.flow import PassState as PassStateModel
+
+        flow_changed_items = Flow(
+            name="Length Mismatch Test Changed",
+            description="Test progress ignored when items changed",
+            start_at="setup",
+            states={
+                "setup": PassStateModel(
+                    type="pass",
+                    parameters={"$.items": ["a", "b", "c"]},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo",
+                                provider="system",
+                                command='echo "result-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    fail_fast=True,
+                    end=True,
+                ),
+            },
+        )
+
+        write_flow_to_file(flow_changed_items, flow_path)
+
+        result = engine.run_flow(
+            flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        assert result["results"] is not None
+        assert len(result["results"]) == 3
+        assert result["results"][0] == "result-a"
+        assert result["results"][1] == "result-b"
+        assert result["results"][2] == "result-c"

--- a/tests/integration/test_map_flow.py
+++ b/tests/integration/test_map_flow.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import pytest
+
+from fdsx.core.engine import run_flow
+from fdsx.core.loader import load_flow
+from fdsx.models.flow import PassState
+from tests import FIXTURES_DIR
+
+
+class TestMapBasic:
+    def test_map_basic_ordered_results(self, tmp_path):
+        """Test basic map iteration with 3 items and 2-state iterator.
+
+        Verifies:
+        - Ordered results array at $.map_results
+        - Each item is processed by both iterator states
+        """
+        path = FIXTURES_DIR / "map_basic.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert "map_results" in result
+        assert len(result["map_results"]) == 3
+
+        assert result["map_results"][0] == "step2-item1"
+        assert result["map_results"][1] == "step2-item2"
+        assert result["map_results"][2] == "step2-item3"
+
+        assert "after_result" in result
+        assert result["after_result"] == "done"
+
+
+class TestMapEmptyItems:
+    def test_map_empty_items_continues(self, tmp_path):
+        """Test that empty items array results in empty results and flow continues."""
+        path = FIXTURES_DIR / "map_empty_items.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert "map_results" in result
+        assert result["map_results"] == []
+
+        assert "after_result" in result
+        assert result["after_result"] == "map-completed"
+
+
+class TestMapFailFast:
+    def test_map_fail_fast_true_raises(self, tmp_path):
+        """Test that fail_fast: true raises error on iteration failure."""
+        from fdsx.core.compiler import compile_flow
+
+        flow = flow_with_failing_iter()
+        compiled = compile_flow(flow)
+
+        with pytest.raises(RuntimeError, match=r"iteration 1 failed"):
+            compiled.graph.invoke({})
+
+
+class TestMapFailFastFalse:
+    def test_map_fail_fast_false_collects_results(self, tmp_path):
+        """Test fail_fast: false collects results from all iterations even with failures.
+
+        With fail_fast: false, all iterations are attempted, the results array is
+        populated with nulls for failed iterations, but an error is still raised
+        after all iterations complete.
+        """
+        from unittest.mock import patch
+
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+            PassState,
+        )
+
+        flow = Flow(
+            name="Fail Fast False Test",
+            description="Test fail_fast false behavior",
+            start_at="setup",
+            states={
+                "setup": PassState(
+                    type="pass",
+                    parameters={"$.items": ["ok1", "fail", "ok2"]},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo_item",
+                                provider="system",
+                                command='sh -c "test {item} = fail && exit 1 || echo ok-{item}"',
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    fail_fast=False,
+                    next="after_map",
+                ),
+                "after_map": PassState(
+                    type="pass",
+                    parameters={"$.after_result": "done"},
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+        initial_state = {
+            "_meta": {
+                "thread_id": "test",
+                "flow_path": "",
+                "flow_name": "test",
+                "run_dir": "",
+            },
+            "_state_iterations": {},
+        }
+
+        captured_results = []
+        original_set = __import__(
+            "fdsx.core.variables", fromlist=["set_jsonpath"]
+        ).set_jsonpath
+
+        def spy_set_jsonpath(path, state, value):
+            if path == "$.results":
+                captured_results.append(value)
+            return original_set(path, state, value)
+
+        with (
+            patch(
+                "fdsx.core.compiler.map_iteration.set_jsonpath",
+                side_effect=spy_set_jsonpath,
+            ),
+            pytest.raises(RuntimeError, match=r"1 of 3 iterations failed"),
+        ):
+            compiled.graph.invoke(initial_state)
+
+        assert len(captured_results) == 1
+        results = captured_results[0]
+        assert len(results) == 3
+        assert results[0] is not None
+        assert results[0] == "ok-ok1"
+        assert results[1] is None
+        assert results[2] is not None
+        assert results[2] == "ok-ok2"
+
+
+class TestMapInsideParallel:
+    def test_map_after_parallel_no_interference(self, tmp_path):
+        """Test that map state after parallel state works correctly.
+
+        Verifies:
+        - Parallel branch results are collected
+        - Map results are collected separately
+        - Both features don't interfere with each other
+        """
+        path = FIXTURES_DIR / "map_inside_parallel.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert "parallel_results" in result
+        assert len(result["parallel_results"]) == 2
+
+        assert "map_results" in result
+        assert len(result["map_results"]) == 2
+        assert result["map_results"][0] == "mapped-x"
+        assert result["map_results"][1] == "mapped-y"
+
+
+class TestMapItemVariableResolution:
+    def test_map_resolves_item_variable(self, tmp_path):
+        """Test that ${item} is properly resolved in iterator task commands."""
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import Flow, IteratorDef, IteratorTaskState, MapState
+
+        flow = Flow(
+            name="Item Resolution Test",
+            description="Test item variable resolution",
+            start_at="map_state",
+            states={
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo_item",
+                                provider="system",
+                                command="echo ITEM_IS_{item}",
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+        initial_state = {
+            "items": ["alpha", "beta", "gamma"],
+            "_meta": {
+                "thread_id": "test",
+                "flow_path": "",
+                "flow_name": "test",
+                "run_dir": "",
+            },
+            "_state_iterations": {},
+        }
+
+        result = compiled.graph.invoke(initial_state)
+
+        assert "results" in result
+        assert len(result["results"]) == 3
+        assert result["results"][0] == "ITEM_IS_alpha"
+        assert result["results"][1] == "ITEM_IS_beta"
+        assert result["results"][2] == "ITEM_IS_gamma"
+
+
+class TestMapInvalidItemsPath:
+    def test_map_items_path_not_resolved_raises(self, tmp_path):
+        """items_path that doesn't resolve raises RuntimeError."""
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import Flow, IteratorDef, IteratorTaskState, MapState
+
+        flow = Flow(
+            name="Invalid Items Path",
+            description="Test unresolved items_path",
+            start_at="map_state",
+            states={
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.nonexistent",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo",
+                                provider="system",
+                                command="echo hi",
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+        with pytest.raises(RuntimeError, match=r"did not resolve to a value"):
+            compiled.graph.invoke({})
+
+    def test_map_items_path_non_list_raises(self, tmp_path):
+        """items_path resolving to non-list raises RuntimeError."""
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import (
+            Flow,
+            IteratorDef,
+            IteratorTaskState,
+            MapState,
+            PassState,
+        )
+
+        flow = Flow(
+            name="Non-List Items",
+            description="Test non-list items_path",
+            start_at="setup",
+            states={
+                "setup": PassState(
+                    type="pass",
+                    parameters={"$.items": "not-a-list"},
+                    next="map_state",
+                ),
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo",
+                                provider="system",
+                                command="echo hi",
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+        with pytest.raises(RuntimeError, match=r"expected list"):
+            compiled.graph.invoke(
+                {
+                    "_meta": {
+                        "thread_id": "t",
+                        "flow_path": "",
+                        "flow_name": "t",
+                        "run_dir": "",
+                    },
+                    "_state_iterations": {},
+                }
+            )
+
+
+class TestMapItemFieldResolution:
+    def test_map_resolves_item_field(self, tmp_path):
+        """Test that ${item.field} resolves nested object fields."""
+        from fdsx.core.compiler import compile_flow
+        from fdsx.models.flow import Flow, IteratorDef, IteratorTaskState, MapState
+
+        flow = Flow(
+            name="Item Field Resolution",
+            description="Test nested item field resolution",
+            start_at="map_state",
+            states={
+                "map_state": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="echo_field",
+                                provider="system",
+                                command="echo {item.name}-{item.value}",
+                                result_path="$.result",
+                            )
+                        ]
+                    ),
+                    result_path="$.results",
+                    end=True,
+                ),
+            },
+        )
+
+        compiled = compile_flow(flow)
+        initial_state = {
+            "items": [
+                {"name": "alice", "value": "100"},
+                {"name": "bob", "value": "200"},
+            ],
+            "_meta": {
+                "thread_id": "t",
+                "flow_path": "",
+                "flow_name": "t",
+                "run_dir": "",
+            },
+            "_state_iterations": {},
+        }
+
+        result = compiled.graph.invoke(initial_state)
+
+        assert "results" in result
+        assert len(result["results"]) == 2
+        assert result["results"][0] == "alice-100"
+        assert result["results"][1] == "bob-200"
+
+
+def flow_with_failing_iter():
+    """Create a flow with a map state that fails on second iteration."""
+    from fdsx.models.flow import Flow, IteratorDef, IteratorTaskState, MapState
+
+    return Flow(
+        name="Fail Fast Test",
+        description="Test fail_fast true behavior",
+        start_at="setup",
+        states={
+            "setup": _pass_state("$.items", ["ok", "fail"]),
+            "map_state": MapState(
+                type="map",
+                items_path="$.items",
+                iterator=IteratorDef(
+                    states=[
+                        IteratorTaskState(
+                            name="echo_item",
+                            provider="system",
+                            command='if [ "{item}" = "fail" ]; then exit 1; fi; echo "{item}"',
+                            result_path="$.result",
+                        )
+                    ]
+                ),
+                result_path="$.results",
+                fail_fast=True,
+                end=True,
+            ),
+        },
+    )
+
+
+def _pass_state(result_path: str, value: list) -> PassState:
+    """Helper to create a pass state that sets a variable to a value."""
+    return PassState(
+        type="pass",
+        parameters={result_path: value},
+        next="map_state",
+    )

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -28,7 +28,7 @@ class TestTasksDirLoader:
     def test_load_tasks_dir_empty_dir(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             tasks_dir = Path(tmpdir)
-            with pytest.raises(ValueError, match=r"No .yaml files"):
+            with pytest.raises(ValueError, match=r"No .yaml or .yml files"):
                 engine.load_tasks_dir(tasks_dir)
 
     def test_load_tasks_dir_nonexistent_dir(self):
@@ -71,6 +71,68 @@ class TestTasksDirLoader:
             symlink_file.symlink_to(real_file)
 
             with pytest.raises(ValueError, match="must be a regular file"):
+                engine.load_tasks_dir(tasks_dir)
+
+    def test_load_tasks_dir_ignores_subdirectory_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            (tasks_dir / "direct-task.yaml").write_text("description: direct task\n")
+            subdir = tasks_dir / "subdir"
+            subdir.mkdir()
+            (subdir / "nested-task.yaml").write_text("description: nested task\n")
+
+            files = engine.load_tasks_dir(tasks_dir)
+
+            assert len(files) == 1
+            assert files[0][0].name == "direct-task.yaml"
+
+    def test_load_tasks_dir_discovers_yml_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            (tasks_dir / "a-task.yml").write_text("description: yml task\n")
+            (tasks_dir / "b-task.yml").write_text("description: another yml task\n")
+
+            files = engine.load_tasks_dir(tasks_dir)
+
+            assert len(files) == 2
+            names = [f.name for f, _ in files]
+            assert names == ["a-task.yml", "b-task.yml"]
+
+    def test_load_tasks_dir_discovers_mixed_yaml_and_yml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            (tasks_dir / "b-task.yaml").write_text("description: yaml task\n")
+            (tasks_dir / "a-task.yml").write_text("description: yml task\n")
+            (tasks_dir / "c-task.yaml").write_text("description: another yaml task\n")
+
+            files = engine.load_tasks_dir(tasks_dir)
+
+            assert len(files) == 3
+            names = [f.name for f, _ in files]
+            assert names == ["a-task.yml", "b-task.yaml", "c-task.yaml"]
+
+    def test_load_tasks_dir_ignores_arbitrary_subdirectory_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            (tasks_dir / "001-task.yaml").write_text("description: task\n")
+            for subdir_name in ["_parked", "done", "archive", "backup", "nested"]:
+                subdir = tasks_dir / subdir_name
+                subdir.mkdir()
+                (subdir / "task.yaml").write_text("description: should be ignored\n")
+
+            files = engine.load_tasks_dir(tasks_dir)
+
+            assert len(files) == 1
+            assert files[0][0].name == "001-task.yaml"
+
+    def test_load_tasks_dir_empty_dir_with_only_subdirectory_yaml(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            subdir = tasks_dir / "some_subdir"
+            subdir.mkdir()
+            (subdir / "task.yaml").write_text("description: hidden task\n")
+
+            with pytest.raises(ValueError, match=r"No .yaml or .yml files"):
                 engine.load_tasks_dir(tasks_dir)
 
 

--- a/tests/unit/test_graph_utils.py
+++ b/tests/unit/test_graph_utils.py
@@ -2,6 +2,9 @@ from fdsx.core.graph_utils import END_SENTINEL, get_next_states
 from fdsx.models.flow import (
     ChoiceRule,
     ChoiceState,
+    IteratorDef,
+    IteratorTaskState,
+    MapState,
     ParallelState,
     PassState,
     TaskState,
@@ -156,3 +159,46 @@ class TestGetNextStatesWaitState:
     def test_end_true_with_sentinel(self):
         state = make_wait_state(end=True)
         assert get_next_states(state, include_end_sentinel=True) == {END_SENTINEL}
+
+
+def make_map_state(next: str | None = None, end: bool | None = None) -> MapState:
+    return MapState(
+        items_path="$.items",
+        iterator=IteratorDef(
+            states=[
+                IteratorTaskState(
+                    name="step1",
+                    provider="claude",
+                    model="claude-3-5-sonnet-20241022",
+                    prompt_template="hello",
+                    result_path="$.out",
+                )
+            ]
+        ),
+        result_path="$.results",
+        next=next,
+        end=end,
+    )
+
+
+class TestGetNextStatesMapState:
+    def test_next_only(self):
+        state = make_map_state(next="Done")
+        assert get_next_states(state) == {"Done"}
+
+    def test_end_true_without_sentinel(self):
+        state = make_map_state(end=True)
+        assert get_next_states(state) == set()
+
+    def test_end_true_with_sentinel(self):
+        state = make_map_state(end=True)
+        assert get_next_states(state, include_end_sentinel=True) == {END_SENTINEL}
+
+    def test_next_with_sentinel_no_end(self):
+        state = make_map_state(next="Cleanup")
+        assert get_next_states(state, include_end_sentinel=True) == {"Cleanup"}
+
+    def test_no_next_no_end(self):
+        state = make_map_state()
+        assert get_next_states(state) == set()
+        assert get_next_states(state, include_end_sentinel=True) == set()

--- a/tests/unit/test_map_model.py
+++ b/tests/unit/test_map_model.py
@@ -1,0 +1,374 @@
+import pytest
+from pydantic import ValidationError
+
+from fdsx.models.flow import (
+    ExtractRule,
+    IteratorDef,
+    IteratorTaskState,
+    MapState,
+)
+
+
+class TestIteratorTaskState:
+    def test_valid_task_state(self):
+        state = IteratorTaskState(
+            name="read_content",
+            provider="claude",
+            model="claude-3-5-sonnet-20241022",
+            prompt_template="Read {{ item.url }}",
+            result_path="$.content",
+        )
+        assert state.name == "read_content"
+        assert state.type == "task"
+        assert state.provider == "claude"
+
+    def test_system_provider_with_command(self):
+        state = IteratorTaskState(
+            name="run_cmd",
+            provider="system",
+            command="echo hello",
+            result_path="$.output",
+        )
+        assert state.provider == "system"
+        assert state.command == "echo hello"
+
+    def test_prompt_file_exclusive_with_prompt_template(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorTaskState(
+                name="bad",
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                prompt_template="hello",
+                prompt_file="prompt.txt",
+                result_path="$.out",
+            )
+        assert "prompt_template and prompt_file are mutually exclusive" in str(
+            exc_info.value
+        )
+
+    def test_provider_system_forbids_prompt(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorTaskState(
+                name="bad",
+                provider="system",
+                prompt_template="hello",
+                result_path="$.out",
+            )
+        assert "provider=system forbids prompt_template" in str(exc_info.value)
+
+    def test_provider_system_requires_command(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorTaskState(
+                name="bad",
+                provider="system",
+                result_path="$.out",
+            )
+        assert "provider=system requires command" in str(exc_info.value)
+
+    def test_provider_non_system_requires_model(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorTaskState(
+                name="bad",
+                provider="claude",
+                prompt_template="hello",
+                result_path="$.out",
+            )
+        assert "provider=claude requires model" in str(exc_info.value)
+
+    def test_extract_path_overlap_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorTaskState(
+                name="bad",
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                prompt_template="hello",
+                result_path="$.steps.read",
+                extract=ExtractRule(
+                    strategy=["json"],
+                    pattern=".*",
+                    result_path="$.steps.read.output",
+                ),
+            )
+        assert "must not overlap" in str(exc_info.value)
+
+    def test_result_file_validation(self):
+        state = IteratorTaskState(
+            name="save",
+            provider="claude",
+            model="claude-3-5-sonnet-20241022",
+            prompt_template="hello",
+            result_path="$.out",
+            result_file="$.result_file_path",
+        )
+        assert state.result_file == "$.result_file_path"
+
+    def test_result_file_must_start_with_dollar(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorTaskState(
+                name="bad",
+                provider="claude",
+                model="claude-3-5-sonnet-20241022",
+                prompt_template="hello",
+                result_path="$.out",
+                result_file="no_dollar",
+            )
+        assert "must start with '$.'" in str(exc_info.value)
+
+
+class TestIteratorDef:
+    def test_valid_iterator_def(self):
+        iterator = IteratorDef(
+            states=[
+                IteratorTaskState(
+                    name="step1",
+                    provider="claude",
+                    model="claude-3-5-sonnet-20241022",
+                    prompt_template="hello",
+                    result_path="$.out1",
+                ),
+                IteratorTaskState(
+                    name="step2",
+                    provider="claude",
+                    model="claude-3-5-sonnet-20241022",
+                    prompt_template="world",
+                    result_path="$.out2",
+                ),
+            ]
+        )
+        assert len(iterator.states) == 2
+
+    def test_empty_states_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorDef(states=[])
+        assert "too_short" in str(exc_info.value)
+
+    def test_duplicate_names_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out1",
+                    ),
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="world",
+                        result_path="$.out2",
+                    ),
+                ]
+            )
+        assert "duplicate iterator state name 'step'" in str(exc_info.value)
+
+    def test_nested_map_type_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorDef(
+                states=[
+                    {
+                        "name": "nested_map",
+                        "type": "map",
+                        "items_path": "$.items",
+                        "iterator": {"states": []},
+                        "result_path": "$.results",
+                    }
+                ]
+            )
+        assert "must have type 'task'" in str(exc_info.value)
+
+    def test_nested_choice_type_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorDef(
+                states=[
+                    {
+                        "name": "nested_choice",
+                        "type": "choice",
+                        "choices": [],
+                    }
+                ]
+            )
+        assert "must have type 'task'" in str(exc_info.value)
+
+    def test_nested_parallel_type_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorDef(
+                states=[
+                    {
+                        "name": "nested_parallel",
+                        "type": "parallel",
+                        "branches": [],
+                        "result_path": "$.results",
+                    }
+                ]
+            )
+        assert "must have type 'task'" in str(exc_info.value)
+
+    def test_non_list_states_rejected(self):
+        with pytest.raises(ValidationError) as exc_info:
+            IteratorDef(states="not_a_list")  # type: ignore[arg-type]
+        assert "list" in str(exc_info.value).lower()
+
+
+class TestMapState:
+    def test_valid_map_state(self):
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="process",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="Process {{ item }}",
+                        result_path="$.result",
+                    )
+                ]
+            ),
+            result_path="$.results",
+        )
+        assert state.type == "map"
+        assert state.items_path == "$.items"
+        assert state.fail_fast is True
+
+    def test_fail_fast_defaults_to_true(self):
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out",
+                    )
+                ]
+            ),
+            result_path="$.results",
+        )
+        assert state.fail_fast is True
+
+    def test_fail_fast_can_be_false(self):
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out",
+                    )
+                ]
+            ),
+            result_path="$.results",
+            fail_fast=False,
+        )
+        assert state.fail_fast is False
+
+    def test_next_and_end_mutually_exclusive(self):
+        with pytest.raises(ValidationError) as exc_info:
+            MapState(
+                items_path="$.items",
+                iterator=IteratorDef(
+                    states=[
+                        IteratorTaskState(
+                            name="step",
+                            provider="claude",
+                            model="claude-3-5-sonnet-20241022",
+                            prompt_template="hello",
+                            result_path="$.out",
+                        )
+                    ]
+                ),
+                result_path="$.results",
+                next="next_state",
+                end=True,
+            )
+        assert "next and end are mutually exclusive" in str(exc_info.value)
+
+    def test_next_only(self):
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out",
+                    )
+                ]
+            ),
+            result_path="$.results",
+            next="cleanup",
+        )
+        assert state.next == "cleanup"
+
+    def test_end_only(self):
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out",
+                    )
+                ]
+            ),
+            result_path="$.results",
+            end=True,
+        )
+        assert state.end is True
+
+    def test_with_hooks(self):
+        from fdsx.models.flow import HookConfig, HookEntry
+
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out",
+                    )
+                ]
+            ),
+            result_path="$.results",
+            hooks=HookConfig(
+                on_start=[HookEntry(command="echo starting")],
+                on_complete=[HookEntry(command="echo done")],
+            ),
+        )
+        assert state.hooks is not None
+        assert len(state.hooks.on_start) == 1
+
+    def test_with_max_iterations(self):
+        state = MapState(
+            items_path="$.items",
+            iterator=IteratorDef(
+                states=[
+                    IteratorTaskState(
+                        name="step",
+                        provider="claude",
+                        model="claude-3-5-sonnet-20241022",
+                        prompt_template="hello",
+                        result_path="$.out",
+                    )
+                ]
+            ),
+            result_path="$.results",
+            max_iterations=5,
+        )
+        assert state.max_iterations == 5

--- a/tests/unit/test_prompt_file.py
+++ b/tests/unit/test_prompt_file.py
@@ -94,6 +94,84 @@ class TestPromptFileParallelBranch:
             assert branch.prompt_template == "Branch prompt content"
 
 
+class TestMapPromptFile:
+    def test_map_iterator_prompt_file_resolved(self):
+        """Iterator state prompt_file is read and replaced with prompt_template."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prompt = Path(tmpdir) / "iter_prompt.txt"
+            prompt.write_text("Summarize: {item.text}")
+
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            flow_yaml.write_text(
+                "name: map-prompt-file-test\n"
+                "description: Test map prompt file resolution\n"
+                "start_at: produce\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  produce:\n"
+                "    type: task\n"
+                "    provider: system\n"
+                "    command: echo '[\"a\",\"b\"]'\n"
+                "    result_path: '$.items'\n"
+                "    next: mapper\n"
+                "  mapper:\n"
+                "    type: map\n"
+                "    items_path: '$.items'\n"
+                "    iterator:\n"
+                "      states:\n"
+                "        - name: summarize\n"
+                "          type: task\n"
+                "          provider: claude\n"
+                "          model: opus\n"
+                "          prompt_file: iter_prompt.txt\n"
+                "          result_path: '$.summary'\n"
+                "    result_path: '$.summaries'\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is not None, f"Flow loading failed: {errors}"
+
+            iter_state = flow.states["mapper"].iterator.states[0]
+            assert iter_state.prompt_template == "Summarize: {item.text}"
+            assert iter_state.prompt_file is None
+
+    def test_map_iterator_prompt_file_missing(self):
+        """Missing prompt_file in iterator state produces an error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            flow_yaml = Path(tmpdir) / "flow.yaml"
+            flow_yaml.write_text(
+                "name: map-prompt-file-missing\n"
+                "description: Test missing map prompt file\n"
+                "start_at: produce\n"
+                "max_loop: 1\n"
+                "states:\n"
+                "  produce:\n"
+                "    type: task\n"
+                "    provider: system\n"
+                "    command: echo '[\"a\",\"b\"]'\n"
+                "    result_path: '$.items'\n"
+                "    next: mapper\n"
+                "  mapper:\n"
+                "    type: map\n"
+                "    items_path: '$.items'\n"
+                "    iterator:\n"
+                "      states:\n"
+                "        - name: summarize\n"
+                "          type: task\n"
+                "          provider: claude\n"
+                "          model: opus\n"
+                "          prompt_file: nonexistent.txt\n"
+                "          result_path: '$.summary'\n"
+                "    result_path: '$.summaries'\n"
+                "    end: true\n"
+            )
+
+            flow, errors = load_flow(flow_yaml)
+            assert flow is None
+            assert any("not found" in e for e in errors)
+
+
 class TestPromptFileEdgeCases:
     def test_prompt_file_empty_content(self):
         """prompt_file with empty content should work."""

--- a/tests/unit/test_prompt_file.py
+++ b/tests/unit/test_prompt_file.py
@@ -111,7 +111,7 @@ class TestMapPromptFile:
                 "  produce:\n"
                 "    type: task\n"
                 "    provider: system\n"
-                "    command: echo '[\"a\",\"b\"]'\n"
+                '    command: echo \'["a","b"]\'\n'
                 "    result_path: '$.items'\n"
                 "    next: mapper\n"
                 "  mapper:\n"
@@ -149,7 +149,7 @@ class TestMapPromptFile:
                 "  produce:\n"
                 "    type: task\n"
                 "    provider: system\n"
-                "    command: echo '[\"a\",\"b\"]'\n"
+                '    command: echo \'["a","b"]\'\n'
                 "    result_path: '$.items'\n"
                 "    next: mapper\n"
                 "  mapper:\n"

--- a/tests/unit/test_variables.py
+++ b/tests/unit/test_variables.py
@@ -6,7 +6,15 @@ from fdsx.core.variables import (
     resolve_template_shell_safe,
     set_jsonpath,
 )
-from fdsx.models.flow import Branch, Flow, ParallelState, TaskState
+from fdsx.models.flow import (
+    Branch,
+    Flow,
+    IteratorDef,
+    IteratorTaskState,
+    MapState,
+    ParallelState,
+    TaskState,
+)
 
 
 class TestResolveTemplate:
@@ -787,3 +795,189 @@ class TestGlobalTaskVarsRecognition:
         errors = analyze_variable_references(flow)
         assert len(errors) == 1
         assert "unknown_var" in errors[0]
+
+
+class TestMapVariableAnalysis:
+    def test_map_result_path_satisfies_downstream(self):
+        """T017: A MapState with result_path should satisfy a downstream state."""
+        flow = Flow(
+            name="Map Result Path Flow",
+            description="Test flow for MapState result_path satisfaction",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.items",
+                    next="process",
+                ),
+                "process": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="item_task",
+                                provider="system",
+                                command="echo processing {item}",
+                                result_path="$.item_result",
+                            ),
+                        ],
+                    ),
+                    result_path="$.map_results",
+                    next="consume",
+                ),
+                "consume": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo {map_results}",
+                    result_path="$.final",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_item_not_flagged_as_missing(self):
+        """T017: ${item} or ${item.name} in iterator prompts must NOT be flagged."""
+        flow = Flow(
+            name="Item Variable Flow",
+            description="Test that item references are not flagged as missing",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.items",
+                    next="process",
+                ),
+                "process": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="item_task",
+                                provider="system",
+                                command="echo {item.name}",
+                                result_path="$.item_result",
+                            ),
+                        ],
+                    ),
+                    result_path="$.map_results",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_unreachable_items_path_detected(self):
+        """T017: A MapState whose items_path references an undefined variable must be flagged."""
+        flow = Flow(
+            name="Unreachable Items Flow",
+            description="Test that undefined items_path is flagged",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.other",
+                    next="process",
+                ),
+                "process": MapState(
+                    type="map",
+                    items_path="$.undefined_items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="item_task",
+                                provider="system",
+                                command="echo {item}",
+                                result_path="$.item_result",
+                            ),
+                        ],
+                    ),
+                    result_path="$.map_results",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 1
+        assert "undefined_items" in errors[0]
+
+    def test_map_items_path_satisfied_by_predecessor(self):
+        """T017: A MapState whose items_path is satisfied by a preceding state must pass."""
+        flow = Flow(
+            name="Satisfied Items Flow",
+            description="Test that items_path satisfied by predecessor is not flagged",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.available_items",
+                    next="process",
+                ),
+                "process": MapState(
+                    type="map",
+                    items_path="$.available_items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="item_task",
+                                provider="system",
+                                command="echo {item.name}",
+                                result_path="$.item_result",
+                            ),
+                        ],
+                    ),
+                    result_path="$.map_results",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+
+    def test_iterator_other_var_still_flagged(self):
+        """T017: Non-item variables in iterator prompts that are undefined must still be flagged."""
+        flow = Flow(
+            name="Iterator Undefined Var Flow",
+            description="Test that undefined non-item vars in iterator are flagged",
+            start_at="start",
+            states={
+                "start": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.items",
+                    next="process",
+                ),
+                "process": MapState(
+                    type="map",
+                    items_path="$.items",
+                    iterator=IteratorDef(
+                        states=[
+                            IteratorTaskState(
+                                name="item_task",
+                                provider="system",
+                                command="echo {item} {undefined_var}",
+                                result_path="$.item_result",
+                            ),
+                        ],
+                    ),
+                    result_path="$.map_results",
+                    end=True,
+                ),
+            },
+        )
+        errors = analyze_variable_references(flow)
+        assert len(errors) == 1
+        assert "undefined_var" in errors[0]

--- a/uv.lock
+++ b/uv.lock
@@ -417,6 +417,9 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
     { name = "types-pyyaml" },
 ]
 
@@ -441,7 +444,12 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "types-pyyaml", specifier = ">=6.0.12.20250915" }]
+dev = [
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "ruff", specifier = ">=0.15.6" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
+]
 
 [[package]]
 name = "filelock"


### PR DESCRIPTION
## What was done

Complete Map state implementation across 7 phases:

### Phase 1 — Models (T003-T008)
Added `MapState`, `IteratorDef`, and `IteratorTaskState` Pydantic models to represent the `map` state type in workflow YAML.

### Phase 2 — Compiler (T009-T013)
Implemented the MapState compiler that translates a `map` state definition into a LangGraph node, iterating over items and running each through the iterator sub-workflow.

### Phase 3 — Checkpointing (T014-T016)
Added per-iteration checkpointing so Map state progress can be resumed after interruption.

### Phase 4 — Loader & Variable Analysis (T017-T019)
Extended the YAML loader to recognize `map` states and added `${item}`/`${item.field}` variable analysis for iterator prompts.

### Phase 5 — Display & Logging (T020-T021)
Added Map-specific terminal display functions (`display_map_start`, `display_map_iteration`, `display_map_complete`) and run recorder methods, wired into `map_iteration.py`.

### Phase 6 — E2E Test & Documentation (T022-T023)
- Added `tests/e2e/test_cli_map_flow.py`: CLI subprocess tests verifying exit code 0, clean stdout, and completion message on stderr
- Updated `README.md` with `map` state YAML schema (`items_path`, `iterator`, `fail_fast`) and `${item}`/`${item.field}` variable reference docs

## Why

Implements the Map state type, enabling workflows to fan out over a list of items and process each with an iterator sub-workflow — a key building block for batch processing patterns in fdsx.

## How to test

```bash
# Run all map-related tests
uv run pytest tests/ -v -k map

# Run just the new E2E test
uv run pytest tests/e2e/test_cli_map_flow.py -v
```