### PR TITLE
refactor(checkpoint,engine): remove legacy channel_values fallback blocks

### DIFF
--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -7,21 +7,9 @@ from pathlib import Path
 from typing import Any
 
 from langchain_core.runnables.config import RunnableConfig
-from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.sqlite import SqliteSaver
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_meta_from_checkpoint(
-    checkpoint_data: Checkpoint | dict[str, Any],
-) -> dict[str, Any]:
-    """Extract _meta from checkpoint channel_values (named-channel TypedDict schema)."""
-    channel_values = checkpoint_data.get("channel_values", {})
-    meta = channel_values.get("_meta")
-    if isinstance(meta, dict):
-        return meta
-    return {}
 
 
 _SAFE_THREAD_ID = re.compile(r"^[a-zA-Z0-9_\-]+$")
@@ -202,6 +190,8 @@ class CheckpointManager:
         Returns:
             List of thread info dictionaries with thread_id, status, flow_name
         """
+        import json
+
         from fdsx.logging.recorder import RUN_FILENAME, RUNS_DIR_NAME
 
         # Collect thread IDs from checkpoint DB
@@ -239,6 +229,25 @@ class CheckpointManager:
         try:
             threads = []
             checkpointer = self.get_checkpointer() if db_path.exists() else None
+            # Cache compiled graphs by flow_path_str to avoid re-compiling
+            _compiled_cache: dict[str, Any] = {}
+
+            # Load project config once so profile-based flows can be reloaded
+            from fdsx.core.config import load_config as _load_config
+            from fdsx.core.compiler import compile_flow
+            from fdsx.core.loader import load_flow
+
+            _config_profiles: dict[str, Any] | None = None
+            try:
+                _fdsx_config = _load_config(project_dir=self.base_dir.parent)
+                if _fdsx_config.profiles:
+                    _config_profiles = {
+                        name: prof.model_dump()
+                        for name, prof in _fdsx_config.profiles.items()
+                    }
+            except Exception:
+                pass  # malformed config: profile resolution unavailable, continue without profiles
+
             for thread_id in all_thread_ids:
                 is_locked, _pid = self.is_locked(thread_id)
                 status = "running" if is_locked else "stopped"
@@ -254,48 +263,80 @@ class CheckpointManager:
                         else None
                     )
                     if checkpoint_tuple is not None:
-                        checkpoint_data = checkpoint_tuple.checkpoint
-                        meta = _extract_meta_from_checkpoint(checkpoint_data)
-                        flow_name = meta.get("flow_name", thread_id)
-                        if not is_locked:
-                            if checkpoint_tuple.pending_writes:
-                                has_error = any(
-                                    pw[1] == "__error__"
-                                    for pw in checkpoint_tuple.pending_writes
-                                    if isinstance(pw, (list, tuple)) and len(pw) >= 2
-                                )
-                                status = "stopped" if has_error else "waiting"
-                            else:
-                                status = "completed"
-                        # Extract current_state from checkpoint.
-                        # For stopped/waiting flows, prefer _meta.next_state (the node
-                        # about to execute when the crash/interrupt happened).
-                        # For completed/running flows, use last entry in versions_seen.
-                        if status in ("stopped", "waiting"):
-                            next_state_val = meta.get("next_state", "")
-                            if next_state_val and next_state_val != "__end__":
-                                current_state = next_state_val
-                            else:
-                                versions_seen = checkpoint_data.get("versions_seen", {})
-                                if isinstance(versions_seen, dict) and versions_seen:
-                                    current_state = list(versions_seen.keys())[-1]
-                        else:
-                            versions_seen = checkpoint_data.get("versions_seen", {})
-                            if isinstance(versions_seen, dict) and versions_seen:
-                                current_state = list(versions_seen.keys())[-1]
-                        # Extract started_at from checkpoint ts
-                        ts = checkpoint_data.get("ts", "")
-                        if ts and "T" in str(ts):
-                            started_at = str(ts)[:16].replace("T", " ")
+                        # Bootstrap flow_path from channel_values — one-time internal
+                        # access used only to locate the flow YAML for compilation.
+                        channel_vals = (
+                            checkpoint_tuple.checkpoint.get("channel_values", {}) or {}
+                        )
+                        meta_boot = (
+                            channel_vals.get("_meta", {})
+                            if isinstance(channel_vals, dict)
+                            else {}
+                        )
+                        if not isinstance(meta_boot, dict):
+                            meta_boot = {}
+                        flow_path_str = meta_boot.get("flow_path")
+                        flow_name = meta_boot.get("flow_name", thread_id)
+
+                        if not is_locked and flow_path_str:
+                            try:
+                                if flow_path_str not in _compiled_cache:
+                                    flow_path = Path(flow_path_str)
+                                    if flow_path.exists():
+                                        loaded_flow, _errors = load_flow(
+                                            flow_path, config_profiles=_config_profiles
+                                        )
+                                        if loaded_flow is not None:
+                                            compiled = compile_flow(
+                                                loaded_flow, checkpointer=checkpointer
+                                            )
+                                            _compiled_cache[flow_path_str] = compiled
+
+                                if flow_path_str in _compiled_cache:
+                                    compiled = _compiled_cache[flow_path_str]
+                                    state_snapshot = compiled.graph.get_state(config)
+
+                                    # Prefer flow_name from snapshot values if available
+                                    if state_snapshot.values:
+                                        snap_meta = state_snapshot.values.get(
+                                            "_meta", {}
+                                        )
+                                        if isinstance(snap_meta, dict):
+                                            flow_name = snap_meta.get(
+                                                "flow_name", flow_name
+                                            )
+
+                                    # Status detection via public StateSnapshot fields
+                                    if state_snapshot.interrupts:
+                                        status = "waiting"
+                                    elif any(
+                                        getattr(task, "error", None)
+                                        for task in state_snapshot.tasks
+                                    ):
+                                        status = "stopped"
+                                    elif state_snapshot.next == ():
+                                        status = "completed"
+                                    else:
+                                        status = "stopped"
+
+                                    # current_state: next node if pending, else run log
+                                    if state_snapshot.next:
+                                        current_state = state_snapshot.next[0]
+
+                                    # started_at from snapshot timestamp
+                                    if state_snapshot.created_at:
+                                        ts = str(state_snapshot.created_at)
+                                        if "T" in ts:
+                                            started_at = ts[:16].replace("T", " ")
+                            except Exception:
+                                pass
                 except Exception:
                     pass
 
-                # Fallback: read flow_name and started_at from run log when
-                # the checkpoint did not provide them.
-                if flow_name == thread_id or not started_at:
+                # Fallback: read flow_name, started_at, and current_state from run log
+                # when the checkpoint/snapshot did not provide them.
+                if flow_name == thread_id or not started_at or not current_state:
                     try:
-                        import json
-
                         run_log_path = runs_dir / thread_id / RUN_FILENAME
                         if run_log_path.is_file():
                             with run_log_path.open() as f:
@@ -311,6 +352,11 @@ class CheckpointManager:
                                 log_status = run_log.get("status", "")
                                 if log_status == "completed":
                                     status = "completed"
+                            # For completed flows, current_state comes from run log
+                            if not current_state:
+                                states = run_log.get("states", [])
+                                if states:
+                                    current_state = states[-1].get("name", "")
                     except (json.JSONDecodeError, OSError, KeyError):
                         pass
 

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -16,19 +16,11 @@ logger = logging.getLogger(__name__)
 def _extract_meta_from_checkpoint(
     checkpoint_data: Checkpoint | dict[str, Any],
 ) -> dict[str, Any]:
-    """Extract _meta from checkpoint channel_values, handling both
-    __root__ (object schema) and named-channel (TypedDict schema) layouts."""
+    """Extract _meta from checkpoint channel_values (named-channel TypedDict schema)."""
     channel_values = checkpoint_data.get("channel_values", {})
-    # Named-channel layout (flows with ParallelState or TypedDict schema)
     meta = channel_values.get("_meta")
     if isinstance(meta, dict):
         return meta
-    # __root__ layout (flows using object schema, e.g. no ParallelState)
-    root = channel_values.get("__root__")
-    if isinstance(root, dict):
-        meta = root.get("_meta")
-        if isinstance(meta, dict):
-            return meta
     return {}
 
 

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -274,16 +274,6 @@ class CheckpointManager:
                         if checkpointer is not None
                         else None
                     )
-                    # Legacy fallback: recover flow_path from checkpoint channel_values
-                    # for threads created before flow_path was persisted to run.json.
-                    if flow_path_str is None and checkpoint_tuple is not None:
-                        try:
-                            _cv = checkpoint_tuple.checkpoint.get("channel_values", {})
-                            _fp = _cv.get("_meta", {}).get("flow_path")
-                            if _fp:
-                                flow_path_str = _fp
-                        except Exception:
-                            pass
                     if checkpoint_tuple is not None and not is_locked and flow_path_str:
                         try:
                             if flow_path_str not in _compiled_cache:

--- a/src/fdsx/checkpoint/manager.py
+++ b/src/fdsx/checkpoint/manager.py
@@ -233,8 +233,8 @@ class CheckpointManager:
             _compiled_cache: dict[str, Any] = {}
 
             # Load project config once so profile-based flows can be reloaded
-            from fdsx.core.config import load_config as _load_config
             from fdsx.core.compiler import compile_flow
+            from fdsx.core.config import load_config as _load_config
             from fdsx.core.loader import load_flow
 
             _config_profiles: dict[str, Any] | None = None
@@ -252,9 +252,21 @@ class CheckpointManager:
                 is_locked, _pid = self.is_locked(thread_id)
                 status = "running" if is_locked else "stopped"
                 flow_name = thread_id  # fallback default
-
+                flow_path_str: str | None = None
                 current_state = ""
                 started_at = ""
+
+                # Read flow_path and metadata from run.json (public sidecar, not checkpoint internals)
+                run_log_path = runs_dir / thread_id / RUN_FILENAME
+                if run_log_path.is_file():
+                    try:
+                        with run_log_path.open() as f:
+                            _run_log_boot = json.load(f)
+                        flow_path_str = _run_log_boot.get("flow_path")
+                        flow_name = _run_log_boot.get("flow_name", thread_id)
+                    except (json.JSONDecodeError, OSError, KeyError):
+                        pass
+
                 config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
                 try:
                     checkpoint_tuple = (
@@ -262,97 +274,84 @@ class CheckpointManager:
                         if checkpointer is not None
                         else None
                     )
-                    if checkpoint_tuple is not None:
-                        # Bootstrap flow_path from channel_values — one-time internal
-                        # access used only to locate the flow YAML for compilation.
-                        channel_vals = (
-                            checkpoint_tuple.checkpoint.get("channel_values", {}) or {}
-                        )
-                        meta_boot = (
-                            channel_vals.get("_meta", {})
-                            if isinstance(channel_vals, dict)
-                            else {}
-                        )
-                        if not isinstance(meta_boot, dict):
-                            meta_boot = {}
-                        flow_path_str = meta_boot.get("flow_path")
-                        flow_name = meta_boot.get("flow_name", thread_id)
-
-                        if not is_locked and flow_path_str:
-                            try:
-                                if flow_path_str not in _compiled_cache:
-                                    flow_path = Path(flow_path_str)
-                                    if flow_path.exists():
-                                        loaded_flow, _errors = load_flow(
-                                            flow_path, config_profiles=_config_profiles
+                    # Legacy fallback: recover flow_path from checkpoint channel_values
+                    # for threads created before flow_path was persisted to run.json.
+                    if flow_path_str is None and checkpoint_tuple is not None:
+                        try:
+                            _cv = checkpoint_tuple.checkpoint.get("channel_values", {})
+                            _fp = _cv.get("_meta", {}).get("flow_path")
+                            if _fp:
+                                flow_path_str = _fp
+                        except Exception:
+                            pass
+                    if checkpoint_tuple is not None and not is_locked and flow_path_str:
+                        try:
+                            if flow_path_str not in _compiled_cache:
+                                flow_path = Path(flow_path_str)
+                                if flow_path.exists():
+                                    loaded_flow, _errors = load_flow(
+                                        flow_path, config_profiles=_config_profiles
+                                    )
+                                    if loaded_flow is not None:
+                                        compiled = compile_flow(
+                                            loaded_flow, checkpointer=checkpointer
                                         )
-                                        if loaded_flow is not None:
-                                            compiled = compile_flow(
-                                                loaded_flow, checkpointer=checkpointer
-                                            )
-                                            _compiled_cache[flow_path_str] = compiled
+                                        _compiled_cache[flow_path_str] = compiled
 
-                                if flow_path_str in _compiled_cache:
-                                    compiled = _compiled_cache[flow_path_str]
-                                    state_snapshot = compiled.graph.get_state(config)
+                            if flow_path_str in _compiled_cache:
+                                compiled = _compiled_cache[flow_path_str]
+                                state_snapshot = compiled.graph.get_state(config)
 
-                                    # Prefer flow_name from snapshot values if available
-                                    if state_snapshot.values:
-                                        snap_meta = state_snapshot.values.get(
-                                            "_meta", {}
+                                # Prefer flow_name from snapshot values if available
+                                if state_snapshot.values:
+                                    snap_meta = state_snapshot.values.get("_meta", {})
+                                    if isinstance(snap_meta, dict):
+                                        flow_name = snap_meta.get(
+                                            "flow_name", flow_name
                                         )
-                                        if isinstance(snap_meta, dict):
-                                            flow_name = snap_meta.get(
-                                                "flow_name", flow_name
-                                            )
 
-                                    # Status detection via public StateSnapshot fields
-                                    if state_snapshot.interrupts:
-                                        status = "waiting"
-                                    elif any(
-                                        getattr(task, "error", None)
-                                        for task in state_snapshot.tasks
-                                    ):
-                                        status = "stopped"
-                                    elif state_snapshot.next == ():
-                                        status = "completed"
-                                    else:
-                                        status = "stopped"
+                                # Status detection via public StateSnapshot fields
+                                if state_snapshot.interrupts:
+                                    status = "waiting"
+                                elif any(
+                                    getattr(task, "error", None)
+                                    for task in state_snapshot.tasks
+                                ):
+                                    status = "stopped"
+                                elif state_snapshot.next == ():
+                                    status = "completed"
+                                else:
+                                    status = "stopped"
 
-                                    # current_state: next node if pending, else run log
-                                    if state_snapshot.next:
-                                        current_state = state_snapshot.next[0]
+                                # current_state: next node if pending, else run log
+                                if state_snapshot.next:
+                                    current_state = state_snapshot.next[0]
 
-                                    # started_at from snapshot timestamp
-                                    if state_snapshot.created_at:
-                                        ts = str(state_snapshot.created_at)
-                                        if "T" in ts:
-                                            started_at = ts[:16].replace("T", " ")
-                            except Exception:
-                                pass
+                                # started_at from snapshot timestamp
+                                if state_snapshot.created_at:
+                                    ts = str(state_snapshot.created_at)
+                                    if "T" in ts:
+                                        started_at = ts[:16].replace("T", " ")
+                        except Exception:
+                            pass
                 except Exception:
                     pass
 
-                # Fallback: read flow_name, started_at, and current_state from run log
-                # when the checkpoint/snapshot did not provide them.
-                if flow_name == thread_id or not started_at or not current_state:
+                # Fallback: read started_at, current_state, and status from run log
+                # when the snapshot did not provide them.
+                if not started_at or not current_state:
                     try:
-                        run_log_path = runs_dir / thread_id / RUN_FILENAME
                         if run_log_path.is_file():
                             with run_log_path.open() as f:
                                 run_log = json.load(f)
-                            if flow_name == thread_id:
-                                flow_name = run_log.get("flow_name", thread_id)
                             if not started_at:
                                 ts_str = run_log.get("started_at", "")
                                 if ts_str and "T" in ts_str:
                                     started_at = ts_str[:16].replace("T", " ")
                             if not is_locked and flow_name != thread_id:
-                                # Run-log-only thread: derive status from log status
                                 log_status = run_log.get("status", "")
                                 if log_status == "completed":
                                     status = "completed"
-                            # For completed flows, current_state comes from run log
                             if not current_state:
                                 states = run_log.get("states", [])
                                 if states:

--- a/src/fdsx/core/compiler/__init__.py
+++ b/src/fdsx/core/compiler/__init__.py
@@ -13,7 +13,6 @@ from .helpers import (
     _get_next_state,
     _merge_provider_options,
     _parallel_branch_reducer,
-    _set_next_state_meta,
     _top_level_key,
 )
 from .nodes import _create_task_node
@@ -35,7 +34,6 @@ __all__ = [
     "_merge_provider_options",
     "_parallel_branch_reducer",
     "_resolve_jsonpath",
-    "_set_next_state_meta",
     "_top_level_key",
     "_wrap_with_hooks",
     "compile_flow",

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -56,9 +56,7 @@ _GRAY = 1
 _BLACK = 2
 
 
-def _get_all_next_state_names(
-    state: Any, flow_states: dict[str, Any]
-) -> list[str]:
+def _get_all_next_state_names(state: Any, flow_states: dict[str, Any]) -> list[str]:
     """Return all possible next state names from a state, filtered to known states.
 
     Handles TaskState/MapState/WaitState/PassState/ParallelState (next attribute)
@@ -104,15 +102,12 @@ def _detect_loop_back_edges(flow: Any) -> set[tuple[str, str]]:
     return back_edges
 
 
-def _make_loop_guard(target: str) -> Callable[[dict[str, Any]], str]:
-    """Return a routing function that routes to END when remaining_steps <= 2.
-
-    Used for regular (non-choice) edges that loop back to an earlier state.
-    """
+def _make_loop_guard(target: str, max_loop: int) -> Callable[[dict[str, Any]], str]:
+    """Route to END after max_loop visits to target (loop start), else loop back."""
 
     def route(state_dict: dict[str, Any]) -> str:
-        remaining = state_dict.get("remaining_steps", float("inf"))
-        if remaining <= 2:
+        iters = state_dict.get("_state_iterations", {})
+        if iters.get(target, 0) >= max_loop:
             return END
         return target
 
@@ -122,18 +117,15 @@ def _make_loop_guard(target: str) -> Callable[[dict[str, Any]], str]:
 def _wrap_routing_with_loop_guard(
     routing_fn: Callable[[dict[str, Any]], str],
     loop_back_targets: set[str],
+    max_loop: int,
 ) -> Callable[[dict[str, Any]], str]:
-    """Wrap an existing routing function to intercept loop-back transitions.
-
-    When the routing function returns a state that is a loop-back target and
-    remaining_steps <= 2, reroutes to END instead.
-    """
+    """Wrap routing fn to intercept loop-back transitions after max_loop visits."""
 
     def route(state_dict: dict[str, Any]) -> str:
         destination = routing_fn(state_dict)
         if destination in loop_back_targets:
-            remaining = state_dict.get("remaining_steps", float("inf"))
-            if remaining <= 2:
+            iters = state_dict.get("_state_iterations", {})
+            if iters.get(destination, 0) >= max_loop:
                 return END
         return destination
 
@@ -514,7 +506,7 @@ def compile_flow(
                 # Loop-back edge: replace add_edge with conditional guard
                 graph.add_conditional_edges(
                     state_name,
-                    _make_loop_guard(next_state),
+                    _make_loop_guard(next_state, flow.max_loop),
                     {next_state: next_state, END: END},
                 )
             else:
@@ -525,11 +517,13 @@ def compile_flow(
             default = state.default or END
             loop_back_targets = loop_back_targets_by_source.get(state_name, set())
             routing_fn = _create_routing_function(state)
-            path_map: dict[Any, str] = (
-                {choice.next: choice.next for choice in choices} | {default: default}
-            )
+            path_map: dict[Any, str] = {
+                choice.next: choice.next for choice in choices
+            } | {default: default}
             if loop_back_targets:
-                routing_fn = _wrap_routing_with_loop_guard(routing_fn, loop_back_targets)
+                routing_fn = _wrap_routing_with_loop_guard(
+                    routing_fn, loop_back_targets, flow.max_loop
+                )
                 path_map[END] = END
             graph.add_conditional_edges(
                 state_name,

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -135,7 +135,7 @@ def _wrap_with_hooks(
 
         try:
             output_data_path = write_hook_data(
-                result,
+                {**state_dict, **result},
                 state_name=state_name,
                 filename=OUTPUT_FILENAME,
                 thread_id=thread_id,

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -51,6 +51,94 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_WHITE = 0
+_GRAY = 1
+_BLACK = 2
+
+
+def _get_all_next_state_names(
+    state: Any, flow_states: dict[str, Any]
+) -> list[str]:
+    """Return all possible next state names from a state, filtered to known states.
+
+    Handles TaskState/MapState/WaitState/PassState/ParallelState (next attribute)
+    and ChoiceState (choices[*].next + default). Excludes "END" and None.
+    """
+    results: list[str] = []
+
+    if isinstance(state, ChoiceState):
+        for choice in state.choices:
+            if choice.next and choice.next in flow_states:
+                results.append(choice.next)
+        if state.default and state.default in flow_states:
+            results.append(state.default)
+    else:
+        next_val = getattr(state, "next", None)
+        if next_val and next_val in flow_states:
+            results.append(next_val)
+
+    return results
+
+
+def _detect_loop_back_edges(flow: Any) -> set[tuple[str, str]]:
+    """Detect back-edges in the flow graph using DFS with color marking.
+
+    A back-edge (src, dst) exists when dst is on the current DFS stack (GRAY).
+    Returns the set of (source_state_name, target_state_name) back-edge pairs.
+    """
+    color: dict[str, int] = {name: _WHITE for name in flow.states}
+    back_edges: set[tuple[str, str]] = set()
+
+    def dfs(node: str) -> None:
+        color[node] = _GRAY
+        for neighbor in _get_all_next_state_names(flow.states[node], flow.states):
+            if color[neighbor] == _GRAY:
+                back_edges.add((node, neighbor))
+            elif color[neighbor] == _WHITE:
+                dfs(neighbor)
+        color[node] = _BLACK
+
+    if flow.start_at in color:
+        dfs(flow.start_at)
+
+    return back_edges
+
+
+def _make_loop_guard(target: str) -> Callable[[dict[str, Any]], str]:
+    """Return a routing function that routes to END when remaining_steps <= 2.
+
+    Used for regular (non-choice) edges that loop back to an earlier state.
+    """
+
+    def route(state_dict: dict[str, Any]) -> str:
+        remaining = state_dict.get("remaining_steps", float("inf"))
+        if remaining <= 2:
+            return END
+        return target
+
+    return route
+
+
+def _wrap_routing_with_loop_guard(
+    routing_fn: Callable[[dict[str, Any]], str],
+    loop_back_targets: set[str],
+) -> Callable[[dict[str, Any]], str]:
+    """Wrap an existing routing function to intercept loop-back transitions.
+
+    When the routing function returns a state that is a loop-back target and
+    remaining_steps <= 2, reroutes to END instead.
+    """
+
+    def route(state_dict: dict[str, Any]) -> str:
+        destination = routing_fn(state_dict)
+        if destination in loop_back_targets:
+            remaining = state_dict.get("remaining_steps", float("inf"))
+            if remaining <= 2:
+                return END
+        return destination
+
+    return route
+
 
 class FlowState(TypedDict):
     """Base flow state - uses Any for flexibility."""
@@ -382,6 +470,12 @@ def compile_flow(
                 ),
             )  # type: ignore[call-overload]
 
+    # Pre-compute loop-back edges for loop guard insertion
+    loop_back_edges = _detect_loop_back_edges(flow)
+    loop_back_targets_by_source: dict[str, set[str]] = {}
+    for src, tgt in loop_back_edges:
+        loop_back_targets_by_source.setdefault(src, set()).add(tgt)
+
     for state_name, state in flow.states.items():
         if isinstance(state, ParallelState):
             # Fan-out: dispatch node → branch nodes via Send API (no path_map needed)
@@ -416,16 +510,31 @@ def compile_flow(
         if next_state:
             if next_state == "END":
                 graph.add_edge(state_name, END)
+            elif next_state in loop_back_targets_by_source.get(state_name, set()):
+                # Loop-back edge: replace add_edge with conditional guard
+                graph.add_conditional_edges(
+                    state_name,
+                    _make_loop_guard(next_state),
+                    {next_state: next_state, END: END},
+                )
             else:
                 graph.add_edge(state_name, next_state)
 
         if isinstance(state, ChoiceState):
             choices = state.choices
             default = state.default or END
+            loop_back_targets = loop_back_targets_by_source.get(state_name, set())
+            routing_fn = _create_routing_function(state)
+            path_map: dict[Any, str] = (
+                {choice.next: choice.next for choice in choices} | {default: default}
+            )
+            if loop_back_targets:
+                routing_fn = _wrap_routing_with_loop_guard(routing_fn, loop_back_targets)
+                path_map[END] = END
             graph.add_conditional_edges(
                 state_name,
-                _create_routing_function(state),
-                {choice.next: choice.next for choice in choices} | {default: default},  # type: ignore[arg-type]
+                routing_fn,
+                path_map,
             )
 
     graph.set_entry_point(flow.start_at)

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING, Annotated, Any, TypedDict
 
 import structlog
+from langgraph.managed import RemainingSteps
 
 from fdsx.core.config import _deep_merge
 from fdsx.models.flow import (
@@ -187,14 +188,11 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
     2. All result_path / extract / aggregate top-level keys as LastValue channels.
     3. Input keys from --input CLI flags.
     4. _meta internal key.
+    5. remaining_steps managed channel for loop control.
 
-    Returns `object` (→ __root__ single channel, no filtering) for flows with no
-    ParallelState, since they don't need the Send API reducer channels.
+    Always returns a TypedDict class with named channels for proper per-key
+    channel tracking in LangGraph checkpoints.
     """
-    has_parallel = any(isinstance(s, ParallelState) for s in flow.states.values())
-    if not has_parallel:
-        return object
-
     annotations: dict[str, Any] = {}
 
     # 1. Reducer channels for parallel branch result accumulation
@@ -234,7 +232,15 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
                     k = _top_level_key(str(target))
                     if k:
                         annotations.setdefault(k, Any)
-        elif isinstance(state, (WaitState, MapState)) and state.result_path:
+        elif isinstance(state, MapState):
+            if state.result_path:
+                k = _top_level_key(state.result_path)
+                if k:
+                    annotations.setdefault(k, Any)
+            k = _top_level_key(state.items_path)
+            if k:
+                annotations.setdefault(k, Any)
+        elif isinstance(state, WaitState) and state.result_path:
             k = _top_level_key(state.result_path)
             if k:
                 annotations.setdefault(k, Any)
@@ -247,5 +253,8 @@ def _build_state_schema(flow: Flow, input_keys: set[str] | None = None) -> type:
     # 4. Internal tracking keys
     annotations.setdefault("_meta", Any)
     annotations.setdefault("_state_iterations", Any)
+
+    # 5. Managed channel for loop control (Phase 4)
+    annotations["remaining_steps"] = RemainingSteps
 
     return TypedDict("FlowState", annotations, total=False)  # type: ignore[no-any-return,operator]

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -132,28 +132,6 @@ def _extract_result_paths(flow: Flow) -> list[str]:
     return paths
 
 
-def _set_next_state_meta(state_dict: dict[str, Any], state: Any) -> dict[str, Any]:
-    """Inject _meta.next_state so list_threads can show the correct current state.
-
-    Stores the name of the node that will execute NEXT so that if the next node
-    crashes before its checkpoint is written, list_threads() can still report the
-    correct CURRENT_STATE for the stopped flow.
-    """
-    next_name = ""
-    if hasattr(state, "next") and state.next:
-        next_name = state.next
-    elif hasattr(state, "end") and state.end:
-        next_name = "__end__"
-    if not next_name:
-        return state_dict
-    meta = state_dict.get("_meta", {})
-    if isinstance(meta, dict):
-        state_dict["_meta"] = {**meta, "next_state": next_name}
-    else:
-        state_dict["_meta"] = {"next_state": next_name}
-    return state_dict
-
-
 def _check_max_iterations(state_name: str, state_def: Any, iteration: int) -> None:
     """Raise RuntimeError if the state has exceeded its max_iterations limit.
 

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -37,6 +37,16 @@ from .helpers import (
 if TYPE_CHECKING:
     from fdsx.core.config import FdsxConfig
 
+
+def _top_key(path: str) -> str:
+    """Extract the top-level channel key from a JSONPath expression.
+
+    e.g. "$.steps.processed" -> "steps", "$.output" -> "output", "$.items[0].x" -> "items"
+    """
+    stripped = path[2:] if path.startswith("$.") else path
+    return stripped.split(".")[0].split("[")[0]
+
+
 _MAP_PROGRESS_FILENAME = "progress.json"
 
 
@@ -131,9 +141,12 @@ def _create_map_node(
             recorder.record_map_start(state_name, len(items))
 
         if len(items) == 0:
-            new_state = set_jsonpath(state.result_path, state_dict, [])
-            new_state = _set_next_state_meta(new_state, state)
-            new_state["_state_iterations"] = iters
+            rp_key = _top_key(state.result_path)
+            seed: dict[str, Any] = {rp_key: state_dict.get(rp_key)} if state_dict.get(rp_key) is not None else {}
+            partial: dict[str, Any] = set_jsonpath(state.result_path, seed, [])
+            partial["_state_iterations"] = iters
+            meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
+            partial["_meta"] = meta_holder["_meta"]
             duration = time.time() - start_time
             display_map_complete(state_name, 0, 0, duration)
             if recorder is not None:
@@ -143,7 +156,7 @@ def _create_map_node(
                     0,
                     0,
                 )
-            return new_state
+            return partial
 
         results: list[Any] = []
         n_failed = 0
@@ -342,9 +355,12 @@ def _create_map_node(
                         str(last_result) if last_result is not None else "",
                     )
 
-        new_state = set_jsonpath(state.result_path, state_dict, results)
-        new_state = _set_next_state_meta(new_state, state)
-        new_state["_state_iterations"] = iters
+        rp_key = _top_key(state.result_path)
+        seed = {rp_key: state_dict.get(rp_key)} if state_dict.get(rp_key) is not None else {}
+        partial = set_jsonpath(state.result_path, seed, results)
+        partial["_state_iterations"] = iters
+        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
+        partial["_meta"] = meta_holder["_meta"]
 
         duration = time.time() - start_time
         display_map_complete(state_name, len(items), n_failed, duration)
@@ -362,6 +378,6 @@ def _create_map_node(
                 f"Map state '{state_name}': {n_failed} of {len(items)} iterations failed"
             )
 
-        return new_state
+        return partial
 
     return node

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -31,7 +31,6 @@ from fdsx.providers.base import get_provider
 from .helpers import (
     _check_max_iterations,
     _merge_provider_options,
-    _set_next_state_meta,
 )
 
 if TYPE_CHECKING:
@@ -142,11 +141,13 @@ def _create_map_node(
 
         if len(items) == 0:
             rp_key = _top_key(state.result_path)
-            seed: dict[str, Any] = {rp_key: state_dict.get(rp_key)} if state_dict.get(rp_key) is not None else {}
+            seed: dict[str, Any] = (
+                {rp_key: state_dict.get(rp_key)}
+                if state_dict.get(rp_key) is not None
+                else {}
+            )
             partial: dict[str, Any] = set_jsonpath(state.result_path, seed, [])
             partial["_state_iterations"] = iters
-            meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
-            partial["_meta"] = meta_holder["_meta"]
             duration = time.time() - start_time
             display_map_complete(state_name, 0, 0, duration)
             if recorder is not None:
@@ -356,11 +357,13 @@ def _create_map_node(
                     )
 
         rp_key = _top_key(state.result_path)
-        seed = {rp_key: state_dict.get(rp_key)} if state_dict.get(rp_key) is not None else {}
+        seed = (
+            {rp_key: state_dict.get(rp_key)}
+            if state_dict.get(rp_key) is not None
+            else {}
+        )
         partial = set_jsonpath(state.result_path, seed, results)
         partial["_state_iterations"] = iters
-        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
-        partial["_meta"] = meta_holder["_meta"]
 
         duration = time.time() - start_time
         display_map_complete(state_name, len(items), n_failed, duration)

--- a/src/fdsx/core/compiler/nodes.py
+++ b/src/fdsx/core/compiler/nodes.py
@@ -28,7 +28,6 @@ from fdsx.providers.base import get_provider
 from .helpers import (
     _check_max_iterations,
     _merge_provider_options,
-    _set_next_state_meta,
 )
 
 if TYPE_CHECKING:
@@ -152,8 +151,6 @@ def _create_task_node(
             )
 
         partial["_state_iterations"] = iters
-        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
-        partial["_meta"] = meta_holder["_meta"]
         return partial
 
     return node
@@ -200,7 +197,9 @@ def _create_pass_node(
                     value = resolve_template(source, state_dict)
                 else:
                     value = source
-                state_dict = set_jsonpath(target, state_dict, value)  # working copy for chaining
+                state_dict = set_jsonpath(
+                    target, state_dict, value
+                )  # working copy for chaining
                 partial = set_jsonpath(target, partial, value)
                 variables_set.append(target)
 
@@ -222,8 +221,6 @@ def _create_pass_node(
             recorder.record_state_complete(state_name, "success", "", variables_set)
 
         partial["_state_iterations"] = iters
-        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
-        partial["_meta"] = meta_holder["_meta"]
         return partial
 
     return node
@@ -290,8 +287,6 @@ def _create_wait_interrupt_node(
                 state_type="wait",
             )
 
-        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
-        partial["_meta"] = meta_holder["_meta"]
         return partial
 
     return node

--- a/src/fdsx/core/compiler/nodes.py
+++ b/src/fdsx/core/compiler/nodes.py
@@ -113,6 +113,8 @@ def _create_task_node(
                 f"Provider {state.provider} failed after {max_retries + 1} attempts with exit code {result.exit_code}: {_sanitize_output(last_error)}"
             )
 
+        partial: dict[str, Any] = {}
+
         if state.extract:
             if extracted is None:
                 terminal.display_state_error(state_name, last_error)
@@ -121,15 +123,11 @@ def _create_task_node(
                 raise RuntimeError(
                     f"Extraction failed after {max_retries + 1} attempts: all strategies returned None"
                 )
-            new_state = set_jsonpath(state.extract.result_path, state_dict, extracted)
-            new_state = set_jsonpath(
-                state.result_path, new_state, result.stdout.strip()
-            )
+            partial = set_jsonpath(state.extract.result_path, partial, extracted)
+            partial = set_jsonpath(state.result_path, partial, result.stdout.strip())
             variables_set = [state.extract.result_path, state.result_path]
         else:
-            new_state = set_jsonpath(
-                state.result_path, state_dict, result.stdout.strip()
-            )
+            partial = set_jsonpath(state.result_path, partial, result.stdout.strip())
             variables_set = [state.result_path]
 
         if state.result_file:
@@ -139,7 +137,7 @@ def _create_task_node(
                 file_path = write_result_to_file(
                     varname, result.stdout.strip(), Path(run_dir)
                 )
-                new_state = set_jsonpath(state.result_file, new_state, file_path)
+                partial = set_jsonpath(state.result_file, partial, file_path)
                 variables_set = [*variables_set, state.result_file]
 
         duration = time.time() - start_time
@@ -153,9 +151,10 @@ def _create_task_node(
                 variables_set,
             )
 
-        new_state = _set_next_state_meta(new_state, state)
-        new_state["_state_iterations"] = iters
-        return new_state
+        partial["_state_iterations"] = iters
+        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
+        partial["_meta"] = meta_holder["_meta"]
+        return partial
 
     return node
 
@@ -173,7 +172,7 @@ def _create_choice_node(
         if recorder is not None:
             recorder.record_state_start(state_name, "choice")
             recorder.record_state_complete(state_name, "success", "", [])
-        return {**state_dict, "_state_iterations": iters}
+        return {"_state_iterations": iters}
 
     return node
 
@@ -193,6 +192,7 @@ def _create_pass_node(
         if recorder is not None:
             recorder.record_state_start(state_name, "pass")
 
+        partial: dict[str, Any] = {}
         variables_set = []
         if state.parameters:
             for target, source in state.parameters.items():
@@ -200,8 +200,8 @@ def _create_pass_node(
                     value = resolve_template(source, state_dict)
                 else:
                     value = source
-                new_state = set_jsonpath(target, state_dict, value)
-                state_dict = new_state
+                state_dict = set_jsonpath(target, state_dict, value)  # working copy for chaining
+                partial = set_jsonpath(target, partial, value)
                 variables_set.append(target)
 
         if state.aggregate:
@@ -215,13 +215,16 @@ def _create_pass_node(
             else:
                 result = state.aggregate.no_match
             state_dict = set_jsonpath(state.aggregate.result_path, state_dict, result)
+            partial = set_jsonpath(state.aggregate.result_path, partial, result)
             variables_set.append(state.aggregate.result_path)
 
         if recorder is not None:
             recorder.record_state_complete(state_name, "success", "", variables_set)
 
-        state_dict = _set_next_state_meta(state_dict, state)
-        return state_dict
+        partial["_state_iterations"] = iters
+        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
+        partial["_meta"] = meta_holder["_meta"]
+        return partial
 
     return node
 
@@ -250,7 +253,7 @@ def _create_wait_notify_node(
             from fdsx.notify.webhook import send_notification
 
             send_notification(state.notify, state_dict)
-        return {**state_dict, "_state_iterations": iters}
+        return {"_state_iterations": iters}
 
     return node
 
@@ -276,7 +279,7 @@ def _create_wait_interrupt_node(
             }
         )
 
-        new_state = set_jsonpath(state.result_path, state_dict, user_selection)
+        partial: dict[str, Any] = set_jsonpath(state.result_path, {}, user_selection)
 
         if recorder is not None:
             recorder.record_state_complete(
@@ -287,7 +290,8 @@ def _create_wait_interrupt_node(
                 state_type="wait",
             )
 
-        new_state = _set_next_state_meta(new_state, state)
-        return new_state
+        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
+        partial["_meta"] = meta_holder["_meta"]
+        return partial
 
     return node

--- a/src/fdsx/core/compiler/parallel.py
+++ b/src/fdsx/core/compiler/parallel.py
@@ -22,7 +22,6 @@ from fdsx.providers.base import get_provider
 from .helpers import (
     _check_max_iterations,
     _merge_provider_options,
-    _set_next_state_meta,
 )
 
 if TYPE_CHECKING:
@@ -277,7 +276,11 @@ def _create_collector_node(
             )
 
         rp_key = _top_key(state.result_path)
-        partial: dict[str, Any] = {rp_key: state_dict.get(rp_key)} if state_dict.get(rp_key) is not None else {}
+        partial: dict[str, Any] = (
+            {rp_key: state_dict.get(rp_key)}
+            if state_dict.get(rp_key) is not None
+            else {}
+        )
         partial = set_jsonpath(state.result_path, partial, clean_results)
 
         if state.result_file:
@@ -327,8 +330,6 @@ def _create_collector_node(
         # The custom _parallel_branch_reducer treats [] as a reset signal.
         partial[f"_br_{state_name}"] = []
 
-        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
-        partial["_meta"] = meta_holder["_meta"]
         return partial
 
     return node

--- a/src/fdsx/core/compiler/parallel.py
+++ b/src/fdsx/core/compiler/parallel.py
@@ -29,6 +29,15 @@ if TYPE_CHECKING:
     from fdsx.core.config import FdsxConfig
 
 
+def _top_key(path: str) -> str:
+    """Extract the top-level channel key from a JSONPath expression.
+
+    e.g. "$.review.results" -> "review", "$.output" -> "output", "$.items[0].x" -> "items"
+    """
+    stripped = path[2:] if path.startswith("$.") else path
+    return stripped.split(".")[0].split("[")[0]
+
+
 def _create_dispatch_node(
     state_name: str, state: ParallelState, recorder: Any = None
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
@@ -267,14 +276,19 @@ def _create_collector_node(
                 f"Failed branches: {'; '.join(failed_branches)}"
             )
 
-        new_state = set_jsonpath(state.result_path, state_dict, clean_results)
+        rp_key = _top_key(state.result_path)
+        partial: dict[str, Any] = {rp_key: state_dict.get(rp_key)} if state_dict.get(rp_key) is not None else {}
+        partial = set_jsonpath(state.result_path, partial, clean_results)
 
         if state.result_file:
             run_dir = state_dict.get("_meta", {}).get("run_dir", "")
             if run_dir:
                 varname = state.result_file[2:]  # strip "$."
                 file_path = write_result_to_file(varname, clean_results, Path(run_dir))
-                new_state = set_jsonpath(state.result_file, new_state, file_path)
+                rf_key = _top_key(state.result_file)
+                if rf_key not in partial and state_dict.get(rf_key) is not None:
+                    partial[rf_key] = state_dict[rf_key]  # seed sibling-safe channel
+                partial = set_jsonpath(state.result_file, partial, file_path)
 
         display_results = []
         for r in sorted_results:
@@ -311,9 +325,10 @@ def _create_collector_node(
 
         # Reset the branch accumulator so the next loop iteration starts clean.
         # The custom _parallel_branch_reducer treats [] as a reset signal.
-        new_state[f"_br_{state_name}"] = []
+        partial[f"_br_{state_name}"] = []
 
-        new_state = _set_next_state_meta(new_state, state)
-        return new_state
+        meta_holder = _set_next_state_meta({"_meta": state_dict.get("_meta") or {}}, state)
+        partial["_meta"] = meta_holder["_meta"]
+        return partial
 
     return node

--- a/src/fdsx/core/engine/interrupts.py
+++ b/src/fdsx/core/engine/interrupts.py
@@ -48,12 +48,12 @@ def handle_interrupts(
 
         user_selection = display_wait_prompt(state_name, message, choices)
 
-        for state_snapshot in graph.stream(
+        for chunk in graph.stream(
             Command(resume=user_selection),
             config=config,
             stream_mode=stream_mode,
+            version="v2",
         ):
-            if "__interrupt__" not in state_snapshot:
-                last_state = state_snapshot
+            last_state = chunk["data"]
 
     return last_state

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -6,7 +6,7 @@ from typing import Any, Literal, cast
 
 from langgraph.types import Command
 
-from fdsx.checkpoint.manager import CheckpointManager, _extract_meta_from_checkpoint
+from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core.compiler import compile_flow
 from fdsx.core.config import load_config
 from fdsx.core.loader import load_flow
@@ -75,11 +75,17 @@ def resume_flow(
             checkpoint = checkpointer.get(config_for_lookup)
 
             if checkpoint:
-                stored_meta = _extract_meta_from_checkpoint(checkpoint)
-                if isinstance(stored_meta, dict):
-                    flow_path_str = stored_meta.get("flow_path")
-                    if flow_path_str:
-                        flow_path = Path(flow_path_str)
+                channel_vals = checkpoint.get("channel_values", {}) or {}
+                meta_boot = (
+                    channel_vals.get("_meta", {})
+                    if isinstance(channel_vals, dict)
+                    else {}
+                )
+                flow_path_str = (
+                    meta_boot.get("flow_path") if isinstance(meta_boot, dict) else None
+                )
+                if flow_path_str:
+                    flow_path = Path(flow_path_str)
 
             if flow_path is None or not (flow_path and flow_path.exists()):
                 raise RuntimeError(

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -1,5 +1,6 @@
 """resume_flow implementation for the engine package."""
 
+import json
 import sys
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -16,7 +17,7 @@ from fdsx.display.terminal import (
     display_wait_prompt,
 )
 from fdsx.logging import RunRecorder
-from fdsx.logging.recorder import LOGS_DIR_NAME
+from fdsx.logging.recorder import LOGS_DIR_NAME, RUN_FILENAME, RUNS_DIR_NAME
 from fdsx.models.task import load_task_file, save_task_file
 
 from .interrupts import handle_interrupts
@@ -71,21 +72,36 @@ def resume_flow(
         checkpointer = checkpoint_manager.get_checkpointer()
 
         if flow_path is None or not flow_path.exists():
-            config_for_lookup: Any = {"configurable": {"thread_id": thread_id}}
-            checkpoint = checkpointer.get(config_for_lookup)
+            # Read flow_path from run.json sidecar (written by RunRecorder on first run)
+            _effective_base = (
+                base_dir if base_dir is not None else checkpoint_manager.base_dir
+            )
+            run_log_path = _effective_base / RUNS_DIR_NAME / thread_id / RUN_FILENAME
+            if run_log_path.is_file():
+                try:
+                    with run_log_path.open() as f:
+                        _run_log = json.load(f)
+                    _flow_path_str = _run_log.get("flow_path")
+                    if _flow_path_str:
+                        flow_path = Path(_flow_path_str)
+                except (json.JSONDecodeError, OSError, KeyError):
+                    pass
 
-            if checkpoint:
-                channel_vals = checkpoint.get("channel_values", {}) or {}
-                meta_boot = (
-                    channel_vals.get("_meta", {})
-                    if isinstance(channel_vals, dict)
-                    else {}
-                )
-                flow_path_str = (
-                    meta_boot.get("flow_path") if isinstance(meta_boot, dict) else None
-                )
-                if flow_path_str:
-                    flow_path = Path(flow_path_str)
+            # Legacy fallback: recover flow_path from checkpoint channel_values
+            # for threads created before flow_path was persisted to run.json.
+            if flow_path is None or not (flow_path and flow_path.exists()):
+                try:
+                    _ckpt = checkpointer.get({"configurable": {"thread_id": thread_id}})
+                    if _ckpt is not None:
+                        _fp = (
+                            _ckpt.get("channel_values", {})
+                            .get("_meta", {})
+                            .get("flow_path")
+                        )
+                        if _fp:
+                            flow_path = Path(_fp)
+                except Exception:
+                    pass
 
             if flow_path is None or not (flow_path and flow_path.exists()):
                 raise RuntimeError(
@@ -106,15 +122,12 @@ def resume_flow(
         if flow is None:
             raise RuntimeError(f"Failed to load flow for resume: {', '.join(errors)}")
 
-        from fdsx.logging.recorder import RUN_FILENAME, RUNS_DIR_NAME
         from fdsx.models.flow import ParallelState, WaitState
 
         runs_dir = base_dir / RUNS_DIR_NAME
         existing_log_path = runs_dir / thread_id / RUN_FILENAME
 
         if existing_log_path.exists():
-            import json
-
             with existing_log_path.open() as f:
                 existing_log = json.load(f)
             flow_name = existing_log.get("flow_name", flow.name)
@@ -127,6 +140,7 @@ def resume_flow(
             thread_id=thread_id,
             flow_name=flow_name,
             flow_version=flow_version,
+            flow_path=str(flow_path),
         )
 
         resume_run_dir = base_dir / RUNS_DIR_NAME / thread_id

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -177,26 +177,24 @@ def resume_flow(
 
                     user_selection = display_wait_prompt(state_name, message, choices)
 
-                    for state_snapshot in compiled.graph.stream(
+                    for chunk in compiled.graph.stream(
                         Command(resume=user_selection),
                         config=resume_config,
                         stream_mode="values",
+                        version="v2",
                     ):
-                        if "__interrupt__" not in state_snapshot:
-                            last_state = state_snapshot
+                        last_state = chunk["data"]
                 else:
                     # Error/pending task (no interrupt) — re-execute from checkpoint
-                    for state_snapshot in compiled.graph.stream(
-                        None, config=resume_config, stream_mode="values"
+                    for chunk in compiled.graph.stream(
+                        None, config=resume_config, stream_mode="values", version="v2"
                     ):
-                        if "__interrupt__" not in state_snapshot:
-                            last_state = state_snapshot
+                        last_state = chunk["data"]
             else:
-                for state_snapshot in compiled.graph.stream(
-                    None, config=resume_config, stream_mode="values"
+                for chunk in compiled.graph.stream(
+                    None, config=resume_config, stream_mode="values", version="v2"
                 ):
-                    if "__interrupt__" not in state_snapshot:
-                        last_state = state_snapshot
+                    last_state = chunk["data"]
 
             # Continue handling any further interrupts (e.g. multi-Wait flows)
             last_state = handle_interrupts(compiled.graph, resume_config, last_state)

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -87,22 +87,6 @@ def resume_flow(
                 except (json.JSONDecodeError, OSError, KeyError):
                     pass
 
-            # Legacy fallback: recover flow_path from checkpoint channel_values
-            # for threads created before flow_path was persisted to run.json.
-            if flow_path is None or not (flow_path and flow_path.exists()):
-                try:
-                    _ckpt = checkpointer.get({"configurable": {"thread_id": thread_id}})
-                    if _ckpt is not None:
-                        _fp = (
-                            _ckpt.get("channel_values", {})
-                            .get("_meta", {})
-                            .get("flow_path")
-                        )
-                        if _fp:
-                            flow_path = Path(_fp)
-                except Exception:
-                    pass
-
             if flow_path is None or not (flow_path and flow_path.exists()):
                 raise RuntimeError(
                     f"Flow path not found for thread ID {thread_id}. "

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from typing import Any, Literal, cast
 
-from langgraph.errors import GraphRecursionError
 from langgraph.types import Command
 
 from fdsx.checkpoint.manager import CheckpointManager, _extract_meta_from_checkpoint
@@ -248,17 +247,6 @@ def resume_flow(
                 pass  # best-effort: do not raise if file is missing or index is invalid
 
         return FlowResult(results=results, status=status, abort_state=failed_state)
-    except GraphRecursionError:
-        if flow is not None:
-            print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
-        rec_status: str = "completed"
-        rec_failed_state: str | None = None
-        if recorder is not None:
-            rec_status, rec_failed_state, _ = _detect_abort_status(recorder)
-            recorder.finalize(_sanitize_state_for_log(last_state), rec_status)
-            recorder.save(base_dir=base_dir)
-            display_completion_summary(recorder.flow_name, _calc_elapsed(recorder))
-        return FlowResult(results={}, status=rec_status, abort_state=rec_failed_state)
     except Exception as e:
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "error")

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -105,6 +105,7 @@ def run_flow(
         thread_id=thread_id,
         flow_name=flow.name,
         flow_version=flow.version,
+        flow_path=str(flow_path),
     )
 
     _runs_base = base_dir if base_dir is not None else Path.cwd() / FDSX_DIR_NAME

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -166,11 +166,10 @@ def run_flow(
 
     try:
         with handler:
-            for state_snapshot in compiled.graph.stream(
-                initial_state, config=config, stream_mode="values"
+            for chunk in compiled.graph.stream(
+                initial_state, config=config, stream_mode="values", version="v2"
             ):
-                if "__interrupt__" not in state_snapshot:
-                    last_state = state_snapshot
+                last_state = chunk["data"]
 
             if needs_checkpointer:
                 last_state = handle_interrupts(compiled.graph, config, last_state)

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Any
 
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.errors import GraphRecursionError
 
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core.compiler import compile_flow
@@ -57,9 +56,7 @@ def run_flow(
         task_entry_index: Optional index of the task entry within task_file_path.
 
     Returns:
-        Final state variables as result dict. When max_loop is reached,
-        returns partial results from the last completed iteration rather
-        than raising an error.
+        Final state variables as result dict.
 
     Raises:
         RuntimeError: If flow validation fails or execution fails
@@ -183,22 +180,6 @@ def run_flow(
             if final_state_info.values:
                 last_state = final_state_info.values
 
-        results = _extract_results(last_state, compiled.result_paths)
-        status, failed_state, error_msg = _detect_abort_status(recorder)
-        recorder.finalize(_sanitize_state_for_log(last_state), status)
-        recorder.save(base_dir=base_dir)
-        if failed_state is not None:
-            display_completion_summary(
-                flow.name,
-                _calc_elapsed(recorder),
-                failed_state,
-                error_msg or "workflow aborted",
-            )
-        else:
-            display_completion_summary(flow.name, _calc_elapsed(recorder))
-        return FlowResult(results=results, status=status, abort_state=failed_state)
-    except GraphRecursionError:
-        print(f"Loop completed after {flow.max_loop} iterations", file=sys.stderr)
         results = _extract_results(last_state, compiled.result_paths)
         status, failed_state, error_msg = _detect_abort_status(recorder)
         recorder.finalize(_sanitize_state_for_log(last_state), status)

--- a/src/fdsx/core/variables.py
+++ b/src/fdsx/core/variables.py
@@ -191,6 +191,38 @@ def set_jsonpath(path: str, data: dict[str, Any], value: Any) -> dict[str, Any]:
     return result
 
 
+def set_jsonpath_partial(path: str, value: Any) -> dict[str, Any]:
+    """Build a minimal partial dict for a JSONPath location.
+
+    Unlike ``set_jsonpath``, this function does NOT take a ``data`` parameter and
+    does NOT copy existing state.  It constructs only the nested structure needed
+    to express the assignment, returning the smallest possible dict.
+
+    Example::
+
+        set_jsonpath_partial("$.review", "text")  # {"review": "text"}
+        set_jsonpath_partial("$.a.b", 1)           # {"a": {"b": 1}}
+        set_jsonpath_partial("$.items[0]", "x")    # {"items": ["x"]}
+    """
+    if path.startswith("$."):
+        path = path[2:]
+
+    parts = parse_jsonpath(path)
+
+    if not parts:
+        return {"": value}
+
+    current: Any = value
+    for part in reversed(parts):
+        if isinstance(part, int):
+            lst: list[Any] = [None] * (part + 1)
+            lst[part] = current
+            current = lst
+        else:
+            current = {part: current}
+    return current  # type: ignore[no-any-return]
+
+
 def _is_var_satisfied(var: str, available: set[str]) -> bool:
     """Check if a variable reference is satisfied by the available paths.
 

--- a/src/fdsx/logging/recorder.py
+++ b/src/fdsx/logging/recorder.py
@@ -24,6 +24,7 @@ class RunRecorder:
         thread_id: str,
         flow_name: str,
         flow_version: str | None = None,
+        flow_path: str | None = None,
     ):
         if not THREAD_ID_PATTERN.match(thread_id):
             raise ValueError(
@@ -32,6 +33,7 @@ class RunRecorder:
         self.thread_id = thread_id
         self.flow_name = flow_name
         self.flow_version = flow_version
+        self.flow_path = flow_path
         self.started_at = datetime.now(timezone.utc).isoformat()
         self.status = "running"
         self.states: list[dict[str, Any]] = []
@@ -272,6 +274,7 @@ class RunRecorder:
             "thread_id": self.thread_id,
             "flow_name": self.flow_name,
             "flow_version": self.flow_version,
+            "flow_path": self.flow_path,
             "started_at": self.started_at,
             "status": self.status,
             "states": self.states,

--- a/tests/e2e/test_cli_flow_types.py
+++ b/tests/e2e/test_cli_flow_types.py
@@ -43,7 +43,5 @@ class TestCLIE2EPhase2:
         assert result.returncode == 0, f"stderr: {result.stderr}"
         # FR-1.3: No JSON on stdout
         assert result.stdout == ""
-        # Verify loop completion message on stderr
-        assert "Loop completed" in result.stderr
         # FR-1.1: Completion message on stderr
         assert "completed successfully" in result.stderr

--- a/tests/fixtures/loop_with_postloop_states.yaml
+++ b/tests/fixtures/loop_with_postloop_states.yaml
@@ -1,0 +1,77 @@
+name: Loop With Post-Loop States
+description: Loop body (plan→decide→plan) with 8 extra post-loop pass states. Verifies guard fires at exactly max_loop iterations regardless of post-loop state count.
+start_at: plan
+max_loop: 2
+
+states:
+  plan:
+    type: task
+    provider: system
+    command: echo "Planning step"
+    result_path: $.plan_output
+    next: decide
+
+  decide:
+    type: choice
+    choices:
+      - variable: $.plan_output
+        operator: equals
+        value: "APPROVED"
+        next: post1
+    default: plan
+
+  post1:
+    type: task
+    provider: system
+    command: echo "post1"
+    result_path: $.post1_output
+    next: post2
+
+  post2:
+    type: task
+    provider: system
+    command: echo "post2"
+    result_path: $.post2_output
+    next: post3
+
+  post3:
+    type: task
+    provider: system
+    command: echo "post3"
+    result_path: $.post3_output
+    next: post4
+
+  post4:
+    type: task
+    provider: system
+    command: echo "post4"
+    result_path: $.post4_output
+    next: post5
+
+  post5:
+    type: task
+    provider: system
+    command: echo "post5"
+    result_path: $.post5_output
+    next: post6
+
+  post6:
+    type: task
+    provider: system
+    command: echo "post6"
+    result_path: $.post6_output
+    next: post7
+
+  post7:
+    type: task
+    provider: system
+    command: echo "post7"
+    result_path: $.post7_output
+    next: post8
+
+  post8:
+    type: task
+    provider: system
+    command: echo "post8"
+    result_path: $.post8_output
+    end: true

--- a/tests/fixtures/map_nested_result_path.yaml
+++ b/tests/fixtures/map_nested_result_path.yaml
@@ -1,0 +1,37 @@
+name: Map Nested Result Path Flow
+description: Tests that map state preserves sibling keys under a nested result_path channel
+start_at: setup_count
+version: '1.0'
+
+states:
+  setup_count:
+    type: task
+    provider: system
+    command: echo "3"
+    result_path: $.steps.count
+    retry: 0
+    next: setup_items
+
+  setup_items:
+    type: pass
+    parameters:
+      $.items:
+        - item1
+        - item2
+        - item3
+    next: map_state
+
+  map_state:
+    type: map
+    items_path: $.items
+    iterator:
+      states:
+        - name: process
+          type: task
+          provider: system
+          command: echo "processed-{item}"
+          result_path: $.iter.result
+          retry: 0
+    result_path: $.steps.processed
+    fail_fast: true
+    end: true

--- a/tests/fixtures/parallel_nested_result_path.yaml
+++ b/tests/fixtures/parallel_nested_result_path.yaml
@@ -1,0 +1,25 @@
+name: Parallel Nested Result Path Flow
+description: Tests that parallel state preserves sibling keys under a nested result_path channel
+start_at: setup
+version: '1.0'
+
+states:
+  setup:
+    type: task
+    provider: system
+    command: echo "preserved"
+    result_path: $.output.other_key
+    retry: 0
+    next: parallel_state
+
+  parallel_state:
+    type: parallel
+    branches:
+      - provider: system
+        command: echo "branch1"
+        retry: 0
+      - provider: system
+        command: echo "branch2"
+        retry: 0
+    result_path: $.output.results
+    end: true

--- a/tests/integration/test_checkpoint_resume.py
+++ b/tests/integration/test_checkpoint_resume.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 from pathlib import Path
@@ -169,46 +168,6 @@ class TestCheckpointSave:
 
 
 class TestResumeSuccess:
-    def test_resume_without_flow_path_uses_legacy_channel_values_fallback(
-        self, temp_dir, wait_resume_flow_path
-    ):
-        """resume_flow succeeds via channel_values legacy fallback when run.json lacks flow_path."""
-        from unittest.mock import patch
-
-        base_dir = temp_dir / ".fdsx"
-        thread_id = "test-legacy-resume-no-flow-path"
-
-        # Step 1: Run flow until Wait state, simulate crash at prompt
-        with (
-            pytest.raises(RuntimeError, match="Flow execution failed"),
-            patch(
-                "fdsx.core.engine.interrupts.display_wait_prompt",
-                side_effect=Exception("simulated crash"),
-            ),
-        ):
-            engine.run_flow(
-                wait_resume_flow_path,
-                thread_id=thread_id,
-                base_dir=base_dir,
-            )
-
-        # Step 2: Remove flow_path from run.json to simulate legacy thread
-        from fdsx.logging.recorder import RUN_FILENAME, RUNS_DIR_NAME
-
-        run_json_path = base_dir / RUNS_DIR_NAME / thread_id / RUN_FILENAME
-        with run_json_path.open() as f:
-            run_log = json.load(f)
-        run_log.pop("flow_path", None)
-        with run_json_path.open("w") as f:
-            json.dump(run_log, f)
-
-        # Step 3: Resume WITHOUT passing flow_path — must succeed via channel_values fallback
-        with patch("builtins.input", return_value="1"):
-            result = engine.resume_flow(thread_id, base_dir)
-
-        assert result.results.get("status") == "approved"
-        assert result.results.get("plan_output") == "plan output"
-
     def test_resume_wait_state_flow(self, temp_dir, wait_resume_flow_path):
         """T051: interrupt at Wait → resume with resume_flow → verify completion."""
         from unittest.mock import patch

--- a/tests/integration/test_checkpoint_resume.py
+++ b/tests/integration/test_checkpoint_resume.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from pathlib import Path
@@ -168,6 +169,46 @@ class TestCheckpointSave:
 
 
 class TestResumeSuccess:
+    def test_resume_without_flow_path_uses_legacy_channel_values_fallback(
+        self, temp_dir, wait_resume_flow_path
+    ):
+        """resume_flow succeeds via channel_values legacy fallback when run.json lacks flow_path."""
+        from unittest.mock import patch
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-legacy-resume-no-flow-path"
+
+        # Step 1: Run flow until Wait state, simulate crash at prompt
+        with (
+            pytest.raises(RuntimeError, match="Flow execution failed"),
+            patch(
+                "fdsx.core.engine.interrupts.display_wait_prompt",
+                side_effect=Exception("simulated crash"),
+            ),
+        ):
+            engine.run_flow(
+                wait_resume_flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        # Step 2: Remove flow_path from run.json to simulate legacy thread
+        from fdsx.logging.recorder import RUN_FILENAME, RUNS_DIR_NAME
+
+        run_json_path = base_dir / RUNS_DIR_NAME / thread_id / RUN_FILENAME
+        with run_json_path.open() as f:
+            run_log = json.load(f)
+        run_log.pop("flow_path", None)
+        with run_json_path.open("w") as f:
+            json.dump(run_log, f)
+
+        # Step 3: Resume WITHOUT passing flow_path — must succeed via channel_values fallback
+        with patch("builtins.input", return_value="1"):
+            result = engine.resume_flow(thread_id, base_dir)
+
+        assert result.results.get("status") == "approved"
+        assert result.results.get("plan_output") == "plan output"
+
     def test_resume_wait_state_flow(self, temp_dir, wait_resume_flow_path):
         """T051: interrupt at Wait → resume with resume_flow → verify completion."""
         from unittest.mock import patch

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -291,7 +291,10 @@ class TestWrapWithHooksDataFiles:
 
         # Second call = output.json, data = full post-execution state (input merged with partial result)
         second_call = mock_write.call_args_list[1]
-        assert second_call[0][0] == {"in": "data", "result": "node_output"}  # positional arg
+        assert second_call[0][0] == {
+            "in": "data",
+            "result": "node_output",
+        }  # positional arg
         assert second_call[1]["filename"] == OUTPUT_FILENAME
 
 

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -289,9 +289,9 @@ class TestWrapWithHooksDataFiles:
             with patch("fdsx.core.compiler.compile.execute_hooks"):
                 wrapped({"in": "data"})
 
-        # Second call = output.json, data = node result
+        # Second call = output.json, data = full post-execution state (input merged with partial result)
         second_call = mock_write.call_args_list[1]
-        assert second_call[0][0] == {"result": "node_output"}  # positional arg
+        assert second_call[0][0] == {"in": "data", "result": "node_output"}  # positional arg
         assert second_call[1]["filename"] == OUTPUT_FILENAME
 
 

--- a/tests/integration/test_list_threads_public_api.py
+++ b/tests/integration/test_list_threads_public_api.py
@@ -1,0 +1,187 @@
+"""Integration tests for list_threads using get_state() public API (T032)."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.checkpoint.manager import CheckpointManager
+from fdsx.core import engine
+from tests import FIXTURES_DIR
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as td:
+        yield Path(td)
+
+
+@pytest.fixture
+def simple_flow_path():
+    return FIXTURES_DIR / "simple_flow.yaml"
+
+
+@pytest.fixture
+def wait_resume_flow_path():
+    return FIXTURES_DIR / "wait_resume_flow.yaml"
+
+
+class TestListThreadsPublicAPI:
+    def test_completed_thread_status(self, temp_dir, simple_flow_path):
+        """T032: list_threads returns 'completed' for a fully executed flow."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-api-completed"
+
+        engine.run_flow(
+            simple_flow_path,
+            thread_id=thread_id,
+            base_dir=base_dir,
+        )
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+
+        assert len(threads) >= 1
+        thread_info = next(t for t in threads if t["thread_id"] == thread_id)
+        assert thread_info["status"] == "completed"
+        assert thread_info["flow_name"] != thread_id
+        assert thread_info["current_state"] != ""
+        assert thread_info["started_at"] != ""
+
+    def test_waiting_thread_status(self, temp_dir, wait_resume_flow_path):
+        """T032: list_threads returns 'waiting' for a flow paused at a Wait state."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-api-waiting"
+
+        # Run until Wait state, then simulate crash at the prompt so the interrupt
+        # checkpoint is persisted but execution never resumes.
+        with (
+            pytest.raises(RuntimeError, match="Flow execution failed"),
+            patch(
+                "fdsx.core.engine.interrupts.display_wait_prompt",
+                side_effect=Exception("simulated crash"),
+            ),
+        ):
+            engine.run_flow(
+                wait_resume_flow_path,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+
+        assert len(threads) >= 1
+        thread_info = next(t for t in threads if t["thread_id"] == thread_id)
+        assert thread_info["status"] == "waiting"
+
+    def test_stopped_thread_status(self, temp_dir):
+        """T032: list_threads returns 'stopped' for a flow that ended with an error."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-api-stopped"
+
+        # Inline flow: first state succeeds, second fails via exit 1
+        flow_yaml = """\
+name: Stopped Flow Test
+description: Flow that fails at the second state for testing
+start_at: ok_state
+states:
+  ok_state:
+    type: task
+    provider: system
+    command: "echo ok"
+    result_path: $.ok_output
+    next: fail_state
+  fail_state:
+    type: task
+    provider: system
+    command: "exit 1"
+    result_path: $.fail_output
+    end: true
+"""
+        flow_file = temp_dir / "stopped_flow.yaml"
+        flow_file.write_text(flow_yaml)
+
+        with pytest.raises(RuntimeError):
+            engine.run_flow(
+                flow_file,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+
+        assert len(threads) >= 1
+        thread_info = next(t for t in threads if t["thread_id"] == thread_id)
+        assert thread_info["status"] == "stopped"
+
+    def test_waiting_thread_with_profile_flow(self, temp_dir):
+        """list_threads resolves 'waiting' for a thread whose flow uses a config profile."""
+        import yaml
+
+        from fdsx.providers.base import ProviderResult
+
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-api-waiting-profile"
+
+        # Config must go to <project_dir>/.fdsx/config.yaml
+        # load_config(project_dir=temp_dir) → _resolve_project_config_dir(temp_dir)
+        # → looks for temp_dir/.fdsx/ directory → reads temp_dir/.fdsx/config.yaml
+        # ProfileConfig requires a valid LLM provider and model (not "system").
+        base_dir.mkdir(parents=True, exist_ok=True)
+        config_path = base_dir / "config.yaml"
+        config_path.write_text(yaml.dump({
+            "profiles": {
+                "test_profile": {"provider": "claude", "model": "claude-haiku-4-5"}
+            }
+        }))
+
+        # Flow uses `profile: test_profile` with NO `provider:` key.
+        # If config_profiles is None, load_flow fails to resolve the profile
+        # (provider is a required field), so get_state() is never reached
+        # and status stays "stopped" instead of "waiting".
+        flow_yaml = """\
+name: Profile Wait Flow
+description: Flow with a wait state using a config profile
+start_at: before_wait
+states:
+  before_wait:
+    type: task
+    profile: test_profile
+    prompt_template: "say ready"
+    result_path: $.ready
+    next: wait_here
+  wait_here:
+    type: wait
+    message: "Continue?"
+    choices:
+      - "yes"
+      - "no"
+    result_path: $.choice
+    end: true
+"""
+        flow_file = temp_dir / "profile_wait_flow.yaml"
+        flow_file.write_text(flow_yaml)
+
+        fake = ProviderResult(exit_code=0, stdout="ready", stderr="")
+        with (
+            pytest.raises(RuntimeError, match="Flow execution failed"),
+            patch("fdsx.providers.claude._run_subprocess", return_value=fake),
+            patch(
+                "fdsx.core.engine.interrupts.display_wait_prompt",
+                side_effect=Exception("simulated crash"),
+            ),
+        ):
+            engine.run_flow(
+                flow_file,
+                thread_id=thread_id,
+                base_dir=base_dir,
+            )
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+
+        thread_info = next(t for t in threads if t["thread_id"] == thread_id)
+        assert thread_info["status"] == "waiting"

--- a/tests/integration/test_list_threads_public_api.py
+++ b/tests/integration/test_list_threads_public_api.py
@@ -1,5 +1,6 @@
 """Integration tests for list_threads using get_state() public API (T032)."""
 
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -132,11 +133,18 @@ states:
         # ProfileConfig requires a valid LLM provider and model (not "system").
         base_dir.mkdir(parents=True, exist_ok=True)
         config_path = base_dir / "config.yaml"
-        config_path.write_text(yaml.dump({
-            "profiles": {
-                "test_profile": {"provider": "claude", "model": "claude-haiku-4-5"}
-            }
-        }))
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "profiles": {
+                        "test_profile": {
+                            "provider": "claude",
+                            "model": "claude-haiku-4-5",
+                        }
+                    }
+                }
+            )
+        )
 
         # Flow uses `profile: test_profile` with NO `provider:` key.
         # If config_profiles is None, load_flow fails to resolve the profile
@@ -185,3 +193,25 @@ states:
 
         thread_info = next(t for t in threads if t["thread_id"] == thread_id)
         assert thread_info["status"] == "waiting"
+
+    def test_legacy_thread_without_flow_path_in_run_json(
+        self, temp_dir, simple_flow_path
+    ):
+        """list_threads returns correct status for threads whose run.json lacks flow_path."""
+        base_dir = temp_dir / ".fdsx"
+        thread_id = "test-legacy-no-flow-path"
+
+        engine.run_flow(simple_flow_path, thread_id=thread_id, base_dir=base_dir)
+
+        # Simulate legacy run.json by removing the flow_path field
+        run_json_path = base_dir / "runs" / thread_id / "run.json"
+        with run_json_path.open() as f:
+            run_log = json.load(f)
+        run_log.pop("flow_path", None)
+        with run_json_path.open("w") as f:
+            json.dump(run_log, f)
+
+        manager = CheckpointManager(base_dir=base_dir)
+        threads = manager.list_threads()
+        thread_info = next(t for t in threads if t["thread_id"] == thread_id)
+        assert thread_info["status"] == "completed"

--- a/tests/integration/test_loop_remaining_steps.py
+++ b/tests/integration/test_loop_remaining_steps.py
@@ -1,0 +1,39 @@
+"""Integration tests for loop termination via RemainingSteps channel (T018/T019).
+
+These tests verify that a loop terminates gracefully via the remaining_steps
+conditional guard rather than raising GraphRecursionError.
+"""
+
+from fdsx.core.engine import FlowResult, run_flow
+from tests import FIXTURES_DIR
+
+
+class TestLoopRemainingSteps:
+    def test_loop_terminates_without_recursion_error(self, tmp_path):
+        """T018: Loop exits cleanly at max_loop without raising GraphRecursionError."""
+        path = FIXTURES_DIR / "loop_flow.yaml"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert result.status != "error", (
+            f"Expected clean exit, got error status. results={result.results}"
+        )
+
+    def test_loop_result_contains_last_iteration_state(self, tmp_path):
+        """T019: Loop results contain complete state from the last iteration."""
+        path = FIXTURES_DIR / "loop_flow.yaml"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        # All three result_paths from the loop body must be present
+        assert "plan_output" in result.results, (
+            f"plan_output missing from results: {list(result.results.keys())}"
+        )
+        assert "impl_output" in result.results, (
+            f"impl_output missing from results: {list(result.results.keys())}"
+        )
+        assert "review_output" in result.results, (
+            f"review_output missing from results: {list(result.results.keys())}"
+        )

--- a/tests/integration/test_loop_remaining_steps.py
+++ b/tests/integration/test_loop_remaining_steps.py
@@ -37,3 +37,107 @@ class TestLoopRemainingSteps:
         assert "review_output" in result.results, (
             f"review_output missing from results: {list(result.results.keys())}"
         )
+
+    def test_loop_fires_at_exact_max_loop_with_postloop_states(self, tmp_path):
+        """Guard fires at exactly max_loop=2 even when 8 non-loop states exist.
+
+        Regression test for the bug where loop_guard_threshold = total_states caused
+        the guard to fire after 6 iterations instead of 2 for a plan→decide→plan loop
+        with 8 extra post-loop states.
+        """
+        import textwrap
+
+        counter_file = tmp_path / "plan_counter.txt"
+
+        # Build a flow inline that counts plan invocations via a file counter
+        flow_yaml = textwrap.dedent(f"""
+            name: Loop With Post-Loop States
+            description: Loop body with 8 extra post-loop states to test guard fires at exact max_loop
+            start_at: plan
+            max_loop: 2
+
+            states:
+              plan:
+                type: task
+                provider: system
+                command: "echo x >> {counter_file} && echo Planning step"
+                result_path: $.plan_output
+                next: decide
+
+              decide:
+                type: choice
+                choices:
+                  - variable: $.plan_output
+                    operator: equals
+                    value: "APPROVED"
+                    next: post1
+                default: plan
+
+              post1:
+                type: task
+                provider: system
+                command: echo post1
+                result_path: $.post1
+                next: post2
+              post2:
+                type: task
+                provider: system
+                command: echo post2
+                result_path: $.post2
+                next: post3
+              post3:
+                type: task
+                provider: system
+                command: echo post3
+                result_path: $.post3
+                next: post4
+              post4:
+                type: task
+                provider: system
+                command: echo post4
+                result_path: $.post4
+                next: post5
+              post5:
+                type: task
+                provider: system
+                command: echo post5
+                result_path: $.post5
+                next: post6
+              post6:
+                type: task
+                provider: system
+                command: echo post6
+                result_path: $.post6
+                next: post7
+              post7:
+                type: task
+                provider: system
+                command: echo post7
+                result_path: $.post7
+                next: post8
+              post8:
+                type: task
+                provider: system
+                command: echo post8
+                result_path: $.post8
+                end: true
+        """)
+
+        flow_path = tmp_path / "loop_postloop.yaml"
+        flow_path.write_text(flow_yaml)
+
+        result = run_flow(flow_path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert result.status != "error", (
+            f"Expected clean exit, got error status. results={result.results}"
+        )
+        assert "plan_output" in result.results, (
+            f"plan_output missing: {list(result.results.keys())}"
+        )
+
+        # Count how many times plan actually ran — must be exactly 2 (max_loop=2)
+        plan_count = len(counter_file.read_text().strip().splitlines())
+        assert plan_count == 2, (
+            f"Expected plan to run exactly 2 times (max_loop=2), ran {plan_count} times"
+        )

--- a/tests/integration/test_map_flow.py
+++ b/tests/integration/test_map_flow.py
@@ -414,3 +414,25 @@ def _pass_state(result_path: str, value: list) -> PassState:
         parameters={result_path: value},
         next="map_state",
     )
+
+
+class TestMapNestedResultPath:
+    """Verify sibling keys under a nested result_path channel are preserved."""
+
+    def test_nested_result_path_preserves_sibling_keys(self, tmp_path):
+        """Map state with result_path=$.steps.processed must not clobber $.steps.count."""
+        path = FIXTURES_DIR / "map_nested_result_path.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert "steps" in result.results
+        steps = result.results["steps"]
+        assert "processed" in steps, "result_path key must be present"
+        assert isinstance(steps["processed"], list)
+        assert len(steps["processed"]) == 3
+        assert "count" in steps, "sibling key must survive the map state"
+        assert steps["count"] == "3"

--- a/tests/integration/test_parallel_flow.py
+++ b/tests/integration/test_parallel_flow.py
@@ -217,3 +217,24 @@ class TestParallelBranchLabeling:
         assert not log_file.exists(), (
             f"Log file should not exist for branch with no output: {log_file}"
         )
+
+
+class TestParallelNestedResultPath:
+    """Verify sibling keys under a nested result_path channel are preserved."""
+
+    def test_nested_result_path_preserves_sibling_keys(self, tmp_path):
+        """Parallel state with result_path=$.output.results must not clobber $.output.other_key."""
+        path = FIXTURES_DIR / "parallel_nested_result_path.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert "output" in result.results
+        output = result.results["output"]
+        assert "results" in output, "result_path key must be present"
+        assert isinstance(output["results"], list)
+        assert "other_key" in output, "sibling key must survive the parallel state"
+        assert output["other_key"] == "preserved"

--- a/tests/integration/test_partial_updates.py
+++ b/tests/integration/test_partial_updates.py
@@ -7,7 +7,7 @@ T007 is a regression guard that is GREEN now and must remain GREEN after the ref
 
 from fdsx.core.compiler.nodes import _create_pass_node, _create_task_node
 from fdsx.core.engine import FlowResult, run_flow
-from fdsx.models.flow import Flow, PassState, TaskState
+from fdsx.models.flow import ExtractRule, Flow, PassState, TaskState
 from tests import FIXTURES_DIR
 
 
@@ -62,6 +62,36 @@ class TestParallelFlowPartialUpdate:
         assert result.results["decision"] == "APPROVED"
 
 
+class TestTaskNodeSiblingPaths:
+    """When extract.result_path and result_path share a parent, both keys survive."""
+
+    def test_task_node_with_extract_siblings_both_preserved(self):
+        """When extract.result_path and result_path share a parent, both keys survive."""
+        state_def = TaskState(
+            type="task",
+            provider="system",
+            command='echo \'{"value": 42}\'',
+            result_path="$.result.raw",
+            extract=ExtractRule(
+                strategy=["json"],
+                pattern="value",
+                result_path="$.result.parsed",
+            ),
+            end=True,
+        )
+        flow = Flow(
+            name="t",
+            description="sibling path test",
+            start_at="s1",
+            states={"s1": state_def},
+        )
+        node_fn = _create_task_node("s1", state_def, flow)
+        result = node_fn({"_state_iterations": {}})
+
+        assert "raw" in result["result"]
+        assert "parsed" in result["result"]
+
+
 class TestPassNodePartialUpdate:
     """T008: Pass node should return only modified keys (partial update)."""
 
@@ -89,3 +119,22 @@ class TestPassNodePartialUpdate:
         assert "noise_key" not in result
         assert "output" in result
         assert "_state_iterations" in result
+
+    def test_pass_node_sibling_parameters_both_preserved(self):
+        """Two parameters targeting sibling paths under the same parent must both survive."""
+        state_def = PassState(
+            type="pass",
+            parameters={"$.review.summary": "good", "$.review.decision": "APPROVED"},
+            end=True,
+        )
+        flow = Flow(
+            name="t",
+            description="sibling test",
+            start_at="s1",
+            states={"s1": state_def},
+        )
+        node_fn = _create_pass_node("s1", state_def, flow)
+        result = node_fn({"_state_iterations": {}})
+
+        assert result["review"]["summary"] == "good"
+        assert result["review"]["decision"] == "APPROVED"

--- a/tests/integration/test_partial_updates.py
+++ b/tests/integration/test_partial_updates.py
@@ -40,7 +40,7 @@ class TestTaskNodePartialUpdate:
 
         # RED until T010: currently full state dict is returned, including unrelated_key
         assert "unrelated_key" not in result
-        assert set(result) == {"result", "_meta", "_state_iterations"}
+        assert set(result) == {"result", "_state_iterations"}
 
 
 class TestParallelFlowPartialUpdate:
@@ -70,7 +70,7 @@ class TestTaskNodeSiblingPaths:
         state_def = TaskState(
             type="task",
             provider="system",
-            command='echo \'{"value": 42}\'',
+            command="echo '{\"value\": 42}'",
             result_path="$.result.raw",
             extract=ExtractRule(
                 strategy=["json"],

--- a/tests/integration/test_partial_updates.py
+++ b/tests/integration/test_partial_updates.py
@@ -1,0 +1,91 @@
+"""Integration tests for partial state update behavior.
+
+T006 and T008 are intentionally RED (failing) until the node refactors in T010/T012
+replace set_jsonpath with set_jsonpath_partial in the task and pass node factories.
+T007 is a regression guard that is GREEN now and must remain GREEN after the refactors.
+"""
+
+from fdsx.core.compiler.nodes import _create_pass_node, _create_task_node
+from fdsx.core.engine import FlowResult, run_flow
+from fdsx.models.flow import Flow, PassState, TaskState
+from tests import FIXTURES_DIR
+
+
+class TestTaskNodePartialUpdate:
+    """T006: Task node should return only modified keys (partial update)."""
+
+    def test_task_node_returns_only_modified_keys(self):
+        """Task node must not echo back keys it did not modify.
+
+        RED until T010 replaces set_jsonpath with set_jsonpath_partial in
+        _create_task_node.
+        """
+        state_def = TaskState(
+            type="task",
+            provider="system",
+            command="echo hello",
+            result_path="$.result",
+            end=True,
+        )
+        flow = Flow(
+            name="t",
+            description="partial update test",
+            start_at="s1",
+            states={"s1": state_def},
+        )
+        node_fn = _create_task_node("s1", state_def, flow)
+        result = node_fn(
+            {"unrelated_key": "should_not_appear", "_state_iterations": {}}
+        )
+
+        # RED until T010: currently full state dict is returned, including unrelated_key
+        assert "unrelated_key" not in result
+        assert set(result) == {"result", "_meta", "_state_iterations"}
+
+
+class TestParallelFlowPartialUpdate:
+    """T007: Parallel flow regression guard — must remain GREEN before and after refactors."""
+
+    def test_parallel_review_accumulation(self, tmp_path):
+        """End-to-end parallel flow with majority aggregation produces correct results.
+
+        This test verifies the parallel branch accumulation pattern works correctly.
+        It is GREEN now and must remain GREEN after all node refactors land.
+        """
+        path = FIXTURES_DIR / "parallel_review.yaml"
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert "reviews" in result.results
+        assert len(result.results["reviews"]) == 3
+        assert "decision" in result.results
+        assert result.results["decision"] == "APPROVED"
+
+
+class TestPassNodePartialUpdate:
+    """T008: Pass node should return only modified keys (partial update)."""
+
+    def test_pass_node_returns_only_parameter_targets(self):
+        """Pass node must not echo back keys not targeted by parameters.
+
+        RED until T012 replaces full-state mutations with partial returns in
+        _create_pass_node.
+        """
+        state_def = PassState(
+            type="pass",
+            parameters={"$.output": "hello"},
+            end=True,
+        )
+        flow = Flow(
+            name="t",
+            description="partial update test",
+            start_at="s1",
+            states={"s1": state_def},
+        )
+        node_fn = _create_pass_node("s1", state_def, flow)
+        result = node_fn({"noise_key": "noise_value", "_state_iterations": {}})
+
+        # RED until T012: currently full state_dict is returned, including noise_key
+        assert "noise_key" not in result
+        assert "output" in result
+        assert "_state_iterations" in result

--- a/tests/integration/test_streaming_v2.py
+++ b/tests/integration/test_streaming_v2.py
@@ -1,0 +1,53 @@
+"""Integration tests for v2 streaming format (T025/T026).
+
+These tests verify that the v2 streaming format correctly handles:
+- Wait state flows that pause and resume (T025)
+- Non-wait flows that complete normally (T026)
+"""
+
+from unittest.mock import patch
+
+from fdsx.core.engine import FlowResult, run_flow
+from tests import FIXTURES_DIR
+
+
+class TestStreamingV2:
+    def test_wait_state_flow_pauses_and_resumes(self, tmp_path):
+        """T025: Wait state flow pauses at interrupt and resumes with approval decision."""
+        base_dir = tmp_path / ".fdsx"
+        path = FIXTURES_DIR / "wait_approval.yaml"
+
+        with patch(
+            "fdsx.core.engine.interrupts.display_wait_prompt",
+            return_value="approve",
+        ):
+            result = run_flow(path, base_dir=base_dir)
+
+        assert isinstance(result, FlowResult)
+        assert result.status == "completed", (
+            f"Expected completed status, got: {result.status}. results={result.results}"
+        )
+        assert result.results.get("approval_decision") == "approve", (
+            f"Expected approval_decision='approve', got: {result.results}"
+        )
+
+    def test_non_wait_flow_completes_normally(self, tmp_path):
+        """T026: Non-wait linear flow completes with all expected result keys present."""
+        base_dir = tmp_path / ".fdsx"
+        path = FIXTURES_DIR / "checkpoint_flow.yaml"
+
+        result = run_flow(path, base_dir=base_dir)
+
+        assert isinstance(result, FlowResult)
+        assert result.status == "completed", (
+            f"Expected completed status, got: {result.status}. results={result.results}"
+        )
+        assert "plan_output" in result.results, (
+            f"plan_output missing from results: {list(result.results.keys())}"
+        )
+        assert "implement_output" in result.results, (
+            f"implement_output missing from results: {list(result.results.keys())}"
+        )
+        assert "review_output" in result.results, (
+            f"review_output missing from results: {list(result.results.keys())}"
+        )

--- a/tests/integration/test_typed_schema.py
+++ b/tests/integration/test_typed_schema.py
@@ -1,0 +1,45 @@
+"""Integration tests for TypedDict schema always being used (Phase 2)."""
+
+from fdsx.core.compiler import compile_flow
+from fdsx.core.engine import FlowResult, run_flow
+from fdsx.core.loader import load_flow
+from tests import FIXTURES_DIR
+
+
+class TestTypedSchemaLinearFlow:
+    def test_non_parallel_flow_produces_correct_results(self, tmp_path):
+        """Non-parallel linear flow runs correctly with TypedDict schema."""
+        path = FIXTURES_DIR / "simple_flow.yaml"
+
+        result = run_flow(path, base_dir=tmp_path)
+
+        assert isinstance(result, FlowResult)
+        assert "plan" in result.results
+        assert "implementation" in result.results
+        assert "review" in result.results
+
+    def test_non_parallel_flow_compiled_graph_uses_named_channels(self):
+        """Compiled graph for non-parallel flow has named channels, not __root__."""
+        path = FIXTURES_DIR / "simple_flow.yaml"
+
+        flow, errors = load_flow(path)
+        assert flow is not None, f"Failed to load: {errors}"
+        assert len(errors) == 0
+
+        compiled = compile_flow(flow)
+        assert compiled is not None
+
+        # With TypedDict schema, LangGraph registers named channels.
+        # The graph must NOT have a '__root__' channel.
+        channels = compiled.graph.channels
+        assert "__root__" not in channels, (
+            "Non-parallel flow must use named channels (TypedDict), not __root__"
+        )
+
+        # Named result channels from simple_flow.yaml must be present
+        assert "plan" in channels
+        assert "implementation" in channels
+        assert "review" in channels
+
+        # remaining_steps managed channel must be present (Phase 2)
+        assert "remaining_steps" in channels

--- a/tests/unit/test_build_state_schema.py
+++ b/tests/unit/test_build_state_schema.py
@@ -1,0 +1,151 @@
+"""Unit tests for _build_state_schema always returning TypedDict (Phase 2)."""
+
+import tempfile
+from pathlib import Path
+
+from fdsx.core.compiler.helpers import _build_state_schema
+from fdsx.core.loader import load_flow
+
+
+def _load(yaml_text: str):
+    """Load a Flow from a YAML string, asserting no errors."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        f.write(yaml_text)
+        path = Path(f.name)
+    try:
+        flow, errors = load_flow(path)
+        assert flow is not None, f"load_flow failed: {errors}"
+        assert len(errors) == 0, f"Unexpected errors: {errors}"
+        return flow
+    finally:
+        path.unlink(missing_ok=True)
+
+
+LINEAR_FLOW_YAML = """\
+name: Linear Flow
+description: Simple linear flow for testing
+start_at: step1
+version: '1.0'
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo hello"
+    result_path: $.output1
+    next: step2
+  step2:
+    type: task
+    provider: system
+    command: "echo world"
+    result_path: $.output2
+    end: true
+"""
+
+PARALLEL_FLOW_YAML = """\
+name: Parallel Flow
+description: Flow with parallel state for testing
+start_at: par
+version: '1.0'
+states:
+  par:
+    type: parallel
+    result_path: $.par_result
+    branches:
+      - provider: system
+        command: "echo branch1"
+    next: done
+  done:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.final
+    end: true
+"""
+
+INPUT_KEYS_FLOW_YAML = """\
+name: Input Keys Flow
+description: Flow with input keys for testing
+start_at: step1
+version: '1.0'
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo ok"
+    result_path: $.result
+    end: true
+"""
+
+
+class TestBuildStateSchemaAlwaysTypedDict:
+    def test_linear_flow_returns_typeddict(self):
+        """Non-parallel flow must return TypedDict, never object."""
+        flow = _load(LINEAR_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        assert schema is not object, "_build_state_schema must never return object"
+        assert hasattr(schema, "__annotations__"), (
+            "Return value must be a TypedDict class with __annotations__"
+        )
+
+    def test_linear_flow_result_keys_in_annotations(self):
+        """result_path top-level keys must appear in schema annotations."""
+        flow = _load(LINEAR_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        annotations = schema.__annotations__
+        assert "output1" in annotations
+        assert "output2" in annotations
+
+    def test_linear_flow_remaining_steps_in_annotations(self):
+        """remaining_steps managed channel must be present for all flows."""
+        flow = _load(LINEAR_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        assert "remaining_steps" in schema.__annotations__, (
+            "remaining_steps must be in schema for loop control (Phase 4)"
+        )
+
+    def test_parallel_flow_returns_typeddict_with_reducer_keys(self):
+        """Parallel flow must return TypedDict with _br_ reducer channels."""
+        flow = _load(PARALLEL_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        assert schema is not object
+        assert hasattr(schema, "__annotations__")
+        annotations = schema.__annotations__
+        assert "_br_par" in annotations, (
+            "Parallel state 'par' must have _br_par channel"
+        )
+
+    def test_parallel_flow_remaining_steps_in_annotations(self):
+        """remaining_steps must also be present for flows with ParallelState."""
+        flow = _load(PARALLEL_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        assert "remaining_steps" in schema.__annotations__
+
+    def test_input_keys_appear_in_annotations(self):
+        """Explicitly provided input_keys must appear in schema annotations."""
+        flow = _load(INPUT_KEYS_FLOW_YAML)
+        schema = _build_state_schema(flow, input_keys={"task", "context"})
+
+        annotations = schema.__annotations__
+        assert "task" in annotations
+        assert "context" in annotations
+
+    def test_internal_keys_always_present(self):
+        """_meta and _state_iterations internal keys must always be present."""
+        flow = _load(LINEAR_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        annotations = schema.__annotations__
+        assert "_meta" in annotations
+        assert "_state_iterations" in annotations
+
+    def test_schema_name_is_flow_state(self):
+        """TypedDict name must be 'FlowState'."""
+        flow = _load(LINEAR_FLOW_YAML)
+        schema = _build_state_schema(flow)
+
+        assert schema.__name__ == "FlowState"

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -377,8 +377,8 @@ class TestHandleInterrupts:
         state_with_interrupt = self._make_state_info(tasks=[task])
         graph.get_state.side_effect = [state_with_interrupt, empty_state]
 
-        # stream yields one non-interrupt snapshot
-        graph.stream.return_value = iter([{"status": "ok"}])
+        # stream yields one v2 chunk
+        graph.stream.return_value = iter([{"data": {"status": "ok"}}])
 
         with patch(
             "fdsx.core.engine.interrupts.display_wait_prompt", return_value="yes"
@@ -403,7 +403,7 @@ class TestHandleInterrupts:
             state_with_interrupt,
             empty_state,
         ]
-        graph.stream.return_value = iter([{"round": 1}])
+        graph.stream.return_value = iter([{"data": {"round": 1}}])
 
         with patch(
             "fdsx.core.engine.interrupts.display_wait_prompt", return_value="yes"
@@ -412,8 +412,8 @@ class TestHandleInterrupts:
 
         assert mock_prompt.call_count == 2
 
-    def test_interrupt_snapshot_with_interrupt_key_skipped(self):
-        """State snapshots containing '__interrupt__' are skipped (last_state not updated)."""
+    def test_interrupt_snapshot_last_chunk_wins(self):
+        """With v2 streaming, each chunk's data updates last_state; the final chunk wins."""
         graph = MagicMock()
         payload = {"message": "ok?", "choices": [], "state_name": "s"}
         task = self._make_task_with_interrupt(payload)
@@ -421,11 +421,11 @@ class TestHandleInterrupts:
         state_with_interrupt = self._make_state_info(tasks=[task])
 
         graph.get_state.side_effect = [state_with_interrupt, empty_state]
-        # stream yields an interrupt snapshot then a valid one
+        # stream yields two v2 chunks; last one wins
         graph.stream.return_value = iter(
             [
-                {"__interrupt__": True},
-                {"real": "state"},
+                {"data": {"intermediate": "state"}},
+                {"data": {"real": "state"}},
             ]
         )
 
@@ -434,5 +434,5 @@ class TestHandleInterrupts:
         ):
             result = handle_interrupts(graph, {}, {"original": True})
 
-        # The __interrupt__ snapshot was skipped; real state was captured
+        # The last chunk's data is captured
         assert result == {"real": "state"}


### PR DESCRIPTION
## Summary

Replace internal checkpoint metadata access with LangGraph's public StateSnapshot API throughout the checkpoint, engine, and logging modules.

## What was done

- checkpoint/manager.py: use StateSnapshot values instead of internal metadata dict
- engine/resume.py: adopt public API for thread state inspection
- engine/run.py: align with public checkpoint API
- logging/recorder.py: use public snapshot interface
- checkpoint/manager.py: remove legacy channel_values fallback from get_thread_status()
- engine/resume.py: remove legacy channel_values fallback from resume_flow()
- Added integration tests for checkpoint resume and list threads public API

## Why

Completes Phase 6 cleanup of LangGraph internal API access by removing _set_next_state_meta call sites and legacy channel_values fallback blocks throughout the codebase.

## How to test

Run: uv run pytest tests/integration/ -v