### PR TITLE
feat(hooks): inject FDSX_HOOKS env var with lifecycle event name

### DIFF
--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -200,6 +200,7 @@ def _wrap_with_hooks(
                 data_path=input_data_path,
                 thread_id=thread_id,
                 flow_name=flow_name,
+                event="on_start",
             )
 
         node_error: BaseException | None = None
@@ -230,6 +231,7 @@ def _wrap_with_hooks(
                     data_path=output_data_path,
                     thread_id=thread_id,
                     flow_name=flow_name,
+                    event="on_complete",
                 )
         except BaseException:
             if node_error is not None:

--- a/src/fdsx/core/hooks.py
+++ b/src/fdsx/core/hooks.py
@@ -35,6 +35,7 @@ ENV_STATUS = "FDSX_STATUS"
 ENV_DATA_PATH = "FDSX_DATA_PATH"
 ENV_THREAD_ID = "FDSX_THREAD_ID"
 ENV_FLOW_NAME = "FDSX_FLOW_NAME"
+ENV_HOOKS = "FDSX_HOOKS"
 
 
 class HookAbortError(Exception):
@@ -56,13 +57,14 @@ def execute_hooks(
     data_path: Path,
     thread_id: str,
     flow_name: str,
+    event: Literal["on_start", "on_complete"],
 ) -> None:
     """Execute a flat list of hook commands in order.
 
     Each command is run with ``shell=True`` and receives:
     - Positional args: $1=state_name, $2=status, $3=data_path
     - Environment variables: FDSX_STATE_NAME, FDSX_STATUS, FDSX_DATA_PATH,
-      FDSX_THREAD_ID, FDSX_FLOW_NAME
+      FDSX_THREAD_ID, FDSX_FLOW_NAME, FDSX_HOOKS
 
     Args:
         hooks: Ordered list of HookEntry objects to execute.
@@ -71,6 +73,8 @@ def execute_hooks(
         data_path: Path to the state data JSON file passed as $3 / FDSX_DATA_PATH.
         thread_id: Current run thread ID.
         flow_name: Name of the flow.
+        event: Lifecycle event that triggered this hook invocation ("on_start" or
+            "on_complete"). Exported as FDSX_HOOKS; overrides any inherited value.
 
     Raises:
         HookAbortError: When a hook exits non-zero and its on_failure is "abort".
@@ -82,6 +86,7 @@ def execute_hooks(
         ENV_DATA_PATH: str(data_path),
         ENV_THREAD_ID: thread_id,
         ENV_FLOW_NAME: flow_name,
+        ENV_HOOKS: event,
     }
 
     # Build positional arg suffix (safely quoted)

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -139,7 +139,8 @@ def _run_subprocess(
         cmd = args
 
     try:
-        proc_env = {**os.environ, **env} if env else None
+        proc_env = {**os.environ, **(env or {})}
+        proc_env.pop("FDSX_HOOKS", None)
         process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE if stdin_data is not None else None,

--- a/tests/integration/test_hook_streaming_interaction.py
+++ b/tests/integration/test_hook_streaming_interaction.py
@@ -200,7 +200,7 @@ states:
         hook_calls: list[dict] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append({"state_name": state_name, "status": status})
 
@@ -557,7 +557,7 @@ states:
         hook_calls: list[dict] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append({"state_name": state_name, "status": status})
 

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -565,7 +565,7 @@ states:
         hook_calls: list[dict] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append(
                 {
@@ -639,7 +639,7 @@ states:
         hook_calls: list[dict] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append({"status": status, "count": len(hooks)})
 
@@ -704,7 +704,7 @@ states:
         hook_calls: list[list] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append([h.command for h in hooks])
 
@@ -773,7 +773,7 @@ states:
         captured_hooks: list[list[str]] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             if status == "starting":
                 captured_hooks.append([h.command for h in hooks])
@@ -869,7 +869,7 @@ states:
         hook_calls: list[dict] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append({"state_name": state_name, "status": status})
 
@@ -941,7 +941,7 @@ states:
         hook_calls: list[dict] = []
 
         def fake_execute_hooks(
-            hooks, *, state_name, status, data_path, thread_id, flow_name
+            hooks, *, state_name, status, data_path, thread_id, flow_name, event
         ):
             hook_calls.append(
                 {"state_name": state_name, "status": status, "count": len(hooks)}

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -20,6 +20,7 @@ import pytest
 
 from fdsx.core.compiler import _wrap_with_hooks, compile_flow
 from fdsx.core.config import FdsxConfig
+from fdsx.core.engine import run_flow
 from fdsx.core.hooks import INPUT_FILENAME, OUTPUT_FILENAME
 from fdsx.core.loader import load_flow
 from fdsx.models.flow import HookConfig, HookEntry
@@ -1076,3 +1077,238 @@ states:
 
         assert len(write_calls) > 0
         assert write_calls[0]["base_dir"] is None
+
+
+# ---------------------------------------------------------------------------
+# T003: FDSX_HOOKS environment variable integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestFdsxHooksEnvVar:
+    """Verify FDSX_HOOKS env var is set for hook subprocesses and absent from provider subprocesses."""
+
+    _FLOW_WITH_ON_START_HOOK = """
+name: FDSX Hooks Env Test
+description: Tests that FDSX_HOOKS is set for on_start hooks
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "echo hook_start"
+"""
+
+    _FLOW_WITH_ON_COMPLETE_HOOK = """
+name: FDSX Hooks Env Test
+description: Tests that FDSX_HOOKS is set for on_complete hooks
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: $.result
+    end: true
+    hooks:
+      on_complete:
+        - command: "echo hook_complete"
+"""
+
+    _FLOW_PROVIDER_ENV_CHECK = """
+name: Provider Env Check
+description: Tests that FDSX_HOOKS is absent from provider subprocess env
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "sh -c 'printf \\"%s\\" \\"${FDSX_HOOKS+PRESENT}\\" > out.txt'"
+    result_path: $.result
+    end: true
+"""
+
+    def test_on_start_hook_observes_event_value(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """on_start hook subprocess receives FDSX_HOOKS=on_start in its environment."""
+        monkeypatch.chdir(tmp_path)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_WITH_ON_START_HOOK)
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "fdsx-hooks-env-start"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="FDSX Hooks Env Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
+
+        captured_envs: list[dict] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            env = kwargs.get("env")
+            if env is not None:
+                captured_envs.append(dict(env))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=fake_subprocess_run),
+            patch(
+                "fdsx.core.compiler.compile.write_hook_data",
+                side_effect=fake_write_hook_data,
+            ),
+        ):
+            compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+            config_dict = {"configurable": {"thread_id": thread_id}}
+            list(
+                compiled.graph.stream(
+                    {"_meta": {}}, config=config_dict, stream_mode="values"
+                )
+            )
+
+        on_start_envs = [e for e in captured_envs if e.get("FDSX_STATUS") == "starting"]
+        assert len(on_start_envs) >= 1, "on_start hook should have fired"
+        assert on_start_envs[0].get("FDSX_HOOKS") == "on_start", (
+            f"Expected FDSX_HOOKS='on_start', got {on_start_envs[0].get('FDSX_HOOKS')!r}"
+        )
+
+    def test_on_complete_hook_observes_event_value_success(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """on_complete hook subprocess receives FDSX_HOOKS=on_complete when node succeeds."""
+        monkeypatch.chdir(tmp_path)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_WITH_ON_COMPLETE_HOOK)
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "fdsx-hooks-env-complete"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="FDSX Hooks Env Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
+
+        captured_envs: list[dict] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            env = kwargs.get("env")
+            if env is not None:
+                captured_envs.append(dict(env))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=fake_subprocess_run),
+            patch(
+                "fdsx.core.compiler.compile.write_hook_data",
+                side_effect=fake_write_hook_data,
+            ),
+        ):
+            compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+            config_dict = {"configurable": {"thread_id": thread_id}}
+            list(
+                compiled.graph.stream(
+                    {"_meta": {}}, config=config_dict, stream_mode="values"
+                )
+            )
+
+        on_complete_envs = [
+            e for e in captured_envs if e.get("FDSX_STATUS") in ("completed", "failed")
+        ]
+        assert len(on_complete_envs) >= 1, "on_complete hook should have fired"
+        assert on_complete_envs[0].get("FDSX_HOOKS") == "on_complete", (
+            f"Expected FDSX_HOOKS='on_complete', got {on_complete_envs[0].get('FDSX_HOOKS')!r}"
+        )
+
+    def test_on_complete_hook_observes_event_value_failure(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """on_complete hook subprocess receives FDSX_HOOKS=on_complete even when node fails."""
+        monkeypatch.chdir(tmp_path)
+
+        def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("node exploded")
+
+        hook = _make_hook("echo on_complete")
+        recorder = _make_recorder()
+        wrapped = _wrap_with_hooks(
+            failing_node,
+            "FailState",
+            [],
+            [hook],
+            recorder=recorder,
+            fdsx_base_dir=tmp_path,
+        )
+
+        captured_envs: list[dict] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            env = kwargs.get("env")
+            if env is not None:
+                captured_envs.append(dict(env))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=fake_subprocess_run),
+            patch(
+                "fdsx.core.compiler.compile.write_hook_data",
+                side_effect=fake_write_hook_data,
+            ),
+            pytest.raises(RuntimeError, match="node exploded"),
+        ):
+            wrapped({"x": 1})
+
+        assert len(captured_envs) >= 1, (
+            "on_complete hook should have fired after node failure"
+        )
+        assert captured_envs[0].get("FDSX_HOOKS") == "on_complete", (
+            f"Expected FDSX_HOOKS='on_complete', got {captured_envs[0].get('FDSX_HOOKS')!r}"
+        )
+
+    def test_provider_subprocess_does_not_see_fdsx_hooks(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Provider subprocess does not receive FDSX_HOOKS when it is absent from the environment."""
+        monkeypatch.chdir(tmp_path)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_PROVIDER_ENV_CHECK)
+
+        run_flow(flow_path, thread_id="provider-env-check", base_dir=tmp_path)
+
+        out = (tmp_path / "out.txt").read_text().strip()
+        assert out == "", (
+            f"FDSX_HOOKS should not be present in provider subprocess env, got: {out!r}"
+        )
+
+    def test_inherited_fdsx_hooks_scrubbed_from_provider(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Stale FDSX_HOOKS inherited from the parent process is scrubbed from provider subprocess env."""
+        monkeypatch.setenv("FDSX_HOOKS", "stale")
+        monkeypatch.chdir(tmp_path)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_PROVIDER_ENV_CHECK)
+
+        run_flow(flow_path, thread_id="provider-env-scrub", base_dir=tmp_path)
+
+        out = (tmp_path / "out.txt").read_text().strip()
+        assert out == "", (
+            f"Stale FDSX_HOOKS should be scrubbed from provider subprocess env, got: {out!r}"
+        )

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -260,6 +260,117 @@ class TestExecuteHooks:
         # Verify the dangerous string is properly quoted (not expanded)
         assert "rm -rf" not in full_cmd.replace("'my state; rm -rf /'", "")
 
+    def test_execute_hooks_sets_fdsx_hooks_on_start(self, tmp_path: Path) -> None:
+        """FDSX_HOOKS env var is set to 'on_start' when event='on_start'."""
+        hook = self._make_hook("true")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="S",
+                status="starting",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+                event="on_start",
+            )
+
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_HOOKS"] == "on_start"
+
+    def test_execute_hooks_sets_fdsx_hooks_on_complete_success(
+        self, tmp_path: Path
+    ) -> None:
+        """FDSX_HOOKS env var is set to 'on_complete' when event='on_complete' and status='completed'."""
+        hook = self._make_hook("true")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="S",
+                status="completed",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+                event="on_complete",
+            )
+
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_HOOKS"] == "on_complete"
+
+    def test_execute_hooks_sets_fdsx_hooks_on_complete_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """FDSX_HOOKS env var is set to 'on_complete' when event='on_complete' and status='failed'."""
+        hook = self._make_hook("true")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="S",
+                status="failed",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+                event="on_complete",
+            )
+
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_HOOKS"] == "on_complete"
+
+    def test_execute_hooks_overrides_inherited_fdsx_hooks(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FDSX_HOOKS from the inherited environment is overridden by the event value."""
+        monkeypatch.setenv("FDSX_HOOKS", "stale")
+        hook = self._make_hook("true")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="S",
+                status="starting",
+                data_path=data_path,
+                thread_id="t",
+                flow_name="F",
+                event="on_start",
+            )
+
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_HOOKS"] == "on_start"
+
+    def test_execute_hooks_preserves_existing_env_vars(self, tmp_path: Path) -> None:
+        """All five existing FDSX_ env vars are still present alongside FDSX_HOOKS (FR-5 regression guard)."""
+        hook = self._make_hook("true")
+        data_path = tmp_path / "data.json"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_hooks(
+                [hook],
+                state_name="StateX",
+                status="starting",
+                data_path=data_path,
+                thread_id="tid-42",
+                flow_name="FlowY",
+                event="on_start",
+            )
+
+        env = mock_run.call_args[1]["env"]
+        assert ENV_STATE_NAME in env
+        assert ENV_STATUS in env
+        assert ENV_DATA_PATH in env
+        assert ENV_THREAD_ID in env
+        assert ENV_FLOW_NAME in env
+
 
 # ---------------------------------------------------------------------------
 # T020: write_hook_data

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -48,6 +48,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="tid-001",
                 flow_name="MyFlow",
+                event="on_start",
             )
         mock_run.assert_not_called()
 
@@ -65,6 +66,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t1",
                 flow_name="F1",
+                event="on_start",
             )
 
         assert mock_run.call_count == 1
@@ -85,6 +87,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t1",
                 flow_name="F1",
+                event="on_start",
             )
 
         full_cmd: str = mock_run.call_args[0][0]
@@ -106,6 +109,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="tid-42",
                 flow_name="FlowY",
+                event="on_start",
             )
 
         env = mock_run.call_args[1]["env"]
@@ -130,6 +134,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
+                event="on_start",
             )
 
     def test_abort_on_failure_raises_hook_abort_error(self, tmp_path: Path) -> None:
@@ -147,6 +152,7 @@ class TestExecuteHooks:
                     data_path=data_path,
                     thread_id="t",
                     flow_name="F",
+                    event="on_start",
                 )
         assert exc_info.value.return_code == 2
         assert exc_info.value.command == "false"
@@ -169,6 +175,7 @@ class TestExecuteHooks:
                     data_path=data_path,
                     thread_id="t",
                     flow_name="F",
+                    event="on_start",
                 )
         # Only cmd1 ran; cmd2 was skipped
         assert mock_run.call_count == 1
@@ -191,6 +198,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
+                event="on_start",
             )
         assert mock_run.call_count == 2
 
@@ -209,6 +217,7 @@ class TestExecuteHooks:
                     data_path=data_path,
                     thread_id="t",
                     flow_name="F",
+                    event="on_start",
                 )
         assert "my-script.sh" in str(exc_info.value)
 
@@ -230,6 +239,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
+                event="on_start",
             )
 
         assert mock_run.call_count == 3
@@ -254,6 +264,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
+                event="on_start",
             )
 
         full_cmd: str = mock_run.call_args[0][0]

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -1,0 +1,86 @@
+"""Unit tests for _run_subprocess FDSX_HOOKS scrub (T002)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.providers.base import _run_subprocess
+
+
+def _make_mock_process() -> MagicMock:
+    """Return a minimal mock subprocess.Popen object."""
+    proc = MagicMock()
+    proc.stdout.readline.return_value = ""
+    proc.stderr.readline.return_value = ""
+    proc.returncode = 0
+    proc.pid = 12345
+    return proc
+
+
+class TestRunSubprocessFdsxHooksScrub:
+    """Tests documenting the FDSX_HOOKS scrub contract for _run_subprocess (T002).
+
+    These tests are written against the post-T008 contract and are expected to
+    fail until T008 implements the scrub in base.py.
+    """
+
+    def test_run_subprocess_strips_fdsx_hooks_from_inherited_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FDSX_HOOKS in os.environ must not be forwarded to the subprocess.
+
+        When no env arg is supplied, _run_subprocess must still build an explicit
+        env dict (not pass env=None) and strip FDSX_HOOKS from it.
+        """
+        monkeypatch.setenv("FDSX_HOOKS", "on_start")
+
+        with patch("fdsx.providers.base.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = _make_mock_process()
+            _run_subprocess(["echo", "hi"])
+
+        captured_env = mock_popen.call_args[1]["env"]
+
+        assert captured_env is not None, (
+            "Expected an explicit env dict to be passed to Popen, got None"
+        )
+        assert "FDSX_HOOKS" not in captured_env, (
+            "FDSX_HOOKS from os.environ must be stripped before passing to Popen"
+        )
+
+    def test_run_subprocess_strips_fdsx_hooks_when_env_arg_provided(self) -> None:
+        """FDSX_HOOKS in caller-supplied env must be stripped from the subprocess env."""
+        with patch("fdsx.providers.base.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = _make_mock_process()
+            _run_subprocess(
+                ["echo", "hi"],
+                env={"FDSX_HOOKS": "on_start", "MY_VAR": "hello"},
+            )
+
+        captured_env = mock_popen.call_args[1]["env"]
+
+        assert "FDSX_HOOKS" not in captured_env, (
+            "FDSX_HOOKS supplied via env arg must be stripped before passing to Popen"
+        )
+        assert "MY_VAR" in captured_env, (
+            "Other vars supplied via env arg must be preserved"
+        )
+
+    def test_run_subprocess_does_not_strip_other_fdsx_vars(self) -> None:
+        """Only FDSX_HOOKS must be stripped; other FDSX_* vars must be preserved."""
+        with patch("fdsx.providers.base.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = _make_mock_process()
+            _run_subprocess(
+                ["echo", "hi"],
+                env={"FDSX_HOOKS": "on_complete", "FDSX_STATE_NAME": "MyState"},
+            )
+
+        captured_env = mock_popen.call_args[1]["env"]
+
+        assert "FDSX_HOOKS" not in captured_env, (
+            "FDSX_HOOKS must be stripped from the subprocess env"
+        )
+        assert "FDSX_STATE_NAME" in captured_env, (
+            "FDSX_STATE_NAME and other FDSX_* vars must not be stripped"
+        )


### PR DESCRIPTION
## Summary

Implement `FDSX_HOOKS` environment variable injection for hook lifecycle events and scrub it from provider subprocess environments.

- `src/fdsx/core/hooks.py`: Inject `FDSX_HOOKS=<event>` into hook subprocess environments (`on_start`, `on_complete`, `on_error`)
- `src/fdsx/providers/base.py`: Scrub `FDSX_HOOKS` from provider subprocess environments so providers cannot see hook event info
- All hook execution call sites now pass `event=` kwarg

## Why

Hooks can now detect which lifecycle event triggered them (`on_start`, `on_complete`, `on_error`), enabling more contextual hook behavior. Provider subprocesses are isolated from hook event context for security/clarity.

## How to Test

```bash
cd /tmp && mkdir fdsx-smoke-test && cd fdsx-smoke-test
cat > flow.yaml << 'YAML'
name: FDSX Hooks Smoke Test
description: Verify FDSX_HOOKS is injected for hooks and absent from provider
start_at: check_env
states:
  check_env:
    type: task
    provider: system
    command: \"sh -c 'printf \\\"%s\\\" \"\${FDSX_HOOKS+PRESENT}\" > out.txt'\"
    result_path: \$.result
    end: true
    hooks:
      on_start:
        - command: \"sh -c 'printf \\\"%s\\\" \"\$FDSX_HOOKS\" > start.txt'\"
      on_complete:
        - command: \"sh -c 'printf \\\"%s\\\" \"\$FDSX_HOOKS\" > complete.txt'\"
YAML
uv run fdsx run flow.yaml
cat start.txt   # => on_start
cat complete.txt # => on_complete
cat out.txt     # => (empty)
```

## Quality Gates

- 1956/1956 tests pass (T001–T003 included)
- `uv run ruff format --check .` clean
- `uv run ruff check src/ tests/` clean
- `uv run mypy src/` clean (60 source files)