### PR TITLE
fix(tasks-dir): retry failed entries and propagate exit codes

### DIFF
--- a/src/fdsx/core/engine/__init__.py
+++ b/src/fdsx/core/engine/__init__.py
@@ -6,6 +6,7 @@ to work without changes.
 """
 
 from .results import (
+    FlowResult,
     _calc_elapsed,
     _detect_abort_status,
     _extract_results,
@@ -24,6 +25,7 @@ from .tasks_dir import (
 from .validate import FlowValidationError, validate_flow
 
 __all__ = [
+    "FlowResult",
     "FlowValidationError",
     "_calc_elapsed",
     "_detect_abort_status",

--- a/src/fdsx/core/engine/results.py
+++ b/src/fdsx/core/engine/results.py
@@ -1,5 +1,6 @@
 """Result extraction and helper utilities for the engine package."""
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -93,3 +94,12 @@ def _detect_abort_status(
         if isinstance(name, str) and name.startswith("abort_"):
             return ("aborted", name, "workflow aborted")
     return ("completed", None, None)
+
+
+@dataclass(frozen=True)
+class FlowResult:
+    """Structured return value for run_flow and resume_flow."""
+
+    results: dict[str, Any]
+    status: str  # "completed" | "aborted"
+    abort_state: str | None = None

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -2,7 +2,7 @@
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
@@ -18,6 +18,7 @@ from fdsx.display.terminal import (
 )
 from fdsx.logging import RunRecorder
 from fdsx.logging.recorder import LOGS_DIR_NAME
+from fdsx.models.task import load_task_file, save_task_file
 
 from .interrupts import handle_interrupts
 from .results import (
@@ -222,6 +223,30 @@ def resume_flow(
                 )
             else:
                 display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
+
+        # Best-effort: update task YAML entry if stored in _meta
+        _meta = last_state.get("_meta", {})
+        _task_file_path_str = _meta.get("task_file_path")
+        _task_entry_index = _meta.get("task_entry_index")
+        if _task_file_path_str is not None and _task_entry_index is not None:
+            try:
+                _task_file_path = Path(_task_file_path_str)
+                _task_file = load_task_file(_task_file_path)
+                _entry = _task_file.entries[_task_entry_index]
+                _new_status = "failed" if status == "aborted" else "completed"
+                _entry.status = cast(
+                    Literal["pending", "running", "completed", "failed"], _new_status
+                )
+                _entry.thread_id = thread_id
+                _entry.error = (
+                    f"workflow aborted at state '{failed_state}'"
+                    if status == "aborted"
+                    else None
+                )
+                save_task_file(_task_file_path, _task_file)
+            except (FileNotFoundError, IndexError, ValueError):
+                pass  # best-effort: do not raise if file is missing or index is invalid
+
         return FlowResult(results=results, status=status, abort_state=failed_state)
     except GraphRecursionError:
         if flow is not None:

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -21,7 +21,9 @@ from fdsx.logging.recorder import LOGS_DIR_NAME
 
 from .interrupts import handle_interrupts
 from .results import (
+    FlowResult,
     _calc_elapsed,
+    _detect_abort_status,
     _extract_results,
     _find_failed_state,
     _sanitize_state_for_log,
@@ -33,7 +35,7 @@ def resume_flow(
     thread_id: str,
     base_dir: Path | None = None,
     flow_path: Path | None = None,
-) -> dict[str, Any]:
+) -> FlowResult:
     """Resume a flow from a checkpoint.
 
     Args:
@@ -205,19 +207,33 @@ def resume_flow(
             last_state = final_state_info.values
 
         results = _extract_results(last_state, compiled.result_paths)
+        status: str = "completed"
+        failed_state: str | None = None
         if recorder is not None:
-            recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+            status, failed_state, _ = _detect_abort_status(recorder)
+            recorder.finalize(_sanitize_state_for_log(last_state), status)
             recorder.save(base_dir=base_dir)
-            display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
-        return results
+            if failed_state is not None:
+                display_completion_summary(
+                    recorder.flow_name,
+                    _calc_elapsed(recorder),
+                    failed_state,
+                    "workflow aborted",
+                )
+            else:
+                display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
+        return FlowResult(results=results, status=status, abort_state=failed_state)
     except GraphRecursionError:
         if flow is not None:
             print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
+        rec_status: str = "completed"
+        rec_failed_state: str | None = None
         if recorder is not None:
-            recorder.finalize(_sanitize_state_for_log(last_state), "completed")
+            rec_status, rec_failed_state, _ = _detect_abort_status(recorder)
+            recorder.finalize(_sanitize_state_for_log(last_state), rec_status)
             recorder.save(base_dir=base_dir)
             display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
-        return {}
+        return FlowResult(results={}, status=rec_status, abort_state=rec_failed_state)
     except Exception as e:
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "error")

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -133,8 +133,16 @@ def run_flow(
             "flow_path": str(flow_path),
             "flow_name": flow.name,
             "run_dir": str(run_dir),
-            **({"task_file_path": str(task_file_path)} if task_file_path is not None else {}),
-            **({"task_entry_index": task_entry_index} if task_entry_index is not None else {}),
+            **(
+                {"task_file_path": str(task_file_path)}
+                if task_file_path is not None
+                else {}
+            ),
+            **(
+                {"task_entry_index": task_entry_index}
+                if task_entry_index is not None
+                else {}
+            ),
         },
         "_state_iterations": {},
     }

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -21,6 +21,7 @@ from fdsx.logging.recorder import FDSX_DIR_NAME, LOGS_DIR_NAME, RUNS_DIR_NAME
 
 from .interrupts import handle_interrupts
 from .results import (
+    FlowResult,
     _calc_elapsed,
     _detect_abort_status,
     _extract_results,
@@ -37,7 +38,7 @@ def run_flow(
     thread_id: str | None = None,
     base_dir: Path | None = None,
     quiet: bool = False,
-) -> dict[str, Any]:
+) -> FlowResult:
     """Run a flow from a YAML file.
 
     Args:
@@ -179,7 +180,7 @@ def run_flow(
             )
         else:
             display_completion_summary(flow.name, _calc_elapsed(recorder))
-        return results
+        return FlowResult(results=results, status=status, abort_state=failed_state)
     except GraphRecursionError:
         print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         results = _extract_results(last_state, compiled.result_paths)
@@ -195,7 +196,7 @@ def run_flow(
             )
         else:
             display_completion_summary(flow.name, _calc_elapsed(recorder))
-        return results
+        return FlowResult(results=results, status=status, abort_state=failed_state)
     except Exception as e:
         if checkpoint_manager is not None:
             print(

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -38,6 +38,8 @@ def run_flow(
     thread_id: str | None = None,
     base_dir: Path | None = None,
     quiet: bool = False,
+    task_file_path: Path | None = None,
+    task_entry_index: int | None = None,
 ) -> FlowResult:
     """Run a flow from a YAML file.
 
@@ -49,6 +51,10 @@ def run_flow(
                   If None, uses MemorySaver (no persistence).
         quiet: When True, suppresses stderr streaming output from StreamLogger.
                Log files are still written and completion summary is still shown.
+        task_file_path: Optional path to the task YAML file. When provided along
+                        with task_entry_index, stored in _meta so that resume_flow
+                        can update the task entry status after completion.
+        task_entry_index: Optional index of the task entry within task_file_path.
 
     Returns:
         Final state variables as result dict. When max_loop is reached,
@@ -127,6 +133,8 @@ def run_flow(
             "flow_path": str(flow_path),
             "flow_name": flow.name,
             "run_dir": str(run_dir),
+            **({"task_file_path": str(task_file_path)} if task_file_path is not None else {}),
+            **({"task_entry_index": task_entry_index} if task_entry_index is not None else {}),
         },
         "_state_iterations": {},
     }

--- a/src/fdsx/core/engine/tasks_dir.py
+++ b/src/fdsx/core/engine/tasks_dir.py
@@ -362,11 +362,18 @@ def run_tasks_dir(
                     thread_id=thread_id,
                     base_dir=base_dir,
                     quiet=quiet,
+                    task_file_path=file_path,
+                    task_entry_index=entry_idx,
                 )
                 if flow_result.status == "aborted":
                     error_msg = f"workflow aborted at state '{flow_result.abort_state}'"
                     _update_task_status(
-                        file_path, task_file, entry_idx, "failed", thread_id=thread_id, error=error_msg
+                        file_path,
+                        task_file,
+                        entry_idx,
+                        "failed",
+                        thread_id=thread_id,
+                        error=error_msg,
                     )
                     results.append(
                         {
@@ -382,7 +389,11 @@ def run_tasks_dir(
                     )
                 else:
                     _update_task_status(
-                        file_path, task_file, entry_idx, "completed", thread_id=thread_id
+                        file_path,
+                        task_file,
+                        entry_idx,
+                        "completed",
+                        thread_id=thread_id,
                     )
                     results.append(
                         {

--- a/src/fdsx/core/engine/tasks_dir.py
+++ b/src/fdsx/core/engine/tasks_dir.py
@@ -356,28 +356,46 @@ def run_tasks_dir(
 
             try:
                 task_inputs = {"task": description, "source": task_file.source or ""}
-                run_flow(
+                flow_result = run_flow(
                     flow_path=effective_workflow,
                     inputs=task_inputs,
                     thread_id=thread_id,
                     base_dir=base_dir,
                     quiet=quiet,
                 )
-                _update_task_status(
-                    file_path, task_file, entry_idx, "completed", thread_id=thread_id
-                )
-                results.append(
-                    {
-                        "file_index": file_idx,
-                        "file_name": file_path.name,
-                        "entry_index": entry_idx,
-                        "entry_description": description,
-                        "thread_id": thread_id,
-                        "status": "completed",
-                        "error": None,
-                        "category": category,
-                    }
-                )
+                if flow_result.status == "aborted":
+                    error_msg = f"workflow aborted at state '{flow_result.abort_state}'"
+                    _update_task_status(
+                        file_path, task_file, entry_idx, "failed", thread_id=thread_id, error=error_msg
+                    )
+                    results.append(
+                        {
+                            "file_index": file_idx,
+                            "file_name": file_path.name,
+                            "entry_index": entry_idx,
+                            "entry_description": description,
+                            "thread_id": thread_id,
+                            "status": "failed",
+                            "error": error_msg,
+                            "category": category,
+                        }
+                    )
+                else:
+                    _update_task_status(
+                        file_path, task_file, entry_idx, "completed", thread_id=thread_id
+                    )
+                    results.append(
+                        {
+                            "file_index": file_idx,
+                            "file_name": file_path.name,
+                            "entry_index": entry_idx,
+                            "entry_description": description,
+                            "thread_id": thread_id,
+                            "status": "completed",
+                            "error": None,
+                            "category": category,
+                        }
+                    )
             except Exception as e:
                 _update_task_status(
                     file_path,

--- a/tests/e2e/test_batch_edge_cases.py
+++ b/tests/e2e/test_batch_edge_cases.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 from fdsx.cli.main import app
 from fdsx.core import engine
+from fdsx.core.engine import FlowResult
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 from tests import FIXTURES_DIR
 
@@ -62,7 +63,8 @@ class TestEdgeCases:
 
         with (
             patch(
-                "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
             ) as mock_run,
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
@@ -84,7 +86,10 @@ class TestEdgeCases:
         save_task_file(tasks_dir / "001-single.yaml", tf)
 
         with (
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             results = engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)

--- a/tests/e2e/test_batch_full_pipeline.py
+++ b/tests/e2e/test_batch_full_pipeline.py
@@ -7,9 +7,9 @@ from typer.testing import CliRunner
 
 from fdsx.cli.main import app
 from fdsx.core import engine
-from fdsx.core.engine import FlowResult
 from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
 from fdsx.core.config import TaskSplitterConfig
+from fdsx.core.engine import FlowResult
 from fdsx.models.task import load_task_file, save_task_file
 from tests import FIXTURES_DIR
 

--- a/tests/e2e/test_batch_full_pipeline.py
+++ b/tests/e2e/test_batch_full_pipeline.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from fdsx.cli.main import app
 from fdsx.core import engine
+from fdsx.core.engine import FlowResult
 from fdsx.core.batch import TASKS_DIR, split_tasks_to_groups, write_task_files
 from fdsx.core.config import TaskSplitterConfig
 from fdsx.models.task import load_task_file, save_task_file
@@ -74,7 +75,7 @@ class TestFullPipelineE2E:
                 task_desc = inputs.get("task", "")
             if task_desc and "feature B" in task_desc:
                 raise RuntimeError("Simulated crash during feature B")
-            return {"result": "ok"}
+            return FlowResult(results={"result": "ok"}, status="completed")
 
         with (
             patch("fdsx.core.engine.tasks_dir.run_flow", side_effect=mock_run_flow),
@@ -100,7 +101,7 @@ class TestFullPipelineE2E:
 
         def mock_run_flow_resume(flow_path, inputs, thread_id, base_dir, **kwargs):
             run_count_after_resume[0] += 1
-            return {"result": "ok"}
+            return FlowResult(results={"result": "ok"}, status="completed")
 
         with (
             patch(
@@ -154,7 +155,10 @@ class TestFullPipelineE2E:
         created_files = write_task_files(result_groups, tasks_dir)
 
         with (
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -255,7 +259,7 @@ class TestFullPipelineE2E:
             run_count[0] += 1
             if inputs and "E2E Task 2" in inputs.get("task", ""):
                 raise RuntimeError("Simulated error on Task 2")
-            return {"result": "ok"}
+            return FlowResult(results={"result": "ok"}, status="completed")
 
         auto_select_spinners: list[str] = []
 
@@ -316,7 +320,7 @@ class TestFullPipelineE2E:
 
         def mock_run_flow_rerun(flow_path, inputs, thread_id, base_dir, **kwargs):
             run_count_rerun[0] += 1
-            return {"result": "ok"}
+            return FlowResult(results={"result": "ok"}, status="completed")
 
         with (
             patch(

--- a/tests/integration/test_checkpoint_resume.py
+++ b/tests/integration/test_checkpoint_resume.py
@@ -123,9 +123,9 @@ class TestCLICommands:
             base_dir=base_dir,
         )
 
-        assert result.get("plan_output") == "plan output"
-        assert result.get("implement_output") == "implement output"
-        assert result.get("review_output") == "review output"
+        assert result.results.get("plan_output") == "plan output"
+        assert result.results.get("implement_output") == "implement output"
+        assert result.results.get("review_output") == "review output"
 
 
 class TestCheckpointSave:
@@ -198,9 +198,11 @@ class TestResumeSuccess:
             result = engine.resume_flow(thread_id, base_dir, wait_resume_flow_path)
 
         # Verify flow completed through the approve branch
-        assert "status" in result, f"Expected 'status' in result, got: {result}"
-        assert result["status"] == "approved"
-        assert result.get("plan_output") == "plan output"
+        assert "status" in result.results, (
+            f"Expected 'status' in result.results, got: {result.results}"
+        )
+        assert result.results["status"] == "approved"
+        assert result.results.get("plan_output") == "plan output"
 
 
 class TestScenario4FullResume:
@@ -245,9 +247,9 @@ class TestScenario4FullResume:
         # Step 2: Resume WITHOUT mock — implement and review should now succeed
         result = engine.resume_flow(thread_id, base_dir, checkpoint_flow_path)
 
-        assert result.get("plan_output") == "plan output"
-        assert result.get("implement_output") == "implement output"
-        assert result.get("review_output") == "review output"
+        assert result.results.get("plan_output") == "plan output"
+        assert result.results.get("implement_output") == "implement output"
+        assert result.results.get("review_output") == "review output"
 
     def test_list_shows_stopped_after_crash(self, temp_dir, checkpoint_flow_path):
         """T051: crash mid-flow → fdsx list shows 'stopped' not 'waiting'."""

--- a/tests/integration/test_choice_flow.py
+++ b/tests/integration/test_choice_flow.py
@@ -1,4 +1,4 @@
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from tests import FIXTURES_DIR
 
@@ -12,23 +12,24 @@ class TestChoiceFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "status" in result
+        assert isinstance(result, FlowResult)
+        assert "status" in result.results
 
     def test_choice_flow_explicit_status(self, tmp_path):
         path = FIXTURES_DIR / "choice_flow.yaml"
 
         result = run_flow(path, inputs={"initial_status": "ready"}, base_dir=tmp_path)
 
-        assert "status" in result
+        assert "status" in result.results
 
     def test_choice_flow_strips_stdout_newline(self, tmp_path):
         path = FIXTURES_DIR / "choice_flow.yaml"
 
         result = run_flow(path, inputs={"initial_status": "ready"}, base_dir=tmp_path)
 
-        assert result["status"] == "ready"
-        assert "proceed_result" in result
-        assert result["proceed_result"] == "Proceeding with execution"
+        assert result.results["status"] == "ready"
+        assert "proceed_result" in result.results
+        assert result.results["proceed_result"] == "Proceeding with execution"
 
     def test_choice_flow_default_branch(self, tmp_path):
         """Test that the default branch is taken when no rule matches."""
@@ -39,7 +40,7 @@ class TestChoiceFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "status" in result
-        assert result["status"] == "unknown_status"
-        assert "error_result" in result
-        assert result["error_result"] == "Unknown status"
+        assert "status" in result.results
+        assert result.results["status"] == "unknown_status"
+        assert "error_result" in result.results
+        assert result.results["error_result"] == "Unknown status"

--- a/tests/integration/test_ci_mode.py
+++ b/tests/integration/test_ci_mode.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from typer.testing import CliRunner
 
 from fdsx.cli.main import app
+from fdsx.core.engine import FlowResult
 from fdsx.core.engine.tasks_dir import run_tasks_dir
 from fdsx.core.mode import get_interactive_mode, is_interactive, set_interactive_mode
 from fdsx.core.selector import confirm_workflow_selection, pick_workflow_manually
@@ -162,7 +163,7 @@ class TestCIModeGuards:
                     run_count[0] += 1
                     if run_count[0] == 1:
                         raise RuntimeError("intentional error")
-                    return {"result": "ok"}
+                    return FlowResult(results={"result": "ok"}, status="completed")
 
                 with (
                     patch(
@@ -202,7 +203,7 @@ class TestCIModeGuards:
                     run_count[0] += 1
                     if run_count[0] == 1:
                         raise RuntimeError("intentional error")
-                    return {"result": "ok"}
+                    return FlowResult(results={"result": "ok"}, status="completed")
 
                 with (
                     patch(
@@ -245,7 +246,7 @@ class TestCIModeGuards:
                     run_count[0] += 1
                     if run_count[0] == 1:
                         raise RuntimeError("intentional error")
-                    return {"result": "ok"}
+                    return FlowResult(results={"result": "ok"}, status="completed")
 
                 with (
                     patch(
@@ -276,7 +277,9 @@ class TestCIModeGuards:
         runner = CliRunner()
 
         with patch("fdsx.core.engine.run_flow") as mock_run_flow:
-            mock_run_flow.return_value = {"result": "ok"}
+            mock_run_flow.return_value = FlowResult(
+                results={"result": "ok"}, status="completed"
+            )
             result = runner.invoke(
                 app,
                 [

--- a/tests/integration/test_default_tasks_dir.py
+++ b/tests/integration/test_default_tasks_dir.py
@@ -7,6 +7,7 @@ import yaml
 from typer.testing import CliRunner
 
 from fdsx.cli.main import app
+from fdsx.core.engine import FlowResult
 from fdsx.models.task import TaskEntry, TaskFile, save_task_file
 
 
@@ -64,7 +65,10 @@ class TestDefaultTasksDirResolution:
 
         with (
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -89,7 +93,10 @@ class TestDefaultTasksDirResolution:
 
         with (
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -114,7 +121,10 @@ class TestDefaultTasksDirResolution:
 
         with (
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -148,7 +158,10 @@ class TestDefaultTasksDirResolution:
 
         with (
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -178,7 +191,10 @@ class TestDefaultTasksDirResolution:
 
         with (
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -203,7 +219,10 @@ class TestDefaultTasksDirResolution:
 
         with (
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()

--- a/tests/integration/test_extraction_flow.py
+++ b/tests/integration/test_extraction_flow.py
@@ -1,4 +1,4 @@
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from fdsx.models.flow import Branch, ExtractRule, Flow, ParallelState
 from tests import FIXTURES_DIR
@@ -14,9 +14,10 @@ class TestExtractionFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "decision" in result
-        assert result["decision"] == "APPROVED"
-        assert "approved_result" in result
+        assert isinstance(result, FlowResult)
+        assert "decision" in result.results
+        assert result.results["decision"] == "APPROVED"
+        assert "approved_result" in result.results
 
     def test_regex_extraction_choice_routing(self, tmp_path):
         """Test regex extraction from structured output."""
@@ -27,9 +28,9 @@ class TestExtractionFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "extracted_status" in result
-        assert result["extracted_status"] == "success"
-        assert "success_result" in result
+        assert "extracted_status" in result.results
+        assert result.results["extracted_status"] == "success"
+        assert "success_result" in result.results
 
     def test_json_extraction_choice_routing(self, tmp_path):
         """Test JSON extraction from raw JSON output."""
@@ -40,9 +41,9 @@ class TestExtractionFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "extracted_status" in result
-        assert result["extracted_status"] == "approved"
-        assert "approved_result" in result
+        assert "extracted_status" in result.results
+        assert result.results["extracted_status"] == "approved"
+        assert "approved_result" in result.results
 
     def test_json_codeblock_extraction_choice_routing(self, tmp_path):
         """Test JSON extraction from ```json code block output (T024)."""
@@ -53,18 +54,18 @@ class TestExtractionFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "extracted_status" in result
-        assert result["extracted_status"] == "approved"
-        assert "approved_result" in result
+        assert "extracted_status" in result.results
+        assert result.results["extracted_status"] == "approved"
+        assert "approved_result" in result.results
 
     def test_json_array_extract_feeds_map(self, tmp_path):
         """System command outputs JSON array, extracted with '.', map iterates over items."""
         path = FIXTURES_DIR / "json_array_extract_map_flow.yaml"
         result = run_flow(path, base_dir=tmp_path)
-        assert "items" in result
-        assert result["items"] == ["item1", "item2", "item3"]
-        assert "map_results" in result
-        assert len(result["map_results"]) == 3
+        assert "items" in result.results
+        assert result.results["items"] == ["item1", "item2", "item3"]
+        assert "map_results" in result.results
+        assert len(result.results["map_results"]) == 3
 
 
 class TestParallelBranchExtraction:

--- a/tests/integration/test_flow_result.py
+++ b/tests/integration/test_flow_result.py
@@ -1,0 +1,41 @@
+"""Integration tests for FlowResult structured return type (T001, T002)."""
+
+from fdsx.core.engine import FlowResult, run_flow
+from tests import FIXTURES_DIR
+
+
+class TestFlowResultNormalCompletion:
+    def test_normal_flow_returns_flow_result_with_completed_status(self, tmp_path):
+        """T001: Normal workflow returns FlowResult with status='completed'."""
+        path = FIXTURES_DIR / "simple_flow.yaml"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert result.status == "completed"
+        assert result.abort_state is None
+        assert isinstance(result.results, dict)
+
+
+class TestFlowResultAbortDetection:
+    def test_abort_state_returns_flow_result_with_aborted_status(self, tmp_path):
+        """T002: Workflow ending at abort_* state returns status='aborted' with abort_state set."""
+        flow_yaml = tmp_path / "abort_flow.yaml"
+        flow_yaml.write_text(
+            "name: Abort Test Flow\n"
+            "description: Test flow that ends at an abort state\n"
+            "start_at: abort_blocked\n"
+            "states:\n"
+            "  abort_blocked:\n"
+            "    type: task\n"
+            "    provider: system\n"
+            "    command: echo blocked\n"
+            "    result_path: $.abort_output\n"
+            "    end: true\n"
+        )
+
+        result = run_flow(flow_yaml, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert result.status == "aborted"
+        assert result.abort_state == "abort_blocked"

--- a/tests/integration/test_gemini_provider.py
+++ b/tests/integration/test_gemini_provider.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import yaml
 
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.providers.base import ARG_MAX_STDIN_THRESHOLD, ProviderResult, get_provider
 from fdsx.providers.gemini import GeminiOptions, GeminiProvider
 
@@ -230,10 +230,11 @@ class TestGeminiWorkflowExecution:
         with patch("fdsx.providers.gemini._run_subprocess", return_value=fake):
             result = run_flow(flow_path, base_dir=tmp_path)
 
-        assert "greeting" in result
-        assert "farewell" in result
-        assert result["greeting"] == "gemini output"
-        assert result["farewell"] == "gemini output"
+        assert isinstance(result, FlowResult)
+        assert "greeting" in result.results
+        assert "farewell" in result.results
+        assert result.results["greeting"] == "gemini output"
+        assert result.results["farewell"] == "gemini output"
 
     def test_gemini_mixed_provider_workflow(self, tmp_path):
         """A mixed claude+gemini workflow passes state correctly between providers."""
@@ -282,10 +283,10 @@ class TestGeminiWorkflowExecution:
         ):
             result = run_flow(flow_path, base_dir=tmp_path)
 
-        assert "claude_output" in result
-        assert "gemini_output" in result
-        assert result["claude_output"] == "claude result"
-        assert result["gemini_output"] == "gemini result"
+        assert "claude_output" in result.results
+        assert "gemini_output" in result.results
+        assert result.results["claude_output"] == "claude result"
+        assert result.results["gemini_output"] == "gemini result"
 
         # Verify Gemini received the interpolated Claude output
         assert len(gemini_calls) == 1

--- a/tests/integration/test_linear_flow.py
+++ b/tests/integration/test_linear_flow.py
@@ -1,5 +1,5 @@
 from fdsx.core.compiler import compile_flow
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from tests import FIXTURES_DIR
 
@@ -17,20 +17,21 @@ class TestLinearFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "plan" in result
-        assert "implementation" in result
-        assert "review" in result
-        assert "Plan:" in result["plan"]
-        assert "Implementation:" in result["implementation"]
-        assert "Review:" in result["review"]
+        assert isinstance(result, FlowResult)
+        assert "plan" in result.results
+        assert "implementation" in result.results
+        assert "review" in result.results
+        assert "Plan:" in result.results["plan"]
+        assert "Implementation:" in result.results["implementation"]
+        assert "Review:" in result.results["review"]
 
     def test_linear_flow_with_inputs(self, tmp_path):
         path = FIXTURES_DIR / "simple_flow.yaml"
 
         result = run_flow(path, inputs={"task": "test task"}, base_dir=tmp_path)
 
-        assert "plan" in result
-        assert "implementation" in result
+        assert "plan" in result.results
+        assert "implementation" in result.results
 
     def test_linear_flow_thread_id(self, tmp_path):
         path = FIXTURES_DIR / "simple_flow.yaml"
@@ -38,4 +39,4 @@ class TestLinearFlow:
         thread_id = "test-thread-123"
         result = run_flow(path, thread_id=thread_id, base_dir=tmp_path)
 
-        assert "plan" in result
+        assert "plan" in result.results

--- a/tests/integration/test_loop_enforcement.py
+++ b/tests/integration/test_loop_enforcement.py
@@ -1,4 +1,4 @@
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from tests import FIXTURES_DIR
 
 
@@ -7,10 +7,12 @@ class TestLoopEnforcement:
         """R2-F5: flow.max_loop must bound execution via LangGraph recursion_limit."""
         path = FIXTURES_DIR / "loop_flow.yaml"
         result = run_flow(path, base_dir=tmp_path)
-        assert isinstance(result, dict)
+        assert isinstance(result, FlowResult)
         # Loop control must return partial results rather than empty dict or an exception
-        assert result != {}, "Loop control must return partial state, not empty dict"
+        assert result.results != {}, (
+            "Loop control must return partial state, not empty dict"
+        )
         # Verify that state from the last completed iteration is preserved
-        assert "plan_output" in result, (
+        assert "plan_output" in result.results, (
             "plan_output from last loop iteration must be present in partial results"
         )

--- a/tests/integration/test_loop_flow.py
+++ b/tests/integration/test_loop_flow.py
@@ -1,4 +1,4 @@
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from tests import FIXTURES_DIR
 
@@ -15,9 +15,11 @@ class TestLoopFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        # Must return a dict (not raise), and must not be empty — partial results preserved
-        assert isinstance(result, dict)
-        assert result != {}, "Loop control must return partial state, not empty dict"
+        # Must return a FlowResult (not raise), and results must not be empty — partial results preserved
+        assert isinstance(result, FlowResult)
+        assert result.results != {}, (
+            "Loop control must return partial state, not empty dict"
+        )
 
     def test_loop_returns_partial_results(self, tmp_path):
         """Test that loop returns results from the last iteration when max_loop is reached."""
@@ -25,14 +27,14 @@ class TestLoopFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert isinstance(result, dict)
+        assert isinstance(result, FlowResult)
         # The fixture loops plan→implement→review→decide and never reaches done,
         # so partial results from the last completed iteration must be present.
-        assert result != {}, "Partial results must be returned (not empty dict)"
+        assert result.results != {}, "Partial results must be returned (not empty dict)"
         # At least one of the task states' result_paths must appear in the result
         partial_keys = {"plan_output", "impl_output", "review_output"}
-        assert partial_keys.intersection(result.keys()), (
-            f"Expected at least one of {partial_keys} in result, got: {list(result.keys())}"
+        assert partial_keys.intersection(result.results.keys()), (
+            f"Expected at least one of {partial_keys} in result, got: {list(result.results.keys())}"
         )
 
     def test_state_variables_retained_across_iterations(self, tmp_path):
@@ -44,12 +46,12 @@ class TestLoopFlow:
         # plan_output, impl_output, and review_output were all set in the loop body.
         # They must all survive to the final captured state (the last iteration overwrites them,
         # so all three should be present in partial results).
-        assert "plan_output" in result, (
+        assert "plan_output" in result.results, (
             "plan_output must be retained in partial results"
         )
-        assert "impl_output" in result, (
+        assert "impl_output" in result.results, (
             "impl_output must be retained in partial results"
         )
-        assert "review_output" in result, (
+        assert "review_output" in result.results, (
             "review_output must be retained in partial results"
         )

--- a/tests/integration/test_map_checkpoint.py
+++ b/tests/integration/test_map_checkpoint.py
@@ -194,11 +194,11 @@ class TestMapCheckpoint:
                 flow_path,
             )
 
-        assert result["results"] is not None
-        assert len(result["results"]) == 3
-        assert result["results"][0] == "result-item1"
-        assert result["results"][1] == "result-item2"
-        assert result["results"][2] == "result-item3"
+        assert result.results["results"] is not None
+        assert len(result.results["results"]) == 3
+        assert result.results["results"][0] == "result-item1"
+        assert result.results["results"][1] == "result-item2"
+        assert result.results["results"][2] == "result-item3"
 
         progress_file = base_dir / "runs" / thread_id / "map_state" / "progress.json"
         assert progress_file.exists()
@@ -284,12 +284,12 @@ class TestMapCheckpoint:
             flow_path,
         )
 
-        assert result["results"] is not None
-        assert len(result["results"]) == 4
-        assert result["results"][0] == "out-a"
-        assert result["results"][1] == "out-b"
-        assert result["results"][2] == "out-c"
-        assert result["results"][3] == "out-d"
+        assert result.results["results"] is not None
+        assert len(result.results["results"]) == 4
+        assert result.results["results"][0] == "out-a"
+        assert result.results["results"][1] == "out-b"
+        assert result.results["results"][2] == "out-c"
+        assert result.results["results"][3] == "out-d"
 
     def test_map_progress_file_not_written_when_run_dir_empty(self, temp_dir):
         """When run_dir is empty (direct invoke), no progress file is written."""
@@ -452,8 +452,8 @@ class TestMapCheckpoint:
             base_dir=base_dir,
         )
 
-        assert result["results"] is not None
-        assert len(result["results"]) == 3
-        assert result["results"][0] == "result-a"
-        assert result["results"][1] == "result-b"
-        assert result["results"][2] == "result-c"
+        assert result.results["results"] is not None
+        assert len(result.results["results"]) == 3
+        assert result.results["results"][0] == "result-a"
+        assert result.results["results"][1] == "result-b"
+        assert result.results["results"][2] == "result-c"

--- a/tests/integration/test_map_flow.py
+++ b/tests/integration/test_map_flow.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from fdsx.models.flow import PassState
 from tests import FIXTURES_DIR
@@ -23,15 +23,16 @@ class TestMapBasic:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "map_results" in result
-        assert len(result["map_results"]) == 3
+        assert isinstance(result, FlowResult)
+        assert "map_results" in result.results
+        assert len(result.results["map_results"]) == 3
 
-        assert result["map_results"][0] == "step2-item1"
-        assert result["map_results"][1] == "step2-item2"
-        assert result["map_results"][2] == "step2-item3"
+        assert result.results["map_results"][0] == "step2-item1"
+        assert result.results["map_results"][1] == "step2-item2"
+        assert result.results["map_results"][2] == "step2-item3"
 
-        assert "after_result" in result
-        assert result["after_result"] == "done"
+        assert "after_result" in result.results
+        assert result.results["after_result"] == "done"
 
 
 class TestMapEmptyItems:
@@ -44,11 +45,11 @@ class TestMapEmptyItems:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "map_results" in result
-        assert result["map_results"] == []
+        assert "map_results" in result.results
+        assert result.results["map_results"] == []
 
-        assert "after_result" in result
-        assert result["after_result"] == "map-completed"
+        assert "after_result" in result.results
+        assert result.results["after_result"] == "map-completed"
 
 
 class TestMapFailFast:
@@ -173,13 +174,13 @@ class TestMapInsideParallel:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "parallel_results" in result
-        assert len(result["parallel_results"]) == 2
+        assert "parallel_results" in result.results
+        assert len(result.results["parallel_results"]) == 2
 
-        assert "map_results" in result
-        assert len(result["map_results"]) == 2
-        assert result["map_results"][0] == "mapped-x"
-        assert result["map_results"][1] == "mapped-y"
+        assert "map_results" in result.results
+        assert len(result.results["map_results"]) == 2
+        assert result.results["map_results"][0] == "mapped-x"
+        assert result.results["map_results"][1] == "mapped-y"
 
 
 class TestMapItemVariableResolution:

--- a/tests/integration/test_parallel_flow.py
+++ b/tests/integration/test_parallel_flow.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from fdsx.logging.recorder import LOGS_DIR_NAME, RUNS_DIR_NAME
 from tests import FIXTURES_DIR
@@ -16,15 +16,16 @@ class TestParallelFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "reviews" in result
-        assert len(result["reviews"]) == 3
+        assert isinstance(result, FlowResult)
+        assert "reviews" in result.results
+        assert len(result.results["reviews"]) == 3
 
-        for review in result["reviews"]:
+        for review in result.results["reviews"]:
             assert "output" in review
             assert "exit_code" in review
 
-        assert "decision" in result
-        assert result["decision"] == "APPROVED"
+        assert "decision" in result.results
+        assert result.results["decision"] == "APPROVED"
 
     def test_parallel_branch_results_have_output_field(self, tmp_path):
         """Verify branch results array contains output field."""
@@ -32,9 +33,9 @@ class TestParallelFlow:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "reviews" in result
-        assert len(result["reviews"]) == 3
-        for review in result["reviews"]:
+        assert "reviews" in result.results
+        assert len(result.results["reviews"]) == 3
+        for review in result.results["reviews"]:
             assert "output" in review
 
 
@@ -48,14 +49,16 @@ class TestParallelMinSuccess:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "results" in result
-        assert len(result["results"]) == 3
+        assert "results" in result.results
+        assert len(result.results["results"]) == 3
 
-        successful = sum(1 for r in result["results"] if r.get("exit_code") == 0)
+        successful = sum(
+            1 for r in result.results["results"] if r.get("exit_code") == 0
+        )
         assert successful == 2
 
-        assert "success_check" in result
-        assert result["success_check"] == "Flow continued after partial failure"
+        assert "success_check" in result.results
+        assert result.results["success_check"] == "Flow continued after partial failure"
 
     def test_min_success_failure_raises_error(self):
         """Test that when too many branches fail, flow raises error."""

--- a/tests/integration/test_profile_flow.py
+++ b/tests/integration/test_profile_flow.py
@@ -82,9 +82,9 @@ class TestProfileFlow:
         with patch("fdsx.providers.claude._run_subprocess", return_value=fake):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "plan" in result
-        assert "implementation" in result
-        assert "review" in result
+        assert "plan" in result.results
+        assert "implementation" in result.results
+        assert "review" in result.results
 
 
 class TestProfileFlowErrors:
@@ -323,8 +323,8 @@ class TestParallelProfileFlow:
 
         result = run_flow(flow_path, base_dir=tmp_path)
 
-        assert "reviews" in result
-        assert len(result["reviews"]) == 2
+        assert "reviews" in result.results
+        assert len(result.results["reviews"]) == 2
 
 
 class TestBackwardCompatibility:
@@ -343,12 +343,12 @@ class TestBackwardCompatibility:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "plan" in result
-        assert "implementation" in result
-        assert "review" in result
-        assert "Plan:" in result["plan"]
-        assert "Implementation:" in result["implementation"]
-        assert "Review:" in result["review"]
+        assert "plan" in result.results
+        assert "implementation" in result.results
+        assert "review" in result.results
+        assert "Plan:" in result.results["plan"]
+        assert "Implementation:" in result.results["implementation"]
+        assert "Review:" in result.results["review"]
 
     def test_parallel_review_flow_loads_compiles_and_runs_without_profiles(
         self, tmp_path
@@ -365,8 +365,8 @@ class TestBackwardCompatibility:
 
         result = run_flow(path, base_dir=tmp_path)
 
-        assert "reviews" in result
-        assert "decision" in result
+        assert "reviews" in result.results
+        assert "decision" in result.results
 
 
 class TestProfilesOptional:

--- a/tests/integration/test_result_file.py
+++ b/tests/integration/test_result_file.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from fdsx.core import engine
+from fdsx.core.engine import FlowResult
 from fdsx.core.variables import RESULT_FILE_DATA_DIR
 from fdsx.logging.recorder import RUNS_DIR_NAME
 from tests import FIXTURES_DIR
@@ -58,14 +59,15 @@ class TestTaskResultFileIntegration:
         thread_id = "test-task-result-file"
         result = engine.run_flow(flow_yaml, thread_id=thread_id, base_dir=tmp_path)
 
+        assert isinstance(result, FlowResult)
         run_dir = tmp_path / RUNS_DIR_NAME / thread_id
         expected_file = run_dir / RESULT_FILE_DATA_DIR / "output_ref.md"
 
-        assert "output_ref" in result, (
-            f"result_file variable missing from result: {result}"
+        assert "output_ref" in result.results, (
+            f"result_file variable missing from result: {result.results}"
         )
-        assert Path(result["output_ref"]).is_absolute(), (
-            f"output_ref should be absolute path, got: {result['output_ref']}"
+        assert Path(result.results["output_ref"]).is_absolute(), (
+            f"output_ref should be absolute path, got: {result.results['output_ref']}"
         )
         assert expected_file.exists(), f"Expected file not found: {expected_file}"
 
@@ -73,12 +75,14 @@ class TestTaskResultFileIntegration:
         assert "Hello World" in content, (
             f"File content mismatch. Expected 'Hello World', got: {content!r}"
         )
-        assert result["output_ref"] == str(expected_file.resolve()), (
-            f"output_ref path mismatch: {result['output_ref']} != {expected_file.resolve()}"
+        assert result.results["output_ref"] == str(expected_file.resolve()), (
+            f"output_ref path mismatch: {result.results['output_ref']} != {expected_file.resolve()}"
         )
-        assert "final" in result, f"Downstream state result missing: {result}"
-        assert "Hello World" in result["final"], (
-            f"Downstream state should read file contents, got: {result['final']!r}"
+        assert "final" in result.results, (
+            f"Downstream state result missing: {result.results}"
+        )
+        assert "Hello World" in result.results["final"], (
+            f"Downstream state should read file contents, got: {result.results['final']!r}"
         )
 
 
@@ -124,11 +128,11 @@ class TestParallelResultFileIntegration:
         run_dir = tmp_path / RUNS_DIR_NAME / thread_id
         expected_file = run_dir / RESULT_FILE_DATA_DIR / "reviews_ref.json"
 
-        assert "reviews_ref" in result, (
-            f"result_file variable missing from result: {result}"
+        assert "reviews_ref" in result.results, (
+            f"result_file variable missing from result: {result.results}"
         )
-        assert Path(result["reviews_ref"]).is_absolute(), (
-            f"reviews_ref should be absolute path, got: {result['reviews_ref']}"
+        assert Path(result.results["reviews_ref"]).is_absolute(), (
+            f"reviews_ref should be absolute path, got: {result.results['reviews_ref']}"
         )
         assert expected_file.exists(), f"Expected JSON file not found: {expected_file}"
 
@@ -143,8 +147,8 @@ class TestParallelResultFileIntegration:
             assert "exit_code" in entry, (
                 f"Missing 'exit_code' key in branch result: {entry}"
             )
-        assert result["reviews_ref"] == str(expected_file.resolve()), (
-            f"reviews_ref path mismatch: {result['reviews_ref']} != {expected_file.resolve()}"
+        assert result.results["reviews_ref"] == str(expected_file.resolve()), (
+            f"reviews_ref path mismatch: {result.results['reviews_ref']} != {expected_file.resolve()}"
         )
 
 
@@ -167,8 +171,12 @@ class TestResultFileRegression:
             f"data/ directory should not be created when result_file is not used, "
             f"but found: {data_dir}"
         )
-        assert "plan" in result, f"Expected 'plan' in result: {result}"
-        assert "implementation" in result, (
-            f"Expected 'implementation' in result: {result}"
+        assert "plan" in result.results, (
+            f"Expected 'plan' in result.results: {result.results}"
         )
-        assert "review" in result, f"Expected 'review' in result: {result}"
+        assert "implementation" in result.results, (
+            f"Expected 'implementation' in result.results: {result.results}"
+        )
+        assert "review" in result.results, (
+            f"Expected 'review' in result.results: {result.results}"
+        )

--- a/tests/integration/test_resume_tasks_dir.py
+++ b/tests/integration/test_resume_tasks_dir.py
@@ -1,0 +1,129 @@
+"""Integration tests for resume_flow updating task YAML entry status.
+
+Tests that when run_flow is called with task_file_path and task_entry_index,
+the checkpoint stores this metadata and resume_flow uses it to update the
+task entry status after completion.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.core import engine
+from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
+from tests import FIXTURES_DIR
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def checkpoint_flow_path():
+    return FIXTURES_DIR / "checkpoint_flow.yaml"
+
+
+def _make_task_file(path: Path, status: str = "pending") -> None:
+    """Write a single-entry task YAML to path."""
+    task_file = TaskFile(
+        entries=[TaskEntry(description="Test task", status=status)]  # type: ignore[arg-type]
+    )
+    save_task_file(path, task_file)
+
+
+class TestResumeUpdatesTaskEntry:
+    def test_resume_updates_entry_to_completed(self, temp_dir, checkpoint_flow_path):
+        """After resuming a flow started via run_flow with task_file_path, the
+        task entry status should be updated to 'completed'."""
+        base_dir = temp_dir / ".fdsx"
+        task_file_path = temp_dir / "task.yaml"
+        _make_task_file(task_file_path, status="running")
+
+        thread_id = "test-resume-task-completed"
+
+        # Run the flow with task_file_path stored in _meta
+        engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+            task_file_path=task_file_path,
+            task_entry_index=0,
+        )
+
+        # Simulate that the task file entry is still "running" (e.g. crash before update)
+        _make_task_file(task_file_path, status="running")
+
+        # Resume the flow — it should update the task entry to "completed"
+        result = engine.resume_flow(thread_id, base_dir=base_dir)
+
+        assert result.status == "completed"
+
+        reloaded = load_task_file(task_file_path)
+        assert reloaded.entries[0].status == "completed"
+        assert reloaded.entries[0].thread_id == thread_id
+        assert reloaded.entries[0].error is None
+
+    def test_resume_updates_entry_to_failed_on_abort(
+        self, temp_dir, checkpoint_flow_path
+    ):
+        """After resuming a flow that is detected as aborted, the task entry
+        status should be updated to 'failed' with an appropriate error message."""
+        base_dir = temp_dir / ".fdsx"
+        task_file_path = temp_dir / "task.yaml"
+        _make_task_file(task_file_path, status="running")
+
+        thread_id = "test-resume-task-aborted"
+
+        engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+            task_file_path=task_file_path,
+            task_entry_index=0,
+        )
+
+        # Reset entry to running
+        _make_task_file(task_file_path, status="running")
+
+        # Patch _detect_abort_status to simulate an aborted flow
+        with patch(
+            "fdsx.core.engine.resume._detect_abort_status",
+            return_value=("aborted", "abort_blocked", "workflow aborted"),
+        ):
+            result = engine.resume_flow(thread_id, base_dir=base_dir)
+
+        assert result.status == "aborted"
+
+        reloaded = load_task_file(task_file_path)
+        assert reloaded.entries[0].status == "failed"
+        assert reloaded.entries[0].thread_id == thread_id
+        assert reloaded.entries[0].error is not None
+        assert "abort_blocked" in reloaded.entries[0].error
+
+    def test_resume_missing_task_file_no_error(self, temp_dir, checkpoint_flow_path):
+        """When the task file no longer exists at resume time, resume_flow must
+        not raise — the update is best-effort."""
+        base_dir = temp_dir / ".fdsx"
+        task_file_path = temp_dir / "task.yaml"
+        _make_task_file(task_file_path, status="running")
+
+        thread_id = "test-resume-task-missing-file"
+
+        engine.run_flow(
+            checkpoint_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+            task_file_path=task_file_path,
+            task_entry_index=0,
+        )
+
+        # Delete the task file before resuming
+        task_file_path.unlink()
+
+        # resume_flow must complete normally without raising
+        result = engine.resume_flow(thread_id, base_dir=base_dir)
+        assert result.status == "completed"

--- a/tests/integration/test_scenario_flows.py
+++ b/tests/integration/test_scenario_flows.py
@@ -9,6 +9,7 @@ import pytest
 
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core import engine
+from fdsx.core.engine import FlowResult
 from fdsx.core.loader import load_flow
 from fdsx.providers.base import ProviderResult
 from tests import FIXTURES_DIR
@@ -27,12 +28,13 @@ class TestScenario1LinearFlow:
         thread_id = "test-scenario1"
         result = engine.run_flow(path, thread_id=thread_id, base_dir=tmp_path)
 
-        assert "plan" in result
-        assert "implementation" in result
-        assert "review" in result
-        assert "Plan:" in result["plan"]
-        assert "Implementation:" in result["implementation"]
-        assert "Review:" in result["review"]
+        assert isinstance(result, FlowResult)
+        assert "plan" in result.results
+        assert "implementation" in result.results
+        assert "review" in result.results
+        assert "Plan:" in result.results["plan"]
+        assert "Implementation:" in result.results["implementation"]
+        assert "Review:" in result.results["review"]
 
     def test_linear_flow_run_log_schema(self, tmp_path, monkeypatch):
         """Verify runs/<thread_id>.json conforms to Run Log Format schema."""
@@ -107,14 +109,14 @@ class TestScenario2ParallelVote:
 
         result = engine.run_flow(path, thread_id="test-scenario2", base_dir=tmp_path)
 
-        assert "reviews" in result
-        assert len(result["reviews"]) == 3
-        for review in result["reviews"]:
+        assert "reviews" in result.results
+        assert len(result.results["reviews"]) == 3
+        for review in result.results["reviews"]:
             assert "output" in review
 
-        assert "decision" in result
-        assert result["decision"] == "APPROVED"
-        assert "approved_result" in result
+        assert "decision" in result.results
+        assert result.results["decision"] == "APPROVED"
+        assert "approved_result" in result.results
 
     def test_parallel_run_log_has_branch_details(self, tmp_path, monkeypatch):
         """Verify parallel state entries include branch-level details."""
@@ -169,10 +171,10 @@ class TestScenario3WaitWebhook:
                 )
 
             assert mock_webhook.call_count == 1
-            assert "plan_output" in result
-            assert "approval_decision" in result
-            assert result["approval_decision"] == "approve"
-            assert "implementation_output" in result
+            assert "plan_output" in result.results
+            assert "approval_decision" in result.results
+            assert result.results["approval_decision"] == "approve"
+            assert "implementation_output" in result.results
 
     def test_wait_webhook_run_log(self, tmp_path, monkeypatch):
         """Verify run log for wait state scenario."""
@@ -235,9 +237,9 @@ class TestScenario4CheckpointResume:
                 flow_path,
             )
 
-            assert result.get("plan_output") == "plan output"
-            assert result.get("implement_output") == "implement output"
-            assert result.get("review_output") == "review output"
+            assert result.results.get("plan_output") == "plan output"
+            assert result.results.get("implement_output") == "implement output"
+            assert result.results.get("review_output") == "review output"
 
     def test_resume_appends_to_existing_run_log(self, monkeypatch):
         """Verify resume appends new state entries to existing run log."""
@@ -330,10 +332,10 @@ class TestScenario5ExtractionChoice:
 
         result = engine.run_flow(path, thread_id="test-scenario5", base_dir=tmp_path)
 
-        assert "raw_output" in result
-        assert "decision" in result
-        assert result["decision"] == "APPROVED"
-        assert "approved_result" in result
+        assert "raw_output" in result.results
+        assert "decision" in result.results
+        assert result.results["decision"] == "APPROVED"
+        assert "approved_result" in result.results
 
     def test_extraction_run_log(self, tmp_path, monkeypatch):
         """Verify run log for extraction + choice scenario."""

--- a/tests/integration/test_self_improve_flow.py
+++ b/tests/integration/test_self_improve_flow.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from fdsx.providers.base import ProviderResult
 from tests import FIXTURES_DIR
@@ -48,8 +48,9 @@ class TestSelfImproveWorkflow:
         with patch("fdsx.providers.system._run_subprocess", return_value=fake):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "collect_decision" in result
-        assert result["collect_decision"] == "HAS_RUNS"
+        assert isinstance(result, FlowResult)
+        assert "collect_decision" in result.results
+        assert result.results["collect_decision"] == "HAS_RUNS"
 
     def test_collect_data_extracts_no_runs_keyword(self, tmp_path):
         """Test that collect_data extracts NO_RUNS when no runs exist."""
@@ -59,8 +60,8 @@ class TestSelfImproveWorkflow:
         with patch("fdsx.providers.system._run_subprocess", return_value=fake):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "collect_decision" in result
-        assert result["collect_decision"] == "NO_RUNS"
+        assert "collect_decision" in result.results
+        assert result.results["collect_decision"] == "NO_RUNS"
 
     def test_choice_routes_to_clean_path_when_no_runs(self, tmp_path):
         """Test that choice routes to update_timestamp_clean when NO_RUNS."""
@@ -83,7 +84,7 @@ class TestSelfImproveWorkflow:
         ):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "timestamp_update" in result
+        assert "timestamp_update" in result.results
         assert call_count[0] >= 2
 
     def test_choice_routes_to_write_lessons_when_has_runs(self, tmp_path):
@@ -107,9 +108,9 @@ class TestSelfImproveWorkflow:
         ):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "collect_decision" in result
-        assert result["collect_decision"] == "HAS_RUNS"
-        assert "lessons" in result
+        assert "collect_decision" in result.results
+        assert result.results["collect_decision"] == "HAS_RUNS"
+        assert "lessons" in result.results
 
 
 class TestCollectDataScript:

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -737,6 +737,92 @@ class TestTasksDirCli:
             f"exit_code={result.exit_code}, stderr={result.stderr}"
         )
 
+    def test_run_tasks_dir_exit_code_one_on_failed(self, tmp_path):
+        project_root = Path(__file__).resolve().parent.parent.parent
+        workflow_path = project_root / "tests/fixtures/batch_flow.yaml"
+
+        (tmp_path / ".fdsx").mkdir()
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="cli task")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        failed_results = [
+            {
+                "file_index": 0,
+                "file_name": "001-test.yaml",
+                "entry_index": 0,
+                "entry_description": "cli task",
+                "thread_id": "thread-1",
+                "status": "failed",
+                "error": "something went wrong",
+                "category": "new",
+            },
+        ]
+
+        with (
+            patch("fdsx.cli.main.engine.run_tasks_dir", return_value=failed_results),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                app,
+                [
+                    "run",
+                    str(workflow_path),
+                    "--tasks-dir",
+                    str(tasks_dir),
+                    "--auto-workflow",
+                ],
+            )
+
+        assert result.exit_code == 1, (
+            f"exit_code={result.exit_code}, output={result.output}"
+        )
+
+    def test_run_tasks_dir_exit_code_zero_on_success(self, tmp_path):
+        project_root = Path(__file__).resolve().parent.parent.parent
+        workflow_path = project_root / "tests/fixtures/batch_flow.yaml"
+
+        (tmp_path / ".fdsx").mkdir()
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        tf = TaskFile(entries=[TaskEntry(description="cli task")])
+        save_task_file(tasks_dir / "001-test.yaml", tf)
+
+        success_results = [
+            {
+                "file_index": 0,
+                "file_name": "001-test.yaml",
+                "entry_index": 0,
+                "entry_description": "cli task",
+                "thread_id": "thread-1",
+                "status": "completed",
+                "error": None,
+                "category": "new",
+            },
+        ]
+
+        with (
+            patch("fdsx.cli.main.engine.run_tasks_dir", return_value=success_results),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                app,
+                [
+                    "run",
+                    str(workflow_path),
+                    "--tasks-dir",
+                    str(tasks_dir),
+                    "--auto-workflow",
+                ],
+            )
+
+        assert result.exit_code == 0, (
+            f"exit_code={result.exit_code}, output={result.output}"
+        )
+
     def test_run_tasks_dir_mutual_exclusion(self, tmp_path):
         (tmp_path / ".fdsx").mkdir()
         tasks_dir = tmp_path / "tasks"

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -603,6 +603,58 @@ class TestRunTasksDir:
             loaded = load_task_file(tasks_dir / "001-test.yaml")
             assert loaded.entries[0].thread_id is not None
 
+    def test_aborted_workflow_marks_entry_failed_no_file_move(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = FIXTURES_DIR / "batch_flow.yaml"
+
+            tf = TaskFile(entries=[TaskEntry(description="task 1")])
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with (
+                patch(
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={}, status="aborted", abort_state="abort_blocked"
+                    ),
+                ),
+                patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+            ):
+                results = engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            assert len(results) == 1
+            result = results[0]
+            assert result["status"] == "failed"
+            assert result["error"] == "workflow aborted at state 'abort_blocked'"
+
+            # Task file must NOT be moved to completed/
+            assert (tasks_dir / "001-test.yaml").exists()
+            assert not (tasks_dir / "completed" / "001-test.yaml").exists()
+
+            # Entry status persisted as failed
+            loaded = load_task_file(tasks_dir / "001-test.yaml")
+            assert loaded.entries[0].status == "failed"
+
+    def test_aborted_workflow_summary_shows_failed_count(self, capsys):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks_dir = Path(tmpdir)
+            flow_path = FIXTURES_DIR / "batch_flow.yaml"
+
+            tf = TaskFile(entries=[TaskEntry(description="task 1")])
+            save_task_file(tasks_dir / "001-test.yaml", tf)
+
+            with patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(
+                    results={}, status="aborted", abort_state="abort_blocked"
+                ),
+            ):
+                engine.run_tasks_dir(flow_path, tasks_dir, auto_workflow=True)
+
+            captured = capsys.readouterr()
+            assert "Failed: 1" in captured.err
+            assert "✗" in captured.err
+
 
 class TestDisplayTasksDirSummary:
     def test_displays_summary_to_stderr(self, capsys):

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 
 from fdsx.cli.main import app
 from fdsx.core import engine
+from fdsx.core.engine import FlowResult
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 from tests import FIXTURES_DIR
 
@@ -240,7 +241,10 @@ class TestRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -279,7 +283,7 @@ class TestRunTasksDir:
 
             def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 run_count[0] += 1
-                return {"result": "ok"}
+                return FlowResult(results={"result": "ok"}, status="completed")
 
             with (
                 patch("fdsx.core.engine.tasks_dir.run_flow", side_effect=mock_run_flow),
@@ -313,7 +317,10 @@ class TestRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -346,7 +353,10 @@ class TestRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -374,7 +384,7 @@ class TestRunTasksDir:
 
             def mock_run_flow(flow_path, inputs, thread_id, base_dir, **kwargs):
                 call_count[0] += 1
-                return {"result": "ok"}
+                return FlowResult(results={"result": "ok"}, status="completed")
 
             with (
                 patch("fdsx.core.engine.tasks_dir.run_flow", side_effect=mock_run_flow),
@@ -413,7 +423,7 @@ class TestRunTasksDir:
                     call_count[0] += 1
                     if call_count[0] == 1:
                         raise RuntimeError("Task 1 failed")
-                    return {"result": "ok"}
+                    return FlowResult(results={"result": "ok"}, status="completed")
 
                 with (
                     patch(
@@ -459,7 +469,7 @@ class TestRunTasksDir:
                     call_count[0] += 1
                     if call_count[0] == 1:
                         raise RuntimeError("Task 1 failed")
-                    return {"result": "ok"}
+                    return FlowResult(results={"result": "ok"}, status="completed")
 
                 with (
                     patch(
@@ -491,7 +501,10 @@ class TestRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ) as mock_run,
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -518,7 +531,10 @@ class TestRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ) as mock_run,
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -647,7 +663,10 @@ class TestTasksDirCli:
         save_task_file(tasks_dir / "001-test.yaml", tf)
 
         with (
-            patch("fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}),
+            patch(
+                "fdsx.core.engine.tasks_dir.run_flow",
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
+            ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
         ):
             runner = CliRunner()
@@ -754,7 +773,10 @@ class TestMoveToCompletedOnRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -805,7 +827,7 @@ class TestMoveToCompletedOnRunTasksDir:
                 call_count[0] += 1
                 if call_count[0] == 1:
                     raise RuntimeError("first fails")
-                return {"result": "ok"}
+                return FlowResult(results={"result": "ok"}, status="completed")
 
             with (
                 patch("fdsx.core.engine.tasks_dir.run_flow", side_effect=mock_run_flow),
@@ -849,7 +871,9 @@ class TestMoveToCompletedOnRunTasksDir:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch(
@@ -881,7 +905,10 @@ class TestMoveToCompletedOnRunTasksDir:
 
             with (
                 patch(
-                    "fdsx.core.engine.tasks_dir.run_flow", return_value={"result": "ok"}
+                    "fdsx.core.engine.tasks_dir.run_flow",
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             ):
@@ -942,7 +969,7 @@ class TestBatchEditFlow:
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
             patch(
                 "fdsx.core.engine.tasks_dir.run_flow",
-                return_value={"result": "ok"},
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
             ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             patch(
@@ -1008,7 +1035,7 @@ class TestBatchEditFlow:
             patch("fdsx.core.selector.get_provider", return_value=MagicMock()),
             patch(
                 "fdsx.core.engine.tasks_dir.run_flow",
-                return_value={"result": "ok"},
+                return_value=FlowResult(results={"result": "ok"}, status="completed"),
             ),
             patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
             patch(

--- a/tests/integration/test_wait_resume.py
+++ b/tests/integration/test_wait_resume.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from fdsx.core.engine import run_flow
+from fdsx.core.engine import FlowResult, run_flow
 from fdsx.core.loader import load_flow
 from tests import FIXTURES_DIR
 
@@ -21,23 +21,25 @@ class TestWaitFlow:
         with patch("builtins.input", return_value="1"):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "plan_output" in result
-        assert "approval_decision" in result
-        assert result["approval_decision"] == "approve"
-        assert "implementation_output" in result
+        assert isinstance(result, FlowResult)
+        assert "plan_output" in result.results
+        assert "approval_decision" in result.results
+        assert result.results["approval_decision"] == "approve"
+        assert "implementation_output" in result.results
 
     def test_wait_state_prompt_with_reject_selection(self, tmp_path):
         """Test Wait → Choice routing: select reject → verify flow takes reject branch."""
         path = FIXTURES_DIR / "wait_approval.yaml"
 
-        # Mock stdin to provide "2" (reject)
-        with patch("builtins.input", return_value="2"):
-            result = run_flow(path, base_dir=tmp_path)
+        # Patch is_interactive to force the interactive prompt path in CI
+        with patch("fdsx.core.mode.is_interactive", return_value=True):
+            with patch("builtins.input", return_value="2"):
+                result = run_flow(path, base_dir=tmp_path)
 
-        assert "plan_output" in result
-        assert "approval_decision" in result
-        assert result["approval_decision"] == "reject"
-        assert "rejected_output" in result
+        assert "plan_output" in result.results
+        assert "approval_decision" in result.results
+        assert result.results["approval_decision"] == "reject"
+        assert "rejected_output" in result.results
 
     def test_wait_state_prompt_with_invalid_input_then_valid(self, tmp_path):
         """Test Wait state re-prompt on invalid input."""
@@ -47,8 +49,8 @@ class TestWaitFlow:
         with patch("builtins.input", side_effect=["invalid", "5", "1"]):
             result = run_flow(path, base_dir=tmp_path)
 
-        assert "approval_decision" in result
-        assert result["approval_decision"] == "approve"
+        assert "approval_decision" in result.results
+        assert result.results["approval_decision"] == "approve"
 
     def test_wait_webhook_notification_sent(self, tmp_path):
         """Test webhook notification: verify POST is sent when notify is configured."""
@@ -65,8 +67,8 @@ class TestWaitFlow:
             call_args = mock_webhook.call_args
             assert call_args[0][0] == "https://example.com/webhook"
             assert "Approval needed" in call_args[0][1]
-            assert "plan_output" in result
-            assert result["approval_decision"] == "approve"
+            assert "plan_output" in result.results
+            assert result.results["approval_decision"] == "approve"
 
     def test_wait_webhook_sent_exactly_once_on_approve(self, tmp_path):
         """Regression: webhook must fire exactly once, not on every resume cycle.
@@ -84,7 +86,7 @@ class TestWaitFlow:
             with patch("builtins.input", return_value="1"):
                 result = run_flow(path, base_dir=tmp_path)
 
-        assert result["approval_decision"] == "approve"
+        assert result.results["approval_decision"] == "approve"
         assert mock_webhook.call_count == 1, (
             f"Expected webhook called exactly once, got {mock_webhook.call_count}"
         )
@@ -103,5 +105,5 @@ class TestWaitFlow:
             # Verify webhook was called
             assert mock_webhook.called
             # Flow should still complete successfully
-            assert result["approval_decision"] == "approve"
-            assert "implementation_output" in result
+            assert result.results["approval_decision"] == "approve"
+            assert "implementation_output" in result.results

--- a/tests/integration/test_wait_resume.py
+++ b/tests/integration/test_wait_resume.py
@@ -32,9 +32,11 @@ class TestWaitFlow:
         path = FIXTURES_DIR / "wait_approval.yaml"
 
         # Patch is_interactive to force the interactive prompt path in CI
-        with patch("fdsx.core.mode.is_interactive", return_value=True):
-            with patch("builtins.input", return_value="2"):
-                result = run_flow(path, base_dir=tmp_path)
+        with (
+            patch("fdsx.core.mode.is_interactive", return_value=True),
+            patch("builtins.input", return_value="2"),
+        ):
+            result = run_flow(path, base_dir=tmp_path)
 
         assert "plan_output" in result.results
         assert "approval_decision" in result.results

--- a/tests/integration/test_workflow_persistence.py
+++ b/tests/integration/test_workflow_persistence.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from fdsx.core import engine
+from fdsx.core.engine import FlowResult
 from fdsx.models.task import TaskEntry, TaskFile, load_task_file, save_task_file
 from tests import FIXTURES_DIR
 
@@ -24,7 +25,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch("fdsx.core.mode.is_interactive", return_value=False),
@@ -50,7 +53,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch("fdsx.core.mode.is_interactive", return_value=False),
@@ -91,7 +96,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch(
@@ -126,7 +133,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch(
@@ -157,7 +166,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch("fdsx.core.mode.is_interactive", return_value=False),
@@ -185,7 +196,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch("fdsx.core.mode.is_interactive", return_value=False),
@@ -218,7 +231,9 @@ class TestWorkflowPersistence:
             with (
                 patch(
                     "fdsx.core.engine.tasks_dir.run_flow",
-                    return_value={"result": "ok"},
+                    return_value=FlowResult(
+                        results={"result": "ok"}, status="completed"
+                    ),
                 ),
                 patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
                 patch("fdsx.core.mode.is_interactive", return_value=False),


### PR DESCRIPTION
## Summary

- **Fix retry logic**: `_filter_actionable_entries` now properly includes failed entries and categorizes them as `retried`
- **Checkpoint persistence**: Persist task file path in checkpoint metadata so task entry status is updated on resume
- **Exit code propagation**: CLI now returns exit code 1 when `tasks-dir` run has failures, 0 on success
- **Lint fixes**: Fixed I001 (unsorted imports) and SIM117 (nested with statements)

## What was done

The core issue was that failed task entries were not being properly tracked for retry. When a task entry with `status: failed` existed in a tasks file, it was not being picked up by `_filter_actionable_entries` and therefore was not being retried. Additionally, when running via `tasks-dir` mode, the CLI was not returning a non-zero exit code when tasks failed.

## How to test

```bash
# Run the full test suite
uv run pytest tests/ -v

# Specifically test the retry logic
uv run pytest tests/integration/test_tasks_dir.py::TestRunTasksDir::test_retries_failed_entries -v

# Test exit code propagation
uv run pytest tests/integration/test_tasks_dir.py::TestTasksDirCli::test_run_tasks_dir_exit_code_one_on_failed -v
uv run pytest tests/integration/test_tasks_dir.py::TestTasksDirCli::test_run_tasks_dir_exit_code_zero_on_success -v
```