### PR TITLE
feat(hooks): add workflow lifecycle hooks (on_workflow_start/end) + smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fdsx enables you to define AI agent workflows in YAML, combining the durability 
 - Multiple LLM provider support (Claude, Codex, Gemini, OpenCode, and system commands)
 - Named profiles for reusable provider/model configuration
 - Webhook notifications on wait states
-- Lifecycle hooks (on_start / on_complete) at flow and state level
+- Lifecycle hooks (on_state_start / on_state_end / on_workflow_start / on_workflow_end) at flow and state level
 - Output extraction with JSON, regex, keyword strategies and LLM fallback
 - Workflow auto-selection via LLM-based matching
 
@@ -101,14 +101,20 @@ providers:
     full_auto: true
 
 # --- Flow-level hooks (optional) ---
-# Run before/after the entire flow. Merged with config-level hooks.
+# Run before/after states or the entire flow. Merged with config-level hooks.
 # See "Hook Environment" section below for available env vars and positional args.
 hooks:
-  on_start:
-    - command: "echo 'Flow starting'"  # (string, REQUIRED) shell command
-      on_failure: warn                  # "warn" (default) = log and continue, "abort" = stop execution
-  on_complete:
-    - command: "echo 'Flow done'"
+  on_state_start:
+    - command: "echo 'State starting'"  # (string, REQUIRED) shell command
+      on_failure: warn                   # "warn" (default) = log and continue, "abort" = stop execution
+  on_state_end:
+    - command: "echo 'State done'"
+      on_failure: warn
+  on_workflow_start:                     # fires once when the workflow begins (fresh runs only)
+    - command: "echo 'Workflow starting'"
+      on_failure: warn
+  on_workflow_end:                       # fires once when the workflow finishes (all terminal paths)
+    - command: "echo 'Workflow done'"
       on_failure: warn
 
 # ============================================================
@@ -168,11 +174,12 @@ states:
       permission_mode: dontAsk
 
     # --- State-level hooks (optional) ---
+    # Note: on_workflow_start and on_workflow_end are NOT valid here; use flow-level hooks.
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo 'task starting'"
           on_failure: warn
-      on_complete:
+      on_state_end:
         - command: "echo 'task done'"
           on_failure: abort             # abort = stop the flow if this hook fails
 
@@ -198,7 +205,7 @@ states:
         next: fix
     default: fallback_state             # (string, optional) state when no choice matches
     max_iterations: 10                  # (int, optional) max times this state can be entered
-    hooks:                              # (optional) same structure as task hooks
+    hooks:                              # (optional) on_state_start / on_state_end only
 
   # ----------------------------------------------------------
   # parallel — run multiple branches concurrently
@@ -235,7 +242,7 @@ states:
     result_file: $.reviews_ref          # (string, optional) path to result file
     min_success: 2                      # (int, optional) minimum branches that must succeed
     max_iterations: 3                   # (int, optional)
-    hooks:                              # (optional)
+    hooks:                              # (optional) on_state_start / on_state_end only
     next: aggregate_reviews             # next / end — same rules as task
     # end: true
 
@@ -262,7 +269,7 @@ states:
     fail_fast: true                     # (bool, default: true) stop all iterations on first failure
     result_path: $.map_results           # (string, REQUIRED) JSONPath for the results array
     max_iterations: 10                  # (int, optional) max times this state can be re-entered
-    hooks:                              # (optional)
+    hooks:                              # (optional) on_state_start / on_state_end only
     next: after_map                     # next / end — same rules as task
     # end: true
 
@@ -286,7 +293,8 @@ states:
       result_path: $.review_decision    # (string, REQUIRED) where aggregated result is stored
 
     max_iterations: 3                   # (int, optional)
-    hooks:                              # (optional)
+    hooks:                              # (optional) pass states accept all hook keys including
+                                        #   on_workflow_start and on_workflow_end
     next: review_route                  # next / end — same rules as task
     # end: true
 
@@ -314,7 +322,7 @@ states:
                                         # Non-2xx responses are logged as warnings, never fail the flow
 
     max_iterations: 1                   # (int, optional)
-    hooks:                              # (optional)
+    hooks:                              # (optional) on_state_start / on_state_end only
     next: post_approval                 # next / end — same rules as task
     # end: true
 ```
@@ -332,6 +340,7 @@ Every hook command receives context via **environment variables** and **position
 | `FDSX_DATA_PATH` | Path to the state data JSON file | `.fdsx/runs/<thread_id>/hooks/plan/input.json` |
 | `FDSX_THREAD_ID` | Current run thread ID | `abc123` |
 | `FDSX_FLOW_NAME` | Name of the flow | `MyWorkflow` |
+| `FDSX_HOOKS` | Lifecycle event name that triggered the hook | `on_state_start`, `on_workflow_end` |
 
 **Positional arguments** (appended to your command):
 
@@ -343,8 +352,8 @@ Every hook command receives context via **environment variables** and **position
 
 **Data files:** Before each hook runs, fdsx writes a JSON file containing the current state dictionary:
 
-- `on_start` hooks receive `input.json` — the state *before* execution
-- `on_complete` hooks receive `output.json` — the state *after* execution
+- `on_state_start` hooks receive `input.json` — the state *before* execution
+- `on_state_end` hooks receive `output.json` — the state *after* execution
 
 Files are written to `.fdsx/runs/<thread_id>/hooks/<state_name>/`.
 
@@ -352,15 +361,17 @@ Files are written to `.fdsx/runs/<thread_id>/hooks/<state_name>/`.
 
 ```yaml
 hooks:
-  on_start:
+  on_state_start:
     - command: "curl -X POST https://slack.example.com/webhook -d '{\"text\": \"State '\"$FDSX_STATE_NAME\"' starting in flow '\"$FDSX_FLOW_NAME\"'\"}'"
       on_failure: warn
-  on_complete:
+  on_state_end:
     - command: "cat $FDSX_DATA_PATH | jq .review_verdict"
       on_failure: warn
 ```
 
 **Merge order:** Hooks from multiple levels are concatenated (not replaced) in this order: global config → project config → flow → state. All hooks at every level run.
+
+**Hook scope:** `on_state_start` and `on_state_end` are valid at all levels (global config, project config, flow, and individual states). `on_workflow_start` and `on_workflow_end` are only valid at global config, project config, and flow scope — placing them inside a state's `hooks:` block will raise a validation error (the one exception is `pass` states, which accept all hook keys).
 
 ### Variable References
 
@@ -484,11 +495,17 @@ providers:
 # --- Global hooks (optional) ---
 # Merged with flow-level hooks (config hooks run first).
 hooks:
-  on_start:
-    - command: "echo 'global start'"
+  on_state_start:
+    - command: "echo 'global state start'"
       on_failure: warn
-  on_complete:
-    - command: "echo 'global done'"
+  on_state_end:
+    - command: "echo 'global state done'"
+      on_failure: warn
+  on_workflow_start:
+    - command: "echo 'global workflow start'"
+      on_failure: warn
+  on_workflow_end:
+    - command: "echo 'global workflow done'"
       on_failure: warn
 ```
 

--- a/examples/hooks_smoke.yaml
+++ b/examples/hooks_smoke.yaml
@@ -1,0 +1,70 @@
+name: Hooks Smoke Test
+description: >
+  Smoke test for all four workflow lifecycle hooks (on_workflow_start,
+  on_workflow_end, on_state_start, on_state_end). Each hook appends a
+  structured line to /tmp/fdsx_smoke_hooks.log.
+
+  Run modes:
+    fdsx run examples/hooks_smoke.yaml --input mode=fast          # fast completion
+    fdsx run examples/hooks_smoke.yaml --input mode=wait          # pause at wait state, then resume
+    fdsx run examples/hooks_smoke.yaml --tasks-dir examples/hooks_smoke_tasks/ --auto-workflow  # 3-task batch
+version: "1.0"
+start_at: start
+
+hooks:
+  on_workflow_start:
+    - command: >-
+        echo "EVENT=on_workflow_start STATUS=$FDSX_STATUS THREAD=$FDSX_THREAD_ID"
+        >> /tmp/fdsx_smoke_hooks.log
+  on_workflow_end:
+    - command: >-
+        echo "EVENT=on_workflow_end STATUS=$FDSX_STATUS THREAD=$FDSX_THREAD_ID"
+        >> /tmp/fdsx_smoke_hooks.log
+  on_state_start:
+    - command: >-
+        echo "EVENT=on_state_start STATE=$FDSX_STATE_NAME STATUS=$FDSX_STATUS THREAD=$FDSX_THREAD_ID"
+        >> /tmp/fdsx_smoke_hooks.log
+  on_state_end:
+    - command: >-
+        echo "EVENT=on_state_end STATE=$FDSX_STATE_NAME STATUS=$FDSX_STATUS THREAD=$FDSX_THREAD_ID"
+        >> /tmp/fdsx_smoke_hooks.log
+
+states:
+  start:
+    type: task
+    provider: system
+    command: "echo 'smoke test started'"
+    result_path: $.start_result
+    next: route
+
+  route:
+    type: choice
+    choices:
+      - variable: $.mode
+        operator: equals
+        value: wait
+        next: pause
+    default: fast_end
+
+  fast_end:
+    type: task
+    provider: system
+    command: "echo 'fast path complete'"
+    result_path: $.final_result
+    end: true
+
+  pause:
+    type: wait
+    mode: prompt
+    message: "Smoke test paused. Select 'continue' to resume."
+    choices:
+      - continue
+    result_path: $.wait_result
+    next: resumed_end
+
+  resumed_end:
+    type: task
+    provider: system
+    command: "echo 'resumed path complete'"
+    result_path: $.final_result
+    end: true

--- a/examples/hooks_smoke_tasks/.gitignore
+++ b/examples/hooks_smoke_tasks/.gitignore
@@ -1,0 +1,1 @@
+completed/

--- a/examples/hooks_smoke_tasks/task1.yaml
+++ b/examples/hooks_smoke_tasks/task1.yaml
@@ -1,0 +1,1 @@
+description: Smoke test task 1

--- a/examples/hooks_smoke_tasks/task2.yaml
+++ b/examples/hooks_smoke_tasks/task2.yaml
@@ -1,0 +1,1 @@
+description: Smoke test task 2

--- a/examples/hooks_smoke_tasks/task3.yaml
+++ b/examples/hooks_smoke_tasks/task3.yaml
@@ -1,0 +1,1 @@
+description: Smoke test task 3

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -200,7 +200,7 @@ def _wrap_with_hooks(
                 data_path=input_data_path,
                 thread_id=thread_id,
                 flow_name=flow_name,
-                event="on_start",
+                event="on_state_start",
             )
 
         node_error: BaseException | None = None
@@ -231,7 +231,7 @@ def _wrap_with_hooks(
                     data_path=output_data_path,
                     thread_id=thread_id,
                     flow_name=flow_name,
-                    event="on_complete",
+                    event="on_state_end",
                 )
         except BaseException:
             if node_error is not None:
@@ -302,16 +302,16 @@ def compile_flow(
     config_hooks = config.hooks if config is not None else None
 
     def _collect_state_hooks(state_obj: Any) -> tuple[list[HookEntry], list[HookEntry]]:
-        """Collect on_start and on_complete hooks for a state from all levels."""
+        """Collect on_state_start and on_state_end hooks for a state from all levels."""
         on_s = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=config_hooks,
             project_hooks=None,
             flow_hooks=flow.hooks,
             state_hooks=state_obj.hooks,
         )
         on_c = collect_hooks(
-            "on_complete",
+            "on_state_end",
             global_hooks=config_hooks,
             project_hooks=None,
             flow_hooks=flow.hooks,

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -150,16 +150,16 @@ class CompiledGraph:
 def _wrap_with_hooks(
     node_fn: Callable[[dict[str, Any]], dict[str, Any]],
     state_name: str,
-    on_start_hooks: list[HookEntry],
-    on_complete_hooks: list[HookEntry],
+    on_state_start_hooks: list[HookEntry],
+    on_state_end_hooks: list[HookEntry],
     *,
     recorder: Any = None,
     fdsx_base_dir: Path | None = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Wrap a node function with hook execution.
 
-    Calls execute_hooks(on_start_hooks) with status "starting" before node
-    execution and execute_hooks(on_complete_hooks) with status "completed"
+    Calls execute_hooks(on_state_start_hooks) with status "starting" before node
+    execution and execute_hooks(on_state_end_hooks) with status "completed"
     after.  Hook data (input/output state dicts) is written to
     .fdsx/runs/<thread-id>/hooks/<state-name>/{input,output}.json.
 
@@ -168,8 +168,8 @@ def _wrap_with_hooks(
     Args:
         node_fn: The original node function to wrap.
         state_name: Logical state name used for hook data paths.
-        on_start_hooks: Hooks to execute before the node runs.
-        on_complete_hooks: Hooks to execute after the node runs.
+        on_state_start_hooks: Hooks to execute before the node runs.
+        on_state_end_hooks: Hooks to execute after the node runs.
         recorder: RunRecorder providing thread_id and flow_name.
         fdsx_base_dir: The .fdsx root directory for hook data files.
                        When None, defaults to CWD/.fdsx.
@@ -177,7 +177,7 @@ def _wrap_with_hooks(
     Returns:
         Wrapped node function, or the original node_fn when both lists are empty.
     """
-    if not on_start_hooks and not on_complete_hooks:
+    if not on_state_start_hooks and not on_state_end_hooks:
         return node_fn
 
     def wrapped(state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -192,9 +192,9 @@ def _wrap_with_hooks(
             base_dir=fdsx_base_dir,
         )
 
-        if on_start_hooks:
+        if on_state_start_hooks:
             execute_hooks(
-                on_start_hooks,
+                on_state_start_hooks,
                 state_name=state_name,
                 status="starting",
                 data_path=input_data_path,
@@ -223,9 +223,9 @@ def _wrap_with_hooks(
                 base_dir=fdsx_base_dir,
             )
 
-            if on_complete_hooks:
+            if on_state_end_hooks:
                 execute_hooks(
-                    on_complete_hooks,
+                    on_state_end_hooks,
                     state_name=state_name,
                     status=status,
                     data_path=output_data_path,
@@ -321,7 +321,7 @@ def compile_flow(
 
     for state_name, state in flow.states.items():
         if isinstance(state, TaskState):
-            on_start, on_complete = _collect_state_hooks(state)
+            on_state_start, on_state_end = _collect_state_hooks(state)
             node = _create_task_node(
                 state_name,
                 state,
@@ -337,36 +337,36 @@ def compile_flow(
                 _wrap_with_hooks(
                     node,
                     state_name,
-                    on_start,
-                    on_complete,
+                    on_state_start,
+                    on_state_end,
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
                 ),
             )  # type: ignore[call-overload]
         elif isinstance(state, ChoiceState):
-            on_start, on_complete = _collect_state_hooks(state)
+            on_state_start, on_state_end = _collect_state_hooks(state)
             node = _create_choice_node(state_name, state, flow, recorder)
             graph.add_node(
                 state_name,
                 _wrap_with_hooks(
                     node,
                     state_name,
-                    on_start,
-                    on_complete,
+                    on_state_start,
+                    on_state_end,
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
                 ),
             )  # type: ignore[call-overload]
         elif isinstance(state, ParallelState):
-            on_start, on_complete = _collect_state_hooks(state)
-            # Hooks wrap dispatch (on_start) and collector (on_complete), not branch executor.
+            on_state_start, on_state_end = _collect_state_hooks(state)
+            # Hooks wrap dispatch (on_state_start) and collector (on_state_end), not branch executor.
             dispatch_node = _create_dispatch_node(state_name, state, recorder)
             graph.add_node(
                 state_name,
                 _wrap_with_hooks(
                     dispatch_node,
                     state_name,
-                    on_start,
+                    on_state_start,
                     [],
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
@@ -392,36 +392,36 @@ def compile_flow(
                     collector_node,
                     state_name,
                     [],
-                    on_complete,
+                    on_state_end,
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
                 ),
             )  # type: ignore[call-overload]
         elif state.type == "pass":
-            on_start, on_complete = _collect_state_hooks(state)
+            on_state_start, on_state_end = _collect_state_hooks(state)
             node = _create_pass_node(state_name, state, flow, recorder)
             graph.add_node(
                 state_name,
                 _wrap_with_hooks(
                     node,
                     state_name,
-                    on_start,
-                    on_complete,
+                    on_state_start,
+                    on_state_end,
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
                 ),
             )  # type: ignore[call-overload]
         elif state.type == "wait":
-            on_start, on_complete = _collect_state_hooks(state)
+            on_state_start, on_state_end = _collect_state_hooks(state)
             # WaitState is split into two nodes: notify (pre-interrupt) and interrupt.
-            # on_start hooks fire in the notify node; on_complete hooks fire in the interrupt node.
+            # on_state_start hooks fire in the notify node; on_state_end hooks fire in the interrupt node.
             notify_node = _create_wait_notify_node(state_name, state, recorder)
             graph.add_node(
                 state_name,
                 _wrap_with_hooks(
                     notify_node,
                     state_name,
-                    on_start,
+                    on_state_start,
                     [],
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
@@ -434,14 +434,14 @@ def compile_flow(
                     interrupt_node,
                     state_name,
                     [],
-                    on_complete,
+                    on_state_end,
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
                 ),
             )  # type: ignore[call-overload]
             graph.add_edge(state_name, f"_{state_name}_int")
         elif isinstance(state, MapState):
-            on_start, on_complete = _collect_state_hooks(state)
+            on_state_start, on_state_end = _collect_state_hooks(state)
             node = _create_map_node(
                 state_name,
                 state,
@@ -457,8 +457,8 @@ def compile_flow(
                 _wrap_with_hooks(
                     node,
                     state_name,
-                    on_start,
-                    on_complete,
+                    on_state_start,
+                    on_state_end,
                     recorder=recorder,
                     fdsx_base_dir=fdsx_base_dir,
                 ),

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -23,7 +23,7 @@ from fdsx.providers.gemini import GeminiOptions
 from fdsx.providers.opencode import OpenCodeOptions
 
 # Keys within HookConfig whose list values are concatenated (not replaced) during deep merge
-_HOOK_LIST_KEYS: frozenset[str] = frozenset({"on_start", "on_complete"})
+_HOOK_LIST_KEYS: frozenset[str] = frozenset({"on_state_start", "on_state_end"})
 
 # Keys whose dict values are shallow-merged instead of deep-merged
 _SHALLOW_MERGE_KEYS: frozenset[str] = frozenset({"profiles"})

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -23,7 +23,9 @@ from fdsx.providers.gemini import GeminiOptions
 from fdsx.providers.opencode import OpenCodeOptions
 
 # Keys within HookConfig whose list values are concatenated (not replaced) during deep merge
-_HOOK_LIST_KEYS: frozenset[str] = frozenset({"on_state_start", "on_state_end", "on_workflow_start", "on_workflow_end"})
+_HOOK_LIST_KEYS: frozenset[str] = frozenset(
+    {"on_state_start", "on_state_end", "on_workflow_start", "on_workflow_end"}
+)
 
 # Keys whose dict values are shallow-merged instead of deep-merged
 _SHALLOW_MERGE_KEYS: frozenset[str] = frozenset({"profiles"})

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -198,7 +198,7 @@ def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any
     """Recursively merge override into base, with override taking precedence.
 
     When both base and override have a dict value for the same key, the dicts
-    are merged recursively. For keys in _HOOK_LIST_KEYS (on_start, on_complete),
+    are merged recursively. For keys in _HOOK_LIST_KEYS (on_state_start, on_state_end),
     list values are concatenated (base + override) rather than replaced.
     For keys in _SHALLOW_MERGE_KEYS (profiles), dict values are shallow-merged
     (full replacement per name, not deep merge of individual profile fields).

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -23,7 +23,7 @@ from fdsx.providers.gemini import GeminiOptions
 from fdsx.providers.opencode import OpenCodeOptions
 
 # Keys within HookConfig whose list values are concatenated (not replaced) during deep merge
-_HOOK_LIST_KEYS: frozenset[str] = frozenset({"on_state_start", "on_state_end"})
+_HOOK_LIST_KEYS: frozenset[str] = frozenset({"on_state_start", "on_state_end", "on_workflow_start", "on_workflow_end"})
 
 # Keys whose dict values are shallow-merged instead of deep-merged
 _SHALLOW_MERGE_KEYS: frozenset[str] = frozenset({"profiles"})

--- a/src/fdsx/core/engine/resume.py
+++ b/src/fdsx/core/engine/resume.py
@@ -10,6 +10,11 @@ from langgraph.types import Command
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core.compiler import compile_flow
 from fdsx.core.config import load_config
+from fdsx.core.hooks import (
+    HookAbortError,
+    collect_workflow_hooks,
+    execute_workflow_hooks,
+)
 from fdsx.core.loader import load_flow
 from fdsx.display.terminal import (
     _sanitize_output,
@@ -213,6 +218,19 @@ def resume_flow(
         failed_state: str | None = None
         if recorder is not None:
             status, failed_state, _ = _detect_abort_status(recorder)
+            # T024: fire on_workflow_end with terminal status on resume completion
+            execute_workflow_hooks(
+                collect_workflow_hooks(
+                    "on_workflow_end",
+                    global_hooks=config.hooks,
+                    project_hooks=None,
+                    flow_hooks=flow.hooks,
+                ),
+                status=status,
+                event="on_workflow_end",
+                thread_id=thread_id,
+                flow_name=recorder.flow_name,
+            )
             recorder.finalize(_sanitize_state_for_log(last_state), status)
             recorder.save(base_dir=base_dir)
             if failed_state is not None:
@@ -253,6 +271,25 @@ def resume_flow(
         if recorder is not None:
             recorder.finalize(_sanitize_state_for_log(last_state), "error")
             recorder.save(base_dir=base_dir)
+            # T024: fire on_workflow_end with failed/aborted status on exception path
+            _abort_detect, _, _ = _detect_abort_status(recorder)
+            _end_status = (
+                "aborted"
+                if _abort_detect == "aborted" or isinstance(e, HookAbortError)
+                else "failed"
+            )
+            execute_workflow_hooks(
+                collect_workflow_hooks(
+                    "on_workflow_end",
+                    global_hooks=config.hooks,
+                    project_hooks=None,
+                    flow_hooks=flow.hooks if flow is not None else None,
+                ),
+                status=_end_status,
+                event="on_workflow_end",
+                thread_id=thread_id,
+                flow_name=recorder.flow_name,
+            )
             failed = _find_failed_state(recorder)
             failed_state_name = failed[0] if failed else "unknown"
             error_message = failed[1] if (failed and failed[1]) else str(e)

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -4,11 +4,17 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import structlog
 from langgraph.checkpoint.memory import MemorySaver
 
 from fdsx.checkpoint.manager import CheckpointManager
 from fdsx.core.compiler import compile_flow
 from fdsx.core.config import load_config
+from fdsx.core.hooks import (
+    HookAbortError,
+    collect_workflow_hooks,
+    execute_workflow_hooks,
+)
 from fdsx.core.loader import load_flow
 from fdsx.core.thread_id import generate_thread_id
 from fdsx.display.terminal import (
@@ -29,6 +35,8 @@ from .results import (
 )
 from .signals import SignalHandler
 from .validate import FlowValidationError
+
+logger = structlog.get_logger(__name__)
 
 
 def run_flow(
@@ -163,6 +171,30 @@ def run_flow(
         "configurable": {"thread_id": thread_id},
     }
 
+    # T022: fire on_workflow_start for fresh runs only (skip if checkpoint exists)
+    _is_fresh = checkpoint_manager is None or not checkpoint_manager.verify_checkpoint(
+        thread_id
+    )
+    if _is_fresh:
+        execute_workflow_hooks(
+            collect_workflow_hooks(
+                "on_workflow_start",
+                global_hooks=fdsx_config.hooks,
+                project_hooks=None,
+                flow_hooks=flow.hooks,
+            ),
+            status="starting",
+            event="on_workflow_start",
+            thread_id=thread_id,
+            flow_name=flow.name,
+        )
+    else:
+        logger.debug(
+            "on_workflow_start_skipped",
+            thread_id=thread_id,
+            flow_name=flow.name,
+        )
+
     last_state: dict[str, Any] = initial_state.copy()
 
     try:
@@ -182,6 +214,19 @@ def run_flow(
 
         results = _extract_results(last_state, compiled.result_paths)
         status, failed_state, error_msg = _detect_abort_status(recorder)
+        # T023: fire on_workflow_end with terminal status
+        execute_workflow_hooks(
+            collect_workflow_hooks(
+                "on_workflow_end",
+                global_hooks=fdsx_config.hooks,
+                project_hooks=None,
+                flow_hooks=flow.hooks,
+            ),
+            status=status,
+            event="on_workflow_end",
+            thread_id=thread_id,
+            flow_name=flow.name,
+        )
         recorder.finalize(_sanitize_state_for_log(last_state), status)
         recorder.save(base_dir=base_dir)
         if failed_state is not None:
@@ -202,6 +247,25 @@ def run_flow(
             )
         recorder.finalize(_sanitize_state_for_log(last_state), "error")
         recorder.save(base_dir=base_dir)
+        # T023: fire on_workflow_end with failed/aborted status on exception path
+        _abort_detect, _, _ = _detect_abort_status(recorder)
+        _end_status = (
+            "aborted"
+            if _abort_detect == "aborted" or isinstance(e, HookAbortError)
+            else "failed"
+        )
+        execute_workflow_hooks(
+            collect_workflow_hooks(
+                "on_workflow_end",
+                global_hooks=fdsx_config.hooks,
+                project_hooks=None,
+                flow_hooks=flow.hooks,
+            ),
+            status=_end_status,
+            event="on_workflow_end",
+            thread_id=thread_id,
+            flow_name=flow.name,
+        )
         failed = _find_failed_state(recorder)
         failed_state_name = failed[0] if failed else "unknown"
         error_message = failed[1] if (failed and failed[1]) else str(e)

--- a/src/fdsx/core/engine/tasks_dir.py
+++ b/src/fdsx/core/engine/tasks_dir.py
@@ -356,6 +356,9 @@ def run_tasks_dir(
 
             try:
                 task_inputs = {"task": description, "source": task_file.source or ""}
+                # FR-4/FR-5: on_workflow_start and on_workflow_end fire once per task, inside
+                # run_flow() / resume_flow() below. Do NOT wrap the outer tasks-dir loop with
+                # additional workflow hook calls — hooks must fire per-task, not per-directory-run.
                 flow_result = run_flow(
                     flow_path=effective_workflow,
                     inputs=task_inputs,

--- a/src/fdsx/core/hooks.py
+++ b/src/fdsx/core/hooks.py
@@ -172,6 +172,86 @@ def write_hook_data(
     return file_path
 
 
+def collect_workflow_hooks(
+    event: Literal["on_workflow_start", "on_workflow_end"],
+    *,
+    global_hooks: HookConfig | None,
+    project_hooks: HookConfig | None,
+    flow_hooks: HookConfig | None,
+) -> list[HookEntry]:
+    """Collect and merge workflow-scope hooks from global, project, and flow configs.
+
+    Merges in order: global → project → flow (no state level).
+    Returns a single flat list of HookEntry objects.
+
+    Args:
+        event: "on_workflow_start" or "on_workflow_end".
+        global_hooks: Hook config from global ~/.config/fdsx/config.yaml.
+        project_hooks: Hook config from project .fdsx/config.yaml.
+        flow_hooks: Hook config from the flow definition.
+
+    Returns:
+        Concatenated list of HookEntry objects in global → project → flow order.
+    """
+    result: list[HookEntry] = []
+    for hook_config in (global_hooks, project_hooks, flow_hooks):
+        if hook_config is not None:
+            result.extend(getattr(hook_config, event))
+    return result
+
+
+def execute_workflow_hooks(
+    hooks: list[HookEntry],
+    *,
+    status: str,
+    thread_id: str,
+    flow_name: str,
+    event: Literal["on_workflow_start", "on_workflow_end"],
+    timeout_seconds: float = 30.0,
+) -> None:
+    """Execute workflow-scope hook commands in order.
+
+    Each command is run with ``shell=True`` and a timeout. Receives:
+    - Environment variables: FDSX_HOOKS, FDSX_STATUS, FDSX_FLOW_NAME, FDSX_THREAD_ID
+    - FDSX_STATE_NAME and FDSX_DATA_PATH are explicitly omitted.
+
+    Non-zero exit codes and timeouts log a warning and continue — never raises.
+
+    Args:
+        hooks: Ordered list of HookEntry objects to execute.
+        status: Lifecycle status ("starting", "completed", "failed", "aborted").
+        thread_id: Current run thread ID.
+        flow_name: Name of the flow.
+        event: Lifecycle event ("on_workflow_start" or "on_workflow_end").
+        timeout_seconds: Per-hook subprocess timeout in seconds. Defaults to 30.0.
+    """
+    env = {
+        k: v for k, v in os.environ.items() if k not in (ENV_STATE_NAME, ENV_DATA_PATH)
+    }
+    env[ENV_HOOKS] = event
+    env[ENV_STATUS] = status
+    env[ENV_FLOW_NAME] = flow_name
+    env[ENV_THREAD_ID] = thread_id
+
+    for hook in hooks:
+        try:
+            result = subprocess.run(
+                hook.command, shell=True, env=env, timeout=timeout_seconds
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "Workflow hook exited with code %d (warn-only): %r",
+                    result.returncode,
+                    hook.command,
+                )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "Workflow hook timed out after %s s (killed): %r",
+                timeout_seconds,
+                hook.command,
+            )
+
+
 def collect_hooks(
     event: Literal["on_state_start", "on_state_end"],
     *,

--- a/src/fdsx/core/hooks.py
+++ b/src/fdsx/core/hooks.py
@@ -57,7 +57,7 @@ def execute_hooks(
     data_path: Path,
     thread_id: str,
     flow_name: str,
-    event: Literal["on_start", "on_complete"],
+    event: Literal["on_state_start", "on_state_end"],
 ) -> None:
     """Execute a flat list of hook commands in order.
 
@@ -73,8 +73,8 @@ def execute_hooks(
         data_path: Path to the state data JSON file passed as $3 / FDSX_DATA_PATH.
         thread_id: Current run thread ID.
         flow_name: Name of the flow.
-        event: Lifecycle event that triggered this hook invocation ("on_start" or
-            "on_complete"). Exported as FDSX_HOOKS; overrides any inherited value.
+        event: Lifecycle event that triggered this hook invocation ("on_state_start" or
+            "on_state_end"). Exported as FDSX_HOOKS; overrides any inherited value.
 
     Raises:
         HookAbortError: When a hook exits non-zero and its on_failure is "abort".
@@ -173,7 +173,7 @@ def write_hook_data(
 
 
 def collect_hooks(
-    event: Literal["on_start", "on_complete"],
+    event: Literal["on_state_start", "on_state_end"],
     *,
     global_hooks: HookConfig | None,
     project_hooks: HookConfig | None,
@@ -186,7 +186,7 @@ def collect_hooks(
     Returns a single flat list of HookEntry objects.
 
     Args:
-        event: "on_start" or "on_complete".
+        event: "on_state_start" or "on_state_end".
         global_hooks: Hook config from global ~/.config/fdsx/config.yaml.
         project_hooks: Hook config from project .fdsx/config.yaml.
         flow_hooks: Hook config from the flow definition.

--- a/src/fdsx/data/skills/fdsx/SKILL.md
+++ b/src/fdsx/data/skills/fdsx/SKILL.md
@@ -159,17 +159,19 @@ Shell commands that run before/after state or flow execution:
 
 ```yaml
 hooks:
-  on_start:
+  on_state_start:
     - command: "echo Starting"
       on_failure: warn       # or "abort"
-  on_complete:
+  on_state_end:
     - command: "echo Done"
 ```
 
 Hooks can be defined at flow level and per-state level. Each hook command receives:
 
 - **Positional arguments:** `$1=state_name`, `$2=status`, `$3=data_path`
-- **Environment variables:** `FDSX_STATE_NAME`, `FDSX_STATUS`, `FDSX_DATA_PATH`, `FDSX_THREAD_ID`, `FDSX_FLOW_NAME`
+- **Environment variables:** `FDSX_STATE_NAME`, `FDSX_STATUS`, `FDSX_DATA_PATH`, `FDSX_THREAD_ID`, `FDSX_FLOW_NAME`, `FDSX_HOOKS`
+
+`FDSX_HOOKS` contains the lifecycle event name (`on_state_start` or `on_state_end`).
 
 Hook data files are written to `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` (before execution) and `output.json` (after execution).
 

--- a/src/fdsx/data/skills/fdsx/SKILL.md
+++ b/src/fdsx/data/skills/fdsx/SKILL.md
@@ -155,7 +155,11 @@ When `fdsx run` is invoked with no workflow, no `--tasks-dir`, and no `--input`,
 
 ## Hooks
 
-Shell commands that run before/after state or flow execution:
+Shell commands that run at lifecycle events. There are two scopes with different behaviors:
+
+### State-scope hooks (`on_state_start`, `on_state_end`)
+
+Run before/after individual state execution. Can be defined at flow level and per-state level. Per-state `hooks` blocks **only** accept `on_state_start` and `on_state_end` — using `on_workflow_start` or `on_workflow_end` in a state block raises a validation error.
 
 ```yaml
 hooks:
@@ -166,14 +170,42 @@ hooks:
     - command: "echo Done"
 ```
 
-Hooks can be defined at flow level and per-state level. Each hook command receives:
+Each state-scope hook command receives:
 
 - **Positional arguments:** `$1=state_name`, `$2=status`, `$3=data_path`
 - **Environment variables:** `FDSX_STATE_NAME`, `FDSX_STATUS`, `FDSX_DATA_PATH`, `FDSX_THREAD_ID`, `FDSX_FLOW_NAME`, `FDSX_HOOKS`
 
-`FDSX_HOOKS` contains the lifecycle event name (`on_state_start` or `on_state_end`).
+`FDSX_STATUS` values: `starting` (on_state_start), `completed` or `failed` (on_state_end).
+
+`FDSX_HOOKS` contains the lifecycle event name: `on_state_start` or `on_state_end`.
 
 Hook data files are written to `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` (before execution) and `output.json` (after execution).
+
+State-scope hooks respect `on_failure: abort` — a non-zero exit with `abort` policy raises an error and stops the workflow. `warn` (default) logs a warning and continues.
+
+### Workflow-scope hooks (`on_workflow_start`, `on_workflow_end`)
+
+Run at the start and end of an entire workflow run. Can only be defined at flow level or in config files — **not** in per-state `hooks` blocks.
+
+```yaml
+hooks:
+  on_workflow_start:
+    - command: "echo Workflow starting"
+  on_workflow_end:
+    - command: "notify.sh"
+```
+
+Each workflow-scope hook command receives:
+
+- **No positional arguments** (unlike state-scope hooks)
+- **Environment variables:** `FDSX_HOOKS`, `FDSX_STATUS`, `FDSX_FLOW_NAME`, `FDSX_THREAD_ID`
+- `FDSX_STATE_NAME` and `FDSX_DATA_PATH` are **not** set
+
+`FDSX_STATUS` values: `starting` (on_workflow_start), `completed`, `failed`, or `aborted` (on_workflow_end).
+
+`FDSX_HOOKS` contains `on_workflow_start` or `on_workflow_end`.
+
+Workflow-scope hooks are always warn-only — non-zero exits log a warning and never abort the workflow. Each hook has a 30-second subprocess timeout. `on_workflow_start` fires only on fresh runs (not on `fdsx resume`).
 
 ## Config File
 
@@ -246,3 +278,4 @@ Inside iterator states, `{item}` refers to the current array element. Use `{item
 - `result_file` must be a top-level `$.varname` path (no nesting)
 - Extract `result_path` must not use reserved keys: `output`, `exit_code`, `error`
 - Map iterator states must all have `type: task` and unique `name` fields
+- `on_workflow_start` and `on_workflow_end` are forbidden inside per-state `hooks` blocks

--- a/src/fdsx/data/skills/fdsx/SKILL.md
+++ b/src/fdsx/data/skills/fdsx/SKILL.md
@@ -159,7 +159,7 @@ Shell commands that run at lifecycle events. There are two scopes with different
 
 ### State-scope hooks (`on_state_start`, `on_state_end`)
 
-Run before/after individual state execution. Can be defined at flow level and per-state level. Per-state `hooks` blocks **only** accept `on_state_start` and `on_state_end` — using `on_workflow_start` or `on_workflow_end` in a state block raises a validation error.
+Run before/after individual state execution. Can be defined at flow level and per-state level. Per-state `hooks` blocks on `task`, `choice`, `parallel`, `wait`, and `map` states **only** accept `on_state_start` and `on_state_end` — using `on_workflow_start` or `on_workflow_end` in those state blocks raises a validation error. **Exception:** `pass` state `hooks` blocks use the full `HookConfig` and accept all four keys (workflow-scope keys are silently ignored at runtime).
 
 ```yaml
 hooks:
@@ -185,7 +185,7 @@ State-scope hooks respect `on_failure: abort` — a non-zero exit with `abort` p
 
 ### Workflow-scope hooks (`on_workflow_start`, `on_workflow_end`)
 
-Run at the start and end of an entire workflow run. Can only be defined at flow level or in config files — **not** in per-state `hooks` blocks.
+Run at the start and end of an entire workflow run. Can be defined at flow level, in config files, or in `pass` state `hooks` blocks (though in a `pass` state they are silently ignored at runtime — workflow hooks only fire from `flow.hooks` and config-level hooks).
 
 ```yaml
 hooks:
@@ -223,9 +223,22 @@ task_splitter:                  # must be explicitly present to enable batch spl
   provider: claude
   model: claude-sonnet-4-6
   extra_instructions: "..."
+hooks:                          # global hooks applied to all flows
+  on_state_start:
+    - command: "echo starting"
+  on_workflow_end:
+    - command: "notify.sh"
+profiles:                       # named provider/model bundles
+  fast:
+    provider: claude
+    model: claude-haiku-4-5-20251001
 ```
 
 Both `workflow_selector` and `task_splitter` support `profile: <name>` (XOR with `provider`/`model`).
+
+`hooks` at config level supports all four lifecycle keys (`on_state_start`, `on_state_end`, `on_workflow_start`, `on_workflow_end`) and are prepended to flow-level and state-level hooks.
+
+`profiles` defined here are merged with workflow-level profiles (workflow-level overrides config-level per name).
 
 ## Common Patterns
 
@@ -278,4 +291,4 @@ Inside iterator states, `{item}` refers to the current array element. Use `{item
 - `result_file` must be a top-level `$.varname` path (no nesting)
 - Extract `result_path` must not use reserved keys: `output`, `exit_code`, `error`
 - Map iterator states must all have `type: task` and unique `name` fields
-- `on_workflow_start` and `on_workflow_end` are forbidden inside per-state `hooks` blocks
+- `on_workflow_start` and `on_workflow_end` are forbidden inside per-state `hooks` blocks for `task`, `choice`, `parallel`, `wait`, and `map` states; `pass` state `hooks` accepts all four keys (workflow-scope keys are silently ignored at runtime)

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -18,6 +18,7 @@ Complete field-by-field reference for fdsx workflow YAML files, derived from the
 - [ChoiceRule](#choicerule)
 - [AggregateRule](#aggregaterule)
 - [HookConfig](#hookconfig)
+- [StateHookConfig](#statehookconfig)
 - [ProfileConfig](#profileconfig)
 - [Provider Options](#provider-options)
 - [Config File](#config-file)
@@ -34,7 +35,7 @@ states: {name: State}           # required — map of state definitions
 version?: string                # optional
 max_loop?: int                  # default: 10 — max loop iterations
 providers?: {name: {k: v}}      # optional — workflow-level provider configs
-hooks?: HookConfig              # optional — flow-level hooks
+hooks?: HookConfig              # optional — flow-level hooks (full HookConfig including workflow-scope keys)
 profiles?: {name: {k: v}}       # optional — raw provider/model/extras dicts
 ```
 
@@ -66,7 +67,7 @@ max_iterations?: int            # optional — >=1, max times state can be enter
 retry?: int                     # default: 3
 timeout_seconds?: int           # optional — per-state timeout override
 provider_options?: {k: v}       # optional — per-task provider option overrides
-hooks?: HookConfig              # optional — per-state hooks
+hooks?: StateHookConfig         # optional — per-state hooks (on_state_start/on_state_end only)
 next?: string                   # XOR with end — target state
 end?: bool                      # XOR with next — terminate flow
 ```
@@ -90,7 +91,7 @@ type: "choice"                  # literal discriminator
 choices: [ChoiceRule]           # required — condition-transition pairs
 default?: string                # optional — fallback state name
 max_iterations?: int            # optional — >=1
-hooks?: HookConfig              # optional
+hooks?: StateHookConfig         # optional — per-state hooks (on_state_start/on_state_end only)
 ```
 
 No `next`/`end` fields — transitions are defined in `choices` and `default`.
@@ -106,7 +107,7 @@ result_path: string             # required — JSONPath for results array
 result_file?: string            # optional — top-level $.varname only
 min_success?: int               # optional — minimum successful branches
 max_iterations?: int            # optional — >=1
-hooks?: HookConfig              # optional
+hooks?: StateHookConfig         # optional — per-state hooks (on_state_start/on_state_end only)
 next?: string                   # XOR with end
 end?: bool                      # XOR with next
 ```
@@ -120,10 +121,12 @@ type: "pass"                    # literal discriminator
 parameters?: {k: v}             # optional — variable transformation
 aggregate?: AggregateRule       # optional — parallel result aggregation
 max_iterations?: int            # optional — >=1
-hooks?: HookConfig              # optional
+hooks?: HookConfig              # optional — full HookConfig (on_state_start/on_state_end/on_workflow_start/on_workflow_end)
 next?: string                   # XOR with end
 end?: bool                      # XOR with next
 ```
+
+**Note:** `PassState` is the only state type whose `hooks` field accepts the full `HookConfig` (including `on_workflow_start`/`on_workflow_end`). The engine does not invoke workflow-scope hooks at state execution time; those keys are silently ignored during state-level execution but will not cause a validation error.
 
 ---
 
@@ -137,7 +140,7 @@ choices: [string]               # required — min 1 item, user selection option
 result_path: string             # required — JSONPath for selection result
 notify?: NotifyConfig           # optional — webhook notification
 max_iterations?: int            # optional — >=1
-hooks?: HookConfig              # optional
+hooks?: StateHookConfig         # optional — per-state hooks (on_state_start/on_state_end only)
 next?: string                   # XOR with end
 end?: bool                      # XOR with next
 ```
@@ -162,7 +165,7 @@ iterator: IteratorDef           # required — sub-workflow to execute for each 
 result_path: string             # required — JSONPath for results array
 fail_fast?: bool                # default: true — stop on first failure
 max_iterations?: int            # optional — >=1, max times this state can be entered
-hooks?: HookConfig              # optional — per-state hooks
+hooks?: StateHookConfig         # optional — per-state hooks (on_state_start/on_state_end only)
 next?: string                   # XOR with end — target state
 end?: bool                      # XOR with next — terminate flow
 ```
@@ -294,31 +297,88 @@ aggregate:
 
 ## HookConfig
 
+Used at **flow level** (`Flow.hooks`) and in `PassState.hooks`. Supports all four lifecycle events including workflow-scope events.
+
 ```yaml
 hooks:
-  on_state_start:               # optional — hooks run before execution
+  on_state_start:               # optional — hooks run before each state execution
     - command: string           # required — shell command (min 1 char)
       on_failure: string        # default: "warn" — abort|warn
-  on_state_end:                 # optional — hooks run after execution
+  on_state_end:                 # optional — hooks run after each state execution
     - command: string
       on_failure: string
+  on_workflow_start:            # optional — hooks run once when the workflow starts (fresh runs only)
+    - command: string
+      on_failure: string        # note: ignored for workflow-scope hooks (always warn-only)
+  on_workflow_end:              # optional — hooks run once when the workflow ends
+    - command: string
+      on_failure: string        # note: ignored for workflow-scope hooks (always warn-only)
 ```
 
-**Note:** The legacy keys `on_start` and `on_complete` are rejected with a validation error. Use `on_state_start` and `on_state_end`.
+**Legacy keys rejected:** `on_start` and `on_complete` raise a validation error. Use `on_state_start` and `on_state_end`.
 
-Hooks can be set at flow level and per-state level. Each hook command receives:
+**Workflow-scope key restriction:** `on_workflow_start` and `on_workflow_end` are **only valid** at flow level, project config, and global config scope. Using them inside a state's `hooks` block raises a validation error (except in `PassState`, which uses the full `HookConfig` — see [PassState](#passstate)).
+
+---
+
+### State Hook Behavior (`on_state_start` / `on_state_end`)
+
+Each command receives:
 
 **Positional arguments:** `$1=state_name`, `$2=status`, `$3=data_path`
 
 **Environment variables:**
 - `FDSX_STATE_NAME` — current state name
-- `FDSX_STATUS` — lifecycle status (`starting`, `completed`, or `failed`)
+- `FDSX_STATUS` — lifecycle status: `starting` (before), `completed` or `failed` (after)
 - `FDSX_DATA_PATH` — path to the state data JSON file
 - `FDSX_THREAD_ID` — current run thread ID
 - `FDSX_FLOW_NAME` — name of the flow
-- `FDSX_HOOKS` — lifecycle event name (`on_state_start` or `on_state_end`)
+- `FDSX_HOOKS` — lifecycle event name: `on_state_start` or `on_state_end`
 
-**Hook data files:** Before hooks run, state data is written to JSON files at `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` (before execution) and `output.json` (after execution). The `FDSX_DATA_PATH` environment variable points to the relevant data file.
+**Failure policy:** `on_failure: abort` raises `HookAbortError` and stops the flow. `on_failure: warn` (default) logs a warning and continues.
+
+**Hook data files:** State data is written to JSON files at `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` (before execution) and `output.json` (after execution). `FDSX_DATA_PATH` points to the relevant file.
+
+---
+
+### Workflow Hook Behavior (`on_workflow_start` / `on_workflow_end`)
+
+**`on_workflow_start`** fires once per fresh workflow run, before any state executes. Skipped when resuming from a checkpoint.
+
+**`on_workflow_end`** fires once when the workflow terminates (success, failure, or abort), including on the exception path.
+
+Each command receives:
+
+**Positional arguments:** none (no `$1`, `$2`, `$3`)
+
+**Environment variables:**
+- `FDSX_HOOKS` — lifecycle event name: `on_workflow_start` or `on_workflow_end`
+- `FDSX_STATUS` — lifecycle status:
+  - `on_workflow_start`: always `starting`
+  - `on_workflow_end`: `completed`, `failed`, or `aborted`
+- `FDSX_FLOW_NAME` — name of the flow
+- `FDSX_THREAD_ID` — current run thread ID
+- `FDSX_STATE_NAME` and `FDSX_DATA_PATH` are **not set** for workflow hooks
+
+**Failure policy:** `on_failure` is ignored for workflow hooks. Non-zero exit codes and timeouts are always logged as warnings and never raise. Each hook has a 30-second subprocess timeout.
+
+---
+
+## StateHookConfig
+
+Used by **most state types** (`TaskState`, `ChoiceState`, `ParallelState`, `WaitState`, `MapState`) for per-state hook configuration. Identical to `HookConfig` except that `on_workflow_start` and `on_workflow_end` are explicitly forbidden.
+
+```yaml
+hooks:
+  on_state_start:               # optional — hooks run before state execution
+    - command: string           # required — shell command (min 1 char)
+      on_failure: string        # default: "warn" — abort|warn
+  on_state_end:                 # optional — hooks run after state execution
+    - command: string
+      on_failure: string
+```
+
+**Rejected keys:** `on_start`, `on_complete` (legacy), `on_workflow_start`, and `on_workflow_end` all raise a validation error when used inside a state's `hooks` block. Workflow-scope keys (`on_workflow_start`, `on_workflow_end`) are only valid at flow level or in config files.
 
 ---
 
@@ -425,3 +485,5 @@ profiles?:
 ```
 
 Config uses `extra="forbid"` — unknown keys cause validation errors.
+
+**Hook merging:** During global → project config deep merge, all four hook list keys (`on_state_start`, `on_state_end`, `on_workflow_start`, `on_workflow_end`) are **concatenated** (base + override), not replaced. This means hooks defined in global config are prepended to hooks defined in project config. Flow-level and state-level hooks are further appended at runtime in global → project → flow → state order.

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -297,7 +297,7 @@ aggregate:
 
 ## HookConfig
 
-Used at **flow level** (`Flow.hooks`) and in `PassState.hooks`. Supports all four lifecycle events including workflow-scope events.
+Used at **flow level** (`Flow.hooks`), in **config files**, and in `PassState.hooks`. Supports all four lifecycle events including workflow-scope events.
 
 ```yaml
 hooks:

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -296,13 +296,15 @@ aggregate:
 
 ```yaml
 hooks:
-  on_start:                     # optional — hooks run before execution
+  on_state_start:               # optional — hooks run before execution
     - command: string           # required — shell command (min 1 char)
       on_failure: string        # default: "warn" — abort|warn
-  on_complete:                  # optional — hooks run after execution
+  on_state_end:                 # optional — hooks run after execution
     - command: string
       on_failure: string
 ```
+
+**Note:** The legacy keys `on_start` and `on_complete` are rejected with a validation error. Use `on_state_start` and `on_state_end`.
 
 Hooks can be set at flow level and per-state level. Each hook command receives:
 
@@ -314,6 +316,7 @@ Hooks can be set at flow level and per-state level. Each hook command receives:
 - `FDSX_DATA_PATH` — path to the state data JSON file
 - `FDSX_THREAD_ID` — current run thread ID
 - `FDSX_FLOW_NAME` — name of the flow
+- `FDSX_HOOKS` — lifecycle event name (`on_state_start` or `on_state_end`)
 
 **Hook data files:** Before hooks run, state data is written to JSON files at `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` (before execution) and `output.json` (after execution). The `FDSX_DATA_PATH` environment variable points to the relevant data file.
 

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -78,12 +78,29 @@ class HookEntry(BaseModel):
 class HookConfig(BaseModel):
     """Hook configuration for a state or flow."""
 
-    on_start: list[HookEntry] = Field(
+    on_state_start: list[HookEntry] = Field(
         default_factory=list, description="Hooks to run before execution"
     )
-    on_complete: list[HookEntry] = Field(
+    on_state_end: list[HookEntry] = Field(
         default_factory=list, description="Hooks to run after execution"
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_keys(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        if "on_start" in values:
+            raise ValueError(
+                "Hook key 'on_start' has been renamed to 'on_state_start'. "
+                "Update the YAML file and retry."
+            )
+        if "on_complete" in values:
+            raise ValueError(
+                "Hook key 'on_complete' has been renamed to 'on_state_end'. "
+                "Update the YAML file and retry."
+            )
+        return values
 
 
 class ChoiceRule(BaseModel):

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -84,6 +84,12 @@ class HookConfig(BaseModel):
     on_state_end: list[HookEntry] = Field(
         default_factory=list, description="Hooks to run after execution"
     )
+    on_workflow_start: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run when the workflow starts"
+    )
+    on_workflow_end: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run when the workflow ends"
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -99,6 +105,51 @@ class HookConfig(BaseModel):
             raise ValueError(
                 "Hook key 'on_complete' has been renamed to 'on_state_end'. "
                 "Update the YAML file and retry."
+            )
+        return values
+
+
+class StateHookConfig(BaseModel):
+    """Hook configuration for a state block (workflow-scope keys are rejected)."""
+
+    on_state_start: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run before execution"
+    )
+    on_state_end: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run after execution"
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_keys(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        if "on_start" in values:
+            raise ValueError(
+                "Hook key 'on_start' has been renamed to 'on_state_start'. "
+                "Update the YAML file and retry."
+            )
+        if "on_complete" in values:
+            raise ValueError(
+                "Hook key 'on_complete' has been renamed to 'on_state_end'. "
+                "Update the YAML file and retry."
+            )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_workflow_scope_keys(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        if "on_workflow_start" in values:
+            raise ValueError(
+                "Hook key 'on_workflow_start' is only valid at flow/project/global scope, "
+                "not in state blocks."
+            )
+        if "on_workflow_end" in values:
+            raise ValueError(
+                "Hook key 'on_workflow_end' is only valid at flow/project/global scope, "
+                "not in state blocks."
             )
         return values
 
@@ -281,7 +332,7 @@ class TaskState(BaseModel):
     provider_options: dict[str, Any] | None = Field(
         default=None, description="Per-task provider option overrides"
     )
-    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -345,7 +396,7 @@ class ChoiceState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
 
 
 class ParallelState(BaseModel):
@@ -362,7 +413,7 @@ class ParallelState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -420,7 +471,7 @@ class WaitState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -552,7 +603,7 @@ class MapState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: HookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -96,12 +96,16 @@ class HookConfig(BaseModel):
     def reject_legacy_keys(cls, values: Any) -> Any:
         if not isinstance(values, dict):
             return values
-        if "on_start" in values:
+        if (
+            "on_start" in values
+        ):  # legacy key name — detecting invalid input to reject it
             raise ValueError(
                 "Hook key 'on_start' has been renamed to 'on_state_start'. "
                 "Update the YAML file and retry."
             )
-        if "on_complete" in values:
+        if (
+            "on_complete" in values
+        ):  # legacy key name — detecting invalid input to reject it
             raise ValueError(
                 "Hook key 'on_complete' has been renamed to 'on_state_end'. "
                 "Update the YAML file and retry."
@@ -124,12 +128,16 @@ class StateHookConfig(BaseModel):
     def reject_legacy_keys(cls, values: Any) -> Any:
         if not isinstance(values, dict):
             return values
-        if "on_start" in values:
+        if (
+            "on_start" in values
+        ):  # legacy key name — detecting invalid input to reject it
             raise ValueError(
                 "Hook key 'on_start' has been renamed to 'on_state_start'. "
                 "Update the YAML file and retry."
             )
-        if "on_complete" in values:
+        if (
+            "on_complete" in values
+        ):  # legacy key name — detecting invalid input to reject it
             raise ValueError(
                 "Hook key 'on_complete' has been renamed to 'on_state_end'. "
                 "Update the YAML file and retry."

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -332,7 +332,9 @@ class TaskState(BaseModel):
     provider_options: dict[str, Any] | None = Field(
         default=None, description="Per-task provider option overrides"
     )
-    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(
+        default=None, description="Hook configuration"
+    )
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -396,7 +398,9 @@ class ChoiceState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(
+        default=None, description="Hook configuration"
+    )
 
 
 class ParallelState(BaseModel):
@@ -413,7 +417,9 @@ class ParallelState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(
+        default=None, description="Hook configuration"
+    )
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -471,7 +477,9 @@ class WaitState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(
+        default=None, description="Hook configuration"
+    )
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )
@@ -603,7 +611,9 @@ class MapState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: StateHookConfig | None = Field(default=None, description="Hook configuration")
+    hooks: StateHookConfig | None = Field(
+        default=None, description="Hook configuration"
+    )
     next: str | None = Field(
         default=None, description="Next state (exclusive with end)"
     )

--- a/tests/integration/test_hook_streaming_interaction.py
+++ b/tests/integration/test_hook_streaming_interaction.py
@@ -178,9 +178,9 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo hook_start"
-      on_complete:
+      on_state_end:
         - command: "echo hook_complete"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -253,7 +253,7 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo hook_start"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -311,9 +311,9 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo hook_start"
-      on_complete:
+      on_state_end:
         - command: "echo hook_done"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -522,9 +522,9 @@ name: Multi State Hook Stream
 description: Multi-state hook and streaming
 start_at: step1
 hooks:
-  on_start:
+  on_state_start:
     - command: "echo flow_start"
-  on_complete:
+  on_state_end:
     - command: "echo flow_complete"
 states:
   step1:
@@ -621,7 +621,7 @@ name: Per State Logs With Hooks
 description: Log files per state with flow hooks
 start_at: stateA
 hooks:
-  on_start:
+  on_state_start:
     - command: "echo flow_hook"
 states:
   stateA:

--- a/tests/integration/test_hook_streaming_interaction.py
+++ b/tests/integration/test_hook_streaming_interaction.py
@@ -3,11 +3,11 @@
 Verifies that hooks fire correctly around states that produce streaming output.
 
 Key interactions to test:
-- on_start hook fires before the task node (before streaming begins)
-- on_complete hook fires after the task node (after streaming ends)
+- on_state_start hook fires before the task node (before streaming begins)
+- on_state_end hook fires after the task node (after streaming ends)
 - StreamLogger log files are created correctly alongside hook execution
 - Hook data files (input.json/output.json) are created correctly
-- Order of operations: on_start → streaming → on_complete
+- Order of operations: on_state_start → streaming → on_state_end
 - Both streaming output AND hook files coexist correctly
 """
 
@@ -50,10 +50,10 @@ def _make_hook(command: str, on_failure: str = "warn") -> HookEntry:
 class TestHookFiringOrderWithStreaming:
     """Verify hooks fire in correct order relative to streaming output."""
 
-    def test_on_start_fires_before_node_output(self, tmp_path: Path) -> None:
-        """on_start hook fires before the task node produces any streaming output.
+    def test_on_state_start_fires_before_node_output(self, tmp_path: Path) -> None:
+        """on_state_start hook fires before the task node produces any streaming output.
 
-        Execution order must be: on_start hook → streaming → on_complete hook.
+        Execution order must be: on_state_start hook → streaming → on_state_end hook.
         """
         execution_order: list[str] = []
 
@@ -65,15 +65,15 @@ class TestHookFiringOrderWithStreaming:
             execution_order.append("node_completed")
             return {**state_dict, "result": "streamed output"}
 
-        on_start = [_make_hook("echo on_start")]
-        on_complete = [_make_hook("echo on_complete")]
+        on_state_start = [_make_hook("echo on_state_start")]
+        on_state_end = [_make_hook("echo on_state_end")]
         recorder = _make_recorder(thread_id="hook-stream-tid")
 
         wrapped = _wrap_with_hooks(
             streaming_node,
             "StreamingState",
-            on_start,
-            on_complete,
+            on_state_start,
+            on_state_end,
             recorder=recorder,
             fdsx_base_dir=tmp_path,
         )
@@ -86,14 +86,14 @@ class TestHookFiringOrderWithStreaming:
                 )
                 wrapped({"input": "value"})
 
-        # on_start fires before node executes
+        # on_state_start fires before node executes
         assert execution_order.index("hook_starting") < execution_order.index(
             "node_started"
-        ), "on_start hook must fire before node execution starts"
-        # node executes before on_complete fires
+        ), "on_state_start hook must fire before node execution starts"
+        # node executes before on_state_end fires
         assert execution_order.index("node_completed") < execution_order.index(
             "hook_completed"
-        ), "on_complete hook must fire after node execution completes"
+        ), "on_state_end hook must fire after node execution completes"
 
     def test_streaming_log_file_and_hook_data_files_coexist(
         self, tmp_path: Path
@@ -163,8 +163,8 @@ class TestHookFiringOrderWithStreaming:
         Uses compile_flow with a real system provider task so that:
         - StreamLogger is instantiated inside the task node
         - Hooks are wired by _wrap_with_hooks
-        - on_start fires before the system command runs
-        - on_complete fires after the system command completes
+        - on_state_start fires before the system command runs
+        - on_state_end fires after the system command completes
         """
         flow_yaml = """
 name: Hook Streaming Integration
@@ -229,8 +229,8 @@ states:
         starting_calls = [c for c in hook_calls if c["status"] == "starting"]
         completed_calls = [c for c in hook_calls if c["status"] == "completed"]
 
-        assert len(starting_calls) >= 1, "on_start hook should have fired"
-        assert len(completed_calls) >= 1, "on_complete hook should have fired"
+        assert len(starting_calls) >= 1, "on_state_start hook should have fired"
+        assert len(completed_calls) >= 1, "on_state_end hook should have fired"
         assert starting_calls[0]["state_name"] == "produce_output"
         assert completed_calls[0]["state_name"] == "produce_output"
 
@@ -439,8 +439,8 @@ class TestHookInputOutputDataWithStreaming:
 class TestHookAbortWithStreaming:
     """Verify abort policy behaves correctly when streaming is also configured."""
 
-    def test_abort_on_start_prevents_streaming(self, tmp_path: Path) -> None:
-        """When on_start hook aborts, the task node (including streaming) does not execute."""
+    def test_abort_on_state_start_prevents_streaming(self, tmp_path: Path) -> None:
+        """When on_state_start hook aborts, the task node (including streaming) does not execute."""
         from fdsx.core.hooks import HookAbortError
 
         node_executed = []
@@ -471,13 +471,13 @@ class TestHookAbortWithStreaming:
 
         # Node (and its streaming) should not have executed
         assert len(node_executed) == 0, (
-            "Node (and streaming) should not execute when on_start aborts"
+            "Node (and streaming) should not execute when on_state_start aborts"
         )
 
-    def test_on_complete_fires_with_failed_status_when_task_node_raises(
+    def test_on_state_end_fires_with_failed_status_when_task_node_raises(
         self, tmp_path: Path
     ) -> None:
-        """on_complete fires with status='failed' when the task node raises.
+        """on_state_end fires with status='failed' when the task node raises.
 
         This covers the case where a streaming task fails mid-execution.
         """
@@ -485,7 +485,7 @@ class TestHookAbortWithStreaming:
         def failing_node(state_dict: dict) -> dict:
             raise RuntimeError("provider failed")
 
-        hook = _make_hook("echo on_complete")
+        hook = _make_hook("echo on_state_end")
         recorder = _make_recorder()
 
         wrapped = _wrap_with_hooks(
@@ -508,7 +508,7 @@ class TestHookAbortWithStreaming:
         assert mock_exec.call_count == 1
         exec_kwargs = mock_exec.call_args[1]
         assert exec_kwargs["status"] == "failed", (
-            "on_complete should fire with 'failed' status when task node raises"
+            "on_state_end should fire with 'failed' status when task node raises"
         )
 
 
@@ -609,10 +609,10 @@ states:
             if c["state_name"] == "step2" and c["status"] == "completed"
         ]
 
-        assert len(step1_starting) == 1, "step1 on_start should fire once"
-        assert len(step1_completed) == 1, "step1 on_complete should fire once"
-        assert len(step2_starting) == 1, "step2 on_start should fire once"
-        assert len(step2_completed) == 1, "step2 on_complete should fire once"
+        assert len(step1_starting) == 1, "step1 on_state_start should fire once"
+        assert len(step1_completed) == 1, "step1 on_state_end should fire once"
+        assert len(step2_starting) == 1, "step2 on_state_start should fire once"
+        assert len(step2_completed) == 1, "step2 on_state_end should fire once"
 
     def test_log_files_created_per_state_with_hooks(self, tmp_path: Path) -> None:
         """Each state creates its own log file even when hooks are configured at flow level."""

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -548,9 +548,9 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo on_start"
-      on_complete:
+      on_state_end:
         - command: "echo on_complete"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -615,9 +615,9 @@ name: Flow Hook Test
 description: Flow-level hooks
 start_at: step1
 hooks:
-  on_start:
+  on_state_start:
     - command: "echo flow_start"
-  on_complete:
+  on_state_end:
     - command: "echo flow_complete"
 states:
   step1:
@@ -693,7 +693,7 @@ states:
 
         # Config with global hook
         fdsx_config = FdsxConfig(
-            hooks=HookConfig(on_start=[HookEntry(command="echo global_start")])
+            hooks=HookConfig(on_state_start=[HookEntry(command="echo global_start")])
         )
 
         recorder = _make_recorder(
@@ -744,7 +744,7 @@ name: Merge Order Test
 description: Hook merge order
 start_at: step1
 hooks:
-  on_start:
+  on_state_start:
     - command: "flow-hook"
 states:
   step1:
@@ -754,7 +754,7 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "state-hook"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -764,7 +764,7 @@ states:
         assert flow is not None
 
         fdsx_config = FdsxConfig(
-            hooks=HookConfig(on_start=[HookEntry(command="global-hook")])
+            hooks=HookConfig(on_state_start=[HookEntry(command="global-hook")])
         )
 
         recorder = _make_recorder(thread_id="merge-tid", flow_name="Merge Order Test")
@@ -852,9 +852,9 @@ states:
     type: pass
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo pass_start"
-      on_complete:
+      on_state_end:
         - command: "echo pass_done"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -917,9 +917,9 @@ states:
     result_path: $.results
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo par_start"
-      on_complete:
+      on_state_end:
         - command: "echo par_done"
     branches:
       - provider: system
@@ -991,7 +991,7 @@ states:
     result_path: $.r
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo h"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -1044,7 +1044,7 @@ states:
     result_path: $.r
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo h"
 """
         flow_path = tmp_path / "flow.yaml"
@@ -1089,7 +1089,7 @@ class TestFdsxHooksEnvVar:
 
     _FLOW_WITH_ON_START_HOOK = """
 name: FDSX Hooks Env Test
-description: Tests that FDSX_HOOKS is set for on_start hooks
+description: Tests that FDSX_HOOKS is set for on_state_start hooks
 start_at: step1
 states:
   step1:
@@ -1099,13 +1099,13 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_state_start:
         - command: "echo hook_start"
 """
 
     _FLOW_WITH_ON_COMPLETE_HOOK = """
 name: FDSX Hooks Env Test
-description: Tests that FDSX_HOOKS is set for on_complete hooks
+description: Tests that FDSX_HOOKS is set for on_state_end hooks
 start_at: step1
 states:
   step1:
@@ -1115,7 +1115,7 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_complete:
+      on_state_end:
         - command: "echo hook_complete"
 """
 
@@ -1176,9 +1176,9 @@ states:
             )
 
         on_start_envs = [e for e in captured_envs if e.get("FDSX_STATUS") == "starting"]
-        assert len(on_start_envs) >= 1, "on_start hook should have fired"
-        assert on_start_envs[0].get("FDSX_HOOKS") == "on_start", (
-            f"Expected FDSX_HOOKS='on_start', got {on_start_envs[0].get('FDSX_HOOKS')!r}"
+        assert len(on_start_envs) >= 1, "on_state_start hook should have fired"
+        assert on_start_envs[0].get("FDSX_HOOKS") == "on_state_start", (
+            f"Expected FDSX_HOOKS='on_state_start', got {on_start_envs[0].get('FDSX_HOOKS')!r}"
         )
 
     def test_on_complete_hook_observes_event_value_success(
@@ -1227,9 +1227,9 @@ states:
         on_complete_envs = [
             e for e in captured_envs if e.get("FDSX_STATUS") in ("completed", "failed")
         ]
-        assert len(on_complete_envs) >= 1, "on_complete hook should have fired"
-        assert on_complete_envs[0].get("FDSX_HOOKS") == "on_complete", (
-            f"Expected FDSX_HOOKS='on_complete', got {on_complete_envs[0].get('FDSX_HOOKS')!r}"
+        assert len(on_complete_envs) >= 1, "on_state_end hook should have fired"
+        assert on_complete_envs[0].get("FDSX_HOOKS") == "on_state_end", (
+            f"Expected FDSX_HOOKS='on_state_end', got {on_complete_envs[0].get('FDSX_HOOKS')!r}"
         )
 
     def test_on_complete_hook_observes_event_value_failure(
@@ -1276,10 +1276,10 @@ states:
             wrapped({"x": 1})
 
         assert len(captured_envs) >= 1, (
-            "on_complete hook should have fired after node failure"
+            "on_state_end hook should have fired after node failure"
         )
-        assert captured_envs[0].get("FDSX_HOOKS") == "on_complete", (
-            f"Expected FDSX_HOOKS='on_complete', got {captured_envs[0].get('FDSX_HOOKS')!r}"
+        assert captured_envs[0].get("FDSX_HOOKS") == "on_state_end", (
+            f"Expected FDSX_HOOKS='on_state_end', got {captured_envs[0].get('FDSX_HOOKS')!r}"
         )
 
     def test_provider_subprocess_does_not_see_fdsx_hooks(
@@ -1398,7 +1398,9 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "fdsx-hooks-state-start"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="State Hook Rename Test")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="State Hook Rename Test"
+        )
         log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
 
         captured_envs: list[dict] = []
@@ -1449,7 +1451,9 @@ states:
         assert flow is not None, f"Load errors: {errors}"
 
         thread_id = "fdsx-hooks-state-end"
-        recorder = _make_recorder(thread_id=thread_id, flow_name="State Hook Rename Test")
+        recorder = _make_recorder(
+            thread_id=thread_id, flow_name="State Hook Rename Test"
+        )
         log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
 
         captured_envs: list[dict] = []

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -1,13 +1,13 @@
 """Integration tests for Phase 8: Hooks System Wiring (T022-T023).
 
 Tests:
-- _wrap_with_hooks() wraps a node with on_start/on_complete hooks
+- _wrap_with_hooks() wraps a node with on_state_start/on_state_end hooks
 - Hooks fire correctly for TaskState, ChoiceState, PassState, ParallelState, WaitState
 - Hook levels merge in correct order: global → flow → state
 - Abort-policy hook failure halts the node execution
 - Warn-policy hook failure continues execution
 - ParallelState hooks wrap dispatch/collector, not branch executor
-- WaitState on_start fires in notify node, on_complete fires in interrupt node
+- WaitState on_state_start fires in notify node, on_state_end fires in interrupt node
 """
 
 from __future__ import annotations
@@ -82,10 +82,10 @@ class TestWrapWithHooksNoOp:
         assert result["executed"] is True
 
 
-class TestWrapWithHooksOnStart:
-    """on_start hooks fire before node execution with status='starting'."""
+class TestWrapWithHooksOnStateStart:
+    """on_state_start hooks fire before node execution with status='starting'."""
 
-    def test_on_start_hook_fires_before_node(self, tmp_path: Path) -> None:
+    def test_on_state_start_hook_fires_before_node(self, tmp_path: Path) -> None:
         execution_order: list[str] = []
 
         def tracking_node(state_dict: dict[str, Any]) -> dict[str, Any]:
@@ -93,13 +93,13 @@ class TestWrapWithHooksOnStart:
             return {**state_dict, "executed": True}
 
         hook = _make_hook("echo start")
-        on_start = [hook]
+        on_state_start = [hook]
 
         recorder = _make_recorder(thread_id="tid-001")
         wrapped = _wrap_with_hooks(
             tracking_node,
             "State1",
-            on_start,
+            on_state_start,
             [],
             recorder=recorder,
             fdsx_base_dir=tmp_path,
@@ -113,7 +113,7 @@ class TestWrapWithHooksOnStart:
             result = wrapped({"x": 1})
 
         assert result["executed"] is True
-        # execute_hooks called once (on_start)
+        # execute_hooks called once (on_state_start)
         assert mock_exec.call_count == 1
         call_kwargs = mock_exec.call_args[1]
         assert call_kwargs["status"] == "starting"
@@ -121,7 +121,7 @@ class TestWrapWithHooksOnStart:
         assert call_kwargs["thread_id"] == "tid-001"
         assert call_kwargs["flow_name"] == "TestFlow"
 
-    def test_input_json_written_before_on_start(self, tmp_path: Path) -> None:
+    def test_input_json_written_before_on_state_start(self, tmp_path: Path) -> None:
         hook = _make_hook("echo start")
         recorder = _make_recorder(thread_id="tid-input")
         wrapped = _wrap_with_hooks(
@@ -148,10 +148,10 @@ class TestWrapWithHooksOnStart:
         assert call_order[1] == "exec_hook"
 
 
-class TestWrapWithHooksOnComplete:
-    """on_complete hooks fire after node execution with status='completed'."""
+class TestWrapWithHooksOnStateEnd:
+    """on_state_end hooks fire after node execution with status='completed'."""
 
-    def test_on_complete_hook_fires_after_node(self, tmp_path: Path) -> None:
+    def test_on_state_end_hook_fires_after_node(self, tmp_path: Path) -> None:
         hook = _make_hook("echo complete")
         recorder = _make_recorder(thread_id="tid-002")
         wrapped = _wrap_with_hooks(
@@ -176,7 +176,7 @@ class TestWrapWithHooksOnComplete:
         assert call_kwargs["status"] == "completed"
         assert call_kwargs["state_name"] == "State2"
 
-    def test_output_json_written_before_on_complete(self, tmp_path: Path) -> None:
+    def test_output_json_written_before_on_state_end(self, tmp_path: Path) -> None:
         hook = _make_hook("echo done")
         recorder = _make_recorder(thread_id="tid-output")
         wrapped = _wrap_with_hooks(
@@ -214,15 +214,15 @@ class TestWrapWithHooksBothEvents:
             execution_order.append("node")
             return {**state_dict, "done": True}
 
-        on_start = [_make_hook("start-hook")]
-        on_complete = [_make_hook("complete-hook")]
+        on_state_start = [_make_hook("start-hook")]
+        on_state_end = [_make_hook("complete-hook")]
         recorder = _make_recorder()
 
         wrapped = _wrap_with_hooks(
             tracking_node,
             "MyState",
-            on_start,
-            on_complete,
+            on_state_start,
+            on_state_end,
             recorder=recorder,
             fdsx_base_dir=tmp_path,
         )
@@ -234,7 +234,7 @@ class TestWrapWithHooksBothEvents:
             mock_write.return_value = tmp_path / "x.json"
             wrapped({"input": "value"})
 
-        # execute_hooks called twice: once for on_start, once for on_complete
+        # execute_hooks called twice: once for on_state_start, once for on_state_end
         assert mock_exec.call_count == 2
         first_call = mock_exec.call_args_list[0]
         second_call = mock_exec.call_args_list[1]
@@ -302,7 +302,7 @@ class TestWrapWithHooksDataFiles:
 class TestWrapWithHooksAbortBehavior:
     """Abort-policy hook failure raises HookAbortError which halts the node."""
 
-    def test_abort_on_start_prevents_node_execution(self, tmp_path: Path) -> None:
+    def test_abort_on_state_start_prevents_node_execution(self, tmp_path: Path) -> None:
         from fdsx.core.hooks import HookAbortError
 
         executed = []
@@ -331,7 +331,7 @@ class TestWrapWithHooksAbortBehavior:
 
         assert len(executed) == 0, "Node should not execute after abort"
 
-    def test_abort_on_complete_raises_after_node(self, tmp_path: Path) -> None:
+    def test_abort_on_state_end_raises_after_node(self, tmp_path: Path) -> None:
         from fdsx.core.hooks import HookAbortError
 
         executed = []
@@ -362,17 +362,17 @@ class TestWrapWithHooksAbortBehavior:
 
 
 class TestWrapWithHooksNodeFailure:
-    """on_complete hooks fire with status='failed' when the node raises, then the error re-raises."""
+    """on_state_end hooks fire with status='failed' when the node raises, then the error re-raises."""
 
-    def test_on_complete_fires_with_failed_status_when_node_raises(
+    def test_on_state_end_fires_with_failed_status_when_node_raises(
         self, tmp_path: Path
     ) -> None:
-        """on_complete hooks fire with status='failed' when node raises RuntimeError."""
+        """on_state_end hooks fire with status='failed' when node raises RuntimeError."""
 
         def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError("node exploded")
 
-        hook = _make_hook("echo on_complete")
+        hook = _make_hook("echo on_state_end")
         recorder = _make_recorder()
         wrapped = _wrap_with_hooks(
             failing_node,
@@ -395,16 +395,16 @@ class TestWrapWithHooksNodeFailure:
         exec_kwargs = mock_exec.call_args[1]
         assert exec_kwargs["status"] == "failed"
 
-    def test_node_error_is_reraised_after_on_complete_hooks(
+    def test_node_error_is_reraised_after_on_state_end_hooks(
         self, tmp_path: Path
     ) -> None:
-        """The original exception is re-raised after on_complete hooks run."""
+        """The original exception is re-raised after on_state_end hooks run."""
         original_error = ValueError("original error")
 
         def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
             raise original_error
 
-        hook = _make_hook("echo on_complete")
+        hook = _make_hook("echo on_state_end")
         recorder = _make_recorder()
         wrapped = _wrap_with_hooks(
             failing_node,
@@ -464,22 +464,22 @@ class TestWrapWithHooksNodeFailure:
             "output.json should contain the input state_dict as fallback on failure"
         )
 
-    def test_both_on_start_and_on_complete_fire_with_correct_statuses_on_failure(
+    def test_both_on_state_start_and_on_state_end_fire_with_correct_statuses_on_failure(
         self, tmp_path: Path
     ) -> None:
-        """on_start fires with 'starting', on_complete fires with 'failed' when node raises."""
+        """on_state_start fires with 'starting', on_state_end fires with 'failed' when node raises."""
 
         def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError("fail")
 
-        on_start = [_make_hook("echo start")]
-        on_complete = [_make_hook("echo complete")]
+        on_state_start = [_make_hook("echo start")]
+        on_state_end = [_make_hook("echo complete")]
         recorder = _make_recorder()
         wrapped = _wrap_with_hooks(
             failing_node,
             "BothHooksFailState",
-            on_start,
-            on_complete,
+            on_state_start,
+            on_state_end,
             recorder=recorder,
             fdsx_base_dir=tmp_path,
         )
@@ -535,7 +535,7 @@ class TestCompileFlowHooksWiring:
     """Verify compile_flow applies _wrap_with_hooks for all node types."""
 
     def test_task_state_hooks_fire_via_compile_flow(self, tmp_path: Path) -> None:
-        """on_start and on_complete hooks fire for TaskState via compile_flow."""
+        """on_state_start and on_state_end hooks fire for TaskState via compile_flow."""
         flow_yaml = """
 name: Task Hook Flow
 description: Task with hooks
@@ -549,9 +549,9 @@ states:
     end: true
     hooks:
       on_state_start:
-        - command: "echo on_start"
+        - command: "echo on_state_start"
       on_state_end:
-        - command: "echo on_complete"
+        - command: "echo on_state_end"
 """
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(flow_yaml)
@@ -603,8 +603,8 @@ states:
 
         starting_calls = [c for c in hook_calls if c["status"] == "starting"]
         completed_calls = [c for c in hook_calls if c["status"] == "completed"]
-        assert len(starting_calls) >= 1, "on_start hooks should have fired"
-        assert len(completed_calls) >= 1, "on_complete hooks should have fired"
+        assert len(starting_calls) >= 1, "on_state_start hooks should have fired"
+        assert len(completed_calls) >= 1, "on_state_end hooks should have fired"
         assert starting_calls[0]["state_name"] == "step1"
         assert completed_calls[0]["state_name"] == "step1"
 
@@ -665,10 +665,10 @@ states:
             )
 
         assert any(c["status"] == "starting" for c in hook_calls), (
-            "on_start should fire"
+            "on_state_start should fire"
         )
         assert any(c["status"] == "completed" for c in hook_calls), (
-            "on_complete should fire"
+            "on_state_end should fire"
         )
 
     def test_config_level_hooks_merge_with_flow_and_state(self, tmp_path: Path) -> None:
@@ -731,7 +731,7 @@ states:
                 )
             )
 
-        # Config-level hook should appear in the on_start call
+        # Config-level hook should appear in the on_state_start call
         all_commands = [cmd for call_cmds in hook_calls for cmd in call_cmds]
         assert "echo global_start" in all_commands, (
             f"Config-level hook not found in hook calls: {hook_calls}"
@@ -906,7 +906,7 @@ states:
     def test_parallel_state_hooks_wrap_dispatch_and_collector(
         self, tmp_path: Path
     ) -> None:
-        """ParallelState: on_start fires in dispatch, on_complete fires in collector."""
+        """ParallelState: on_state_start fires in dispatch, on_state_end fires in collector."""
         flow_yaml = """
 name: Parallel Hook Flow
 description: ParallelState with hooks
@@ -971,7 +971,7 @@ states:
         starting_calls = [c for c in hook_calls if c["status"] == "starting"]
         completed_calls = [c for c in hook_calls if c["status"] == "completed"]
 
-        # on_start fires once (in dispatch node), on_complete fires once (in collector)
+        # on_state_start fires once (in dispatch node), on_state_end fires once (in collector)
         assert len(starting_calls) == 1
         assert len(completed_calls) == 1
         assert starting_calls[0]["state_name"] == "par"
@@ -1132,10 +1132,10 @@ states:
     end: true
 """
 
-    def test_on_start_hook_observes_event_value(
+    def test_on_state_start_hook_observes_event_value(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """on_start hook subprocess receives FDSX_HOOKS=on_start in its environment."""
+        """on_state_start hook subprocess receives FDSX_HOOKS=on_state_start in its environment."""
         monkeypatch.chdir(tmp_path)
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(self._FLOW_WITH_ON_START_HOOK)
@@ -1181,10 +1181,10 @@ states:
             f"Expected FDSX_HOOKS='on_state_start', got {on_start_envs[0].get('FDSX_HOOKS')!r}"
         )
 
-    def test_on_complete_hook_observes_event_value_success(
+    def test_on_state_end_hook_observes_event_value_success(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """on_complete hook subprocess receives FDSX_HOOKS=on_complete when node succeeds."""
+        """on_state_end hook subprocess receives FDSX_HOOKS=on_state_end when node succeeds."""
         monkeypatch.chdir(tmp_path)
         flow_path = tmp_path / "flow.yaml"
         flow_path.write_text(self._FLOW_WITH_ON_COMPLETE_HOOK)
@@ -1232,16 +1232,16 @@ states:
             f"Expected FDSX_HOOKS='on_state_end', got {on_complete_envs[0].get('FDSX_HOOKS')!r}"
         )
 
-    def test_on_complete_hook_observes_event_value_failure(
+    def test_on_state_end_hook_observes_event_value_failure(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """on_complete hook subprocess receives FDSX_HOOKS=on_complete even when node fails."""
+        """on_state_end hook subprocess receives FDSX_HOOKS=on_state_end even when node fails."""
         monkeypatch.chdir(tmp_path)
 
         def failing_node(state_dict: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError("node exploded")
 
-        hook = _make_hook("echo on_complete")
+        hook = _make_hook("echo on_state_end")
         recorder = _make_recorder()
         wrapped = _wrap_with_hooks(
             failing_node,

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -1366,7 +1366,7 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_start:
+      on_start:  # intentionally uses legacy key — testing rejection behavior
         - command: "echo x"
 """
 
@@ -1382,7 +1382,7 @@ states:
     result_path: $.result
     end: true
     hooks:
-      on_complete:
+      on_complete:  # intentionally uses legacy key — testing rejection behavior
         - command: "echo x"
 """
 

--- a/tests/integration/test_hooks_integration.py
+++ b/tests/integration/test_hooks_integration.py
@@ -1312,3 +1312,202 @@ states:
         assert out == "", (
             f"Stale FDSX_HOOKS should be scrubbed from provider subprocess env, got: {out!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# T002: TestStateHookRename — on_state_start/on_state_end rename (US1)
+# ---------------------------------------------------------------------------
+
+
+class TestStateHookRename:
+    """Verify on_state_start/on_state_end rename acceptance criteria (US1)."""
+
+    _FLOW_WITH_ON_STATE_START_HOOK = """
+name: State Hook Rename Test
+description: Tests on_state_start hook fires with renamed key
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+    hooks:
+      on_state_start:
+        - command: "echo hook_state_start"
+"""
+
+    _FLOW_WITH_ON_STATE_END_HOOK = """
+name: State Hook Rename Test
+description: Tests on_state_end hook fires with renamed key
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+    hooks:
+      on_state_end:
+        - command: "echo hook_state_end"
+"""
+
+    _FLOW_WITH_LEGACY_ON_START = """
+name: Legacy Key Test
+description: YAML with legacy on_start key
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+    hooks:
+      on_start:
+        - command: "echo x"
+"""
+
+    _FLOW_WITH_LEGACY_ON_COMPLETE = """
+name: Legacy Key Test
+description: YAML with legacy on_complete key
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: "echo done"
+    result_path: $.result
+    end: true
+    hooks:
+      on_complete:
+        - command: "echo x"
+"""
+
+    def test_on_state_start_fires_with_correct_fdsx_hooks_value(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """on_state_start hook subprocess receives FDSX_HOOKS='on_state_start' in its environment."""
+        monkeypatch.chdir(tmp_path)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_WITH_ON_STATE_START_HOOK)
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "fdsx-hooks-state-start"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="State Hook Rename Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
+
+        captured_envs: list[dict] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            env = kwargs.get("env")
+            if env is not None:
+                captured_envs.append(dict(env))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=fake_subprocess_run),
+            patch(
+                "fdsx.core.compiler.compile.write_hook_data",
+                side_effect=fake_write_hook_data,
+            ),
+        ):
+            compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+            config_dict = {"configurable": {"thread_id": thread_id}}
+            list(
+                compiled.graph.stream(
+                    {"_meta": {}}, config=config_dict, stream_mode="values"
+                )
+            )
+
+        on_state_start_envs = [
+            e for e in captured_envs if e.get("FDSX_STATUS") == "starting"
+        ]
+        assert len(on_state_start_envs) >= 1, "on_state_start hook should have fired"
+        assert on_state_start_envs[0].get("FDSX_HOOKS") == "on_state_start", (
+            f"Expected FDSX_HOOKS='on_state_start', got {on_state_start_envs[0].get('FDSX_HOOKS')!r}"
+        )
+
+    def test_on_state_end_fires_with_correct_fdsx_hooks_value(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """on_state_end hook subprocess receives FDSX_HOOKS='on_state_end' in its environment."""
+        monkeypatch.chdir(tmp_path)
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_WITH_ON_STATE_END_HOOK)
+
+        flow, errors = load_flow(flow_path)
+        assert flow is not None, f"Load errors: {errors}"
+
+        thread_id = "fdsx-hooks-state-end"
+        recorder = _make_recorder(thread_id=thread_id, flow_name="State Hook Rename Test")
+        log_dir = tmp_path / ".fdsx" / "runs" / thread_id / "logs"
+
+        captured_envs: list[dict] = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            env = kwargs.get("env")
+            if env is not None:
+                captured_envs.append(dict(env))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        def fake_write_hook_data(data, *, state_name, filename, thread_id, base_dir):
+            return tmp_path / filename
+
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=fake_subprocess_run),
+            patch(
+                "fdsx.core.compiler.compile.write_hook_data",
+                side_effect=fake_write_hook_data,
+            ),
+        ):
+            compiled = compile_flow(flow, recorder=recorder, log_dir=log_dir)
+            config_dict = {"configurable": {"thread_id": thread_id}}
+            list(
+                compiled.graph.stream(
+                    {"_meta": {}}, config=config_dict, stream_mode="values"
+                )
+            )
+
+        on_state_end_envs = [
+            e for e in captured_envs if e.get("FDSX_STATUS") in ("completed", "failed")
+        ]
+        assert len(on_state_end_envs) >= 1, "on_state_end hook should have fired"
+        assert on_state_end_envs[0].get("FDSX_HOOKS") == "on_state_end", (
+            f"Expected FDSX_HOOKS='on_state_end', got {on_state_end_envs[0].get('FDSX_HOOKS')!r}"
+        )
+
+    def test_legacy_on_start_rejected_by_load_flow(self, tmp_path: Path) -> None:
+        """load_flow rejects YAML with legacy 'on_start' key and hints at 'on_state_start'."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_WITH_LEGACY_ON_START)
+
+        flow, errors = load_flow(flow_path)
+
+        assert flow is None, "Expected load_flow to fail with legacy on_start key"
+        assert any("on_state_start" in e for e in errors), (
+            f"Expected error hinting at 'on_state_start', got: {errors}"
+        )
+
+    def test_legacy_on_complete_rejected_by_load_flow(self, tmp_path: Path) -> None:
+        """load_flow rejects YAML with legacy 'on_complete' key and hints at 'on_state_end'."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_WITH_LEGACY_ON_COMPLETE)
+
+        flow, errors = load_flow(flow_path)
+
+        assert flow is None, "Expected load_flow to fail with legacy on_complete key"
+        assert any("on_state_end" in e for e in errors), (
+            f"Expected error hinting at 'on_state_end', got: {errors}"
+        )

--- a/tests/integration/test_tasks_dir.py
+++ b/tests/integration/test_tasks_dir.py
@@ -1282,3 +1282,106 @@ class TestRunTasksDirSourceInjection:
             assert len(captured_inputs) == 1
             assert captured_inputs[0]["task"] == "task B"
             assert captured_inputs[0]["source"] == ""
+
+
+# ---------------------------------------------------------------------------
+# T017: TestWorkflowHooksPerTask — on_workflow_start/end fires once per task
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowHooksPerTask:
+    """Verify that workflow lifecycle hooks fire exactly once per task in run_tasks_dir."""
+
+    _FLOW_YAML = """
+name: HookTasksFlow
+description: Flow with workflow-level hooks for tasks-dir test
+start_at: step1
+hooks:
+  on_workflow_start:
+    - command: "echo wf_start"
+  on_workflow_end:
+    - command: "echo wf_end"
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: "$.result"
+    end: true
+"""
+
+    def test_workflow_hooks_fire_once_per_task(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """on_workflow_start and on_workflow_end each fire exactly once per task (3 tasks total)."""
+        monkeypatch.chdir(tmp_path)
+        from fdsx.providers.base import ProviderResult
+
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir()
+        for i in range(1, 4):
+            (tasks_dir / f"00{i}-task.yaml").write_text(f"description: task {i}\n")
+
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(self._FLOW_YAML)
+
+        fake_result = ProviderResult(exit_code=0, stdout="done", stderr="")
+
+        with (
+            patch(
+                "fdsx.core.engine.run.execute_workflow_hooks", create=True
+            ) as mock_run_wh,
+            patch(
+                "fdsx.core.engine.resume.execute_workflow_hooks", create=True
+            ) as mock_resume_wh,
+            patch("fdsx.providers.system._run_subprocess", return_value=fake_result),
+            patch("fdsx.core.engine.tasks_dir.display_tasks_dir_summary"),
+        ):
+            engine.run_tasks_dir(
+                flow_path,
+                tasks_dir,
+                base_dir=tmp_path / ".fdsx",
+                auto_workflow=True,
+            )
+
+        # Collect all calls from both run and resume patches
+        all_start_calls = [
+            c
+            for c in mock_run_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_start"
+        ] + [
+            c
+            for c in mock_resume_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_start"
+        ]
+        all_end_calls = [
+            c
+            for c in mock_run_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ] + [
+            c
+            for c in mock_resume_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+
+        assert len(all_start_calls) == 3, (
+            f"on_workflow_start should fire once per task (3 tasks), "
+            f"got {len(all_start_calls)} calls"
+        )
+        assert len(all_end_calls) == 3, (
+            f"on_workflow_end should fire once per task (3 tasks), "
+            f"got {len(all_end_calls)} calls"
+        )
+
+        # Each task should run with a distinct thread_id
+        start_thread_ids = {c.kwargs.get("thread_id") for c in all_start_calls}
+        assert len(start_thread_ids) == 3, (
+            f"Expected 3 distinct thread_ids for 3 tasks, got: {start_thread_ids}"
+        )
+
+        # Each on_workflow_start's thread_id should match a corresponding on_workflow_end
+        end_thread_ids = {c.kwargs.get("thread_id") for c in all_end_calls}
+        assert start_thread_ids == end_thread_ids, (
+            f"thread_ids from on_workflow_start {start_thread_ids} must match "
+            f"on_workflow_end {end_thread_ids}"
+        )

--- a/tests/integration/test_workflow_hooks_integration.py
+++ b/tests/integration/test_workflow_hooks_integration.py
@@ -1,0 +1,522 @@
+"""Integration tests for US2: workflow lifecycle hooks (T016).
+
+Tests cover Scenarios 1-7, 10-12, 14:
+- Scenario 1:  on_workflow_start fires exactly once on fresh run_flow
+- Scenario 2:  on_workflow_start does NOT fire on resume_flow
+- Scenario 3:  on_workflow_end fires with status='completed' on normal completion
+- Scenario 4:  on_workflow_end fires with status='failed' on provider failure
+- Scenario 5:  on_workflow_end fires with status='aborted' when state hook aborts
+- Scenario 6:  on_workflow_end does NOT fire when SIGINT interrupts execution
+- Scenario 7:  on_workflow_end does NOT fire when SIGTERM interrupts execution
+- Scenario 10: Declaring on_workflow_start/end in a state block raises a load error
+- Scenario 11: Global → flow merge order for on_workflow_start hooks
+- Scenario 12: Workflow hook failure warns and continues (never raises)
+- Scenario 14: Inactivity timeout triggers on_workflow_end with failure status
+
+TDD note: Tests 1-5, 10-12, 14 will FAIL (or ERROR) until T018-T024 land.
+Tests 2, 6, 7 (negative assertions) pass trivially before implementation and
+serve as regression guards after implementation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.core.engine import resume_flow, run_flow
+from fdsx.core.loader import load_flow
+from fdsx.models.flow import HookEntry
+
+# ---------------------------------------------------------------------------
+# Shared YAML fixtures (inline — no dependency on tests/fixtures/)
+# ---------------------------------------------------------------------------
+
+_SIMPLE_FLOW_YAML = """
+name: HookTestFlow
+description: Minimal system-provider flow for workflow hook testing
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: "$.result"
+    end: true
+"""
+
+_HOOK_FLOW_YAML = """
+name: HookTestFlow
+description: Flow with workflow-level hooks
+start_at: step1
+hooks:
+  on_workflow_start:
+    - command: "echo wf_start"
+  on_workflow_end:
+    - command: "echo wf_end"
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    retry: 0
+    result_path: "$.result"
+    end: true
+"""
+
+_FAIL_FLOW_YAML = """
+name: FailFlow
+description: Flow that always fails
+start_at: step1
+hooks:
+  on_workflow_end:
+    - command: "echo wf_end"
+states:
+  step1:
+    type: task
+    provider: system
+    command: "exit 1"
+    retry: 0
+    result_path: "$.result"
+    end: true
+"""
+
+_ABORT_HOOK_FLOW_YAML = """
+name: AbortHookFlow
+description: Flow aborted by a state hook with on_failure=abort
+start_at: step1
+hooks:
+  on_workflow_end:
+    - command: "echo wf_end"
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: "$.result"
+    end: true
+    hooks:
+      on_state_start:
+        - command: "exit 1"
+          on_failure: abort
+"""
+
+_WAIT_FLOW_YAML = """
+name: WaitTestFlow
+description: Flow with wait state for resume testing
+start_at: step1
+hooks:
+  on_workflow_start:
+    - command: "echo wf_start"
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: "$.step1_result"
+    next: wait1
+  wait1:
+    type: wait
+    message: "Continue?"
+    choices:
+      - "yes"
+    result_path: "$.choice"
+    end: true
+"""
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 & 2: TestWorkflowStart
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowStart:
+    """Scenarios 1 and 2: on_workflow_start fires on fresh run, not on resume."""
+
+    def test_fires_once_on_fresh_run(self, tmp_path: Path) -> None:
+        """Scenario 1: on_workflow_start fires exactly once at the start of run_flow."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_HOOK_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+
+        with patch(
+            "fdsx.core.engine.run.execute_workflow_hooks", create=True
+        ) as mock_wh:
+            run_flow(flow_path, base_dir=base_dir)
+
+        start_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_start"
+        ]
+        assert mock_wh.call_count >= 1, (
+            "execute_workflow_hooks should be called at least once"
+        )
+        assert len(start_calls) == 1, (
+            f"on_workflow_start should fire exactly once, got {len(start_calls)} calls"
+        )
+        assert start_calls[0].kwargs.get("status") == "starting"
+
+    def test_does_not_fire_on_resume(self, tmp_path: Path) -> None:
+        """Scenario 2: on_workflow_start must NOT fire when resuming from checkpoint."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_WAIT_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+        thread_id = "no-start-on-resume-thread"
+
+        # Step 1: Run until wait state, simulating a crash at the prompt to create checkpoint
+        with (
+            pytest.raises(RuntimeError),
+            patch(
+                "fdsx.core.engine.interrupts.display_wait_prompt",
+                side_effect=RuntimeError("simulated crash at wait"),
+            ),
+        ):
+            run_flow(flow_path, thread_id=thread_id, base_dir=base_dir)
+
+        # Step 2: Resume — on_workflow_start must NOT fire
+        with (
+            patch(
+                "fdsx.core.engine.resume.execute_workflow_hooks", create=True
+            ) as mock_wh,
+            patch("builtins.input", return_value="1"),
+        ):
+            resume_flow(thread_id, base_dir, flow_path)
+
+        start_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_start"
+        ]
+        assert len(start_calls) == 0, (
+            "on_workflow_start must NOT fire during resume_flow"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenarios 3-7: TestWorkflowEnd
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowEnd:
+    """Scenarios 3-7: on_workflow_end fires or doesn't fire in various terminal states."""
+
+    def test_fires_on_complete(self, tmp_path: Path) -> None:
+        """Scenario 3: on_workflow_end fires with status='completed' on normal completion."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_HOOK_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+
+        with patch(
+            "fdsx.core.engine.run.execute_workflow_hooks", create=True
+        ) as mock_wh:
+            run_flow(flow_path, base_dir=base_dir)
+
+        end_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+        assert len(end_calls) == 1, "on_workflow_end should fire on completion"
+        assert end_calls[0].kwargs.get("status") == "completed"
+
+    def test_fires_on_failed(self, tmp_path: Path) -> None:
+        """Scenario 4: on_workflow_end fires with status='failed' when provider fails."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_FAIL_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+
+        with (
+            patch(
+                "fdsx.core.engine.run.execute_workflow_hooks", create=True
+            ) as mock_wh,
+            pytest.raises(RuntimeError),
+        ):
+            run_flow(flow_path, base_dir=base_dir)
+
+        end_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+        assert len(end_calls) == 1, "on_workflow_end should fire on provider failure"
+        assert end_calls[0].kwargs.get("status") == "failed"
+
+    def test_fires_on_aborted_by_state_hook(self, tmp_path: Path) -> None:
+        """Scenario 5: on_workflow_end fires when a state hook abort policy triggers."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_ABORT_HOOK_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+
+        with (
+            patch(
+                "fdsx.core.engine.run.execute_workflow_hooks", create=True
+            ) as mock_wh,
+            pytest.raises(RuntimeError),
+        ):
+            run_flow(flow_path, base_dir=base_dir)
+
+        end_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+        assert len(end_calls) == 1, (
+            "on_workflow_end should fire when a state hook aborts"
+        )
+        assert end_calls[0].kwargs.get("status") == "aborted"
+
+    def test_does_not_fire_on_sigint(self, tmp_path: Path) -> None:
+        """Scenario 6: on_workflow_end must NOT fire when SIGINT (SystemExit) interrupts execution."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_SIMPLE_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+        thread_id = "sigint-test-thread"
+
+        # Simulate SIGINT by raising SystemExit during provider execution
+        with (
+            patch(
+                "fdsx.core.engine.run.execute_workflow_hooks", create=True
+            ) as mock_wh,
+            patch(
+                "fdsx.providers.system._run_subprocess",
+                side_effect=SystemExit(130),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            run_flow(flow_path, thread_id=thread_id, base_dir=base_dir)
+
+        end_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+        assert len(end_calls) == 0, (
+            "on_workflow_end must NOT fire when SIGINT interrupts execution"
+        )
+
+    def test_does_not_fire_on_sigterm(self, tmp_path: Path) -> None:
+        """Scenario 7: on_workflow_end must NOT fire when SIGTERM (SystemExit) interrupts execution."""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_SIMPLE_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+        thread_id = "sigterm-test-thread"
+
+        # Simulate SIGTERM by raising SystemExit during provider execution
+        with (
+            patch(
+                "fdsx.core.engine.run.execute_workflow_hooks", create=True
+            ) as mock_wh,
+            patch(
+                "fdsx.providers.system._run_subprocess",
+                side_effect=SystemExit(143),
+            ),
+            pytest.raises(SystemExit),
+        ):
+            run_flow(flow_path, thread_id=thread_id, base_dir=base_dir)
+
+        end_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+        assert len(end_calls) == 0, (
+            "on_workflow_end must NOT fire when SIGTERM interrupts execution"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 10: TestWorkflowScope
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowScope:
+    """Scenario 10: on_workflow_start/end declared in a state block must be rejected."""
+
+    def test_declaring_workflow_hook_in_state_block_errors(
+        self, tmp_path: Path
+    ) -> None:
+        """Scenario 10: YAML with on_workflow_start inside a state hooks block must fail validation."""
+        flow_yaml = """
+name: BadScopeFlow
+description: Invalid flow using workflow hook in state block
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: "$.result"
+    end: true
+    hooks:
+      on_workflow_start:
+        - command: "echo bad"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        flow, _errors = load_flow(flow_path)
+
+        assert flow is None, (
+            "load_flow should fail when on_workflow_start is declared inside a state block"
+        )
+
+    def test_declaring_workflow_end_hook_in_state_block_errors(
+        self, tmp_path: Path
+    ) -> None:
+        """Scenario 10b: YAML with on_workflow_end inside a state hooks block must fail validation."""
+        flow_yaml = """
+name: BadScopeFlow2
+description: Invalid flow using workflow end hook in state block
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    command: echo done
+    result_path: "$.result"
+    end: true
+    hooks:
+      on_workflow_end:
+        - command: "echo bad"
+"""
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(flow_yaml)
+
+        flow, _errors = load_flow(flow_path)
+
+        assert flow is None, (
+            "load_flow should fail when on_workflow_end is declared inside a state block"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 11: TestWorkflowMerge
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowMerge:
+    """Scenario 11: Global → project → flow merge order for on_workflow_start."""
+
+    def test_global_project_flow_merge_order(self, tmp_path: Path) -> None:
+        """Scenario 11: collect_workflow_hooks merges in global → project → flow order."""
+        from fdsx.core.hooks import collect_workflow_hooks
+        from fdsx.models.flow import HookConfig
+
+        global_cfg = HookConfig(on_workflow_start=[HookEntry(command="global-wf-hook")])
+        project_cfg = HookConfig(on_workflow_start=[HookEntry(command="project-wf-hook")])
+        flow_cfg = HookConfig(on_workflow_start=[HookEntry(command="flow-wf-hook")])
+
+        result = collect_workflow_hooks(
+            "on_workflow_start",
+            global_hooks=global_cfg,
+            project_hooks=project_cfg,
+            flow_hooks=flow_cfg,
+        )
+
+        commands = [h.command for h in result]
+        assert commands == ["global-wf-hook", "project-wf-hook", "flow-wf-hook"], (
+            f"Expected global → project → flow order, got: {commands}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 12: TestWorkflowFailure
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowFailure:
+    """Scenario 12: workflow hook failure warns and never raises."""
+
+    def test_hook_failure_warns_and_continues(self, caplog) -> None:
+        """Scenario 12: When a workflow hook fails, it warns and does not raise."""
+        import logging
+
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = HookEntry(command="false", on_failure="abort")  # type: ignore[arg-type]
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            # Must NOT raise — abort policy is silently demoted to warn for workflow hooks
+            with caplog.at_level(logging.WARNING, logger="fdsx.core.hooks"):
+                execute_workflow_hooks(
+                    [hook],
+                    status="starting",
+                    thread_id="t1",
+                    flow_name="FailFlow",
+                    event="on_workflow_start",
+                )
+
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING log when workflow hook exits non-zero"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 14: TestWorkflowTimeout
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowTimeout:
+    """Scenario 14: Inactivity timeout triggers on_workflow_end with failure status."""
+
+    def test_fires_on_inactivity_timeout(self, tmp_path: Path) -> None:
+        """Scenario 14: on_workflow_end fires with status='failed' on inactivity timeout."""
+        from fdsx.providers.base import ProviderResult
+
+        flow_path = tmp_path / "flow.yaml"
+        flow_path.write_text(_HOOK_FLOW_YAML)
+        base_dir = tmp_path / ".fdsx"
+
+        inactivity_result = ProviderResult(
+            exit_code=124,
+            stdout="",
+            stderr="Process killed due to inactivity timeout after 300 seconds (no output received)",
+        )
+
+        with (
+            patch(
+                "fdsx.core.engine.run.execute_workflow_hooks", create=True
+            ) as mock_wh,
+            patch(
+                "fdsx.providers.system._run_subprocess", return_value=inactivity_result
+            ),
+            pytest.raises(RuntimeError),
+        ):
+            run_flow(flow_path, base_dir=base_dir)
+
+        end_calls = [
+            c
+            for c in mock_wh.call_args_list
+            if c.kwargs.get("event") == "on_workflow_end"
+        ]
+        assert len(end_calls) == 1, "on_workflow_end should fire on inactivity timeout"
+        assert end_calls[0].kwargs.get("status") in ("failed", "aborted")
+
+    def test_hook_hang_is_killed_after_timeout(self, caplog) -> None:
+        """Scenario 14b: A slow workflow hook is killed after timeout_seconds; does not raise."""
+        import logging
+
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = HookEntry(command="sleep 9999")
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(
+                cmd="sleep 9999", timeout=2.0
+            )
+            # Must NOT raise TimeoutExpired
+            with caplog.at_level(logging.WARNING, logger="fdsx.core.hooks"):
+                execute_workflow_hooks(
+                    [hook],
+                    status="starting",
+                    thread_id="t1",
+                    flow_name="TestFlow",
+                    event="on_workflow_start",
+                    timeout_seconds=2.0,
+                )
+
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING log when workflow hook times out"
+        )

--- a/tests/integration/test_workflow_hooks_integration.py
+++ b/tests/integration/test_workflow_hooks_integration.py
@@ -406,7 +406,9 @@ class TestWorkflowMerge:
         from fdsx.models.flow import HookConfig
 
         global_cfg = HookConfig(on_workflow_start=[HookEntry(command="global-wf-hook")])
-        project_cfg = HookConfig(on_workflow_start=[HookEntry(command="project-wf-hook")])
+        project_cfg = HookConfig(
+            on_workflow_start=[HookEntry(command="project-wf-hook")]
+        )
         flow_cfg = HookConfig(on_workflow_start=[HookEntry(command="flow-wf-hook")])
 
         result = collect_workflow_hooks(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -604,80 +604,88 @@ class TestFdsxConfigHooks:
         """T018: FdsxConfig.hooks accepts a valid HookConfig."""
         cfg = FdsxConfig(
             hooks=HookConfig(
-                on_start=[HookEntry(command="setup.sh")],
-                on_complete=[HookEntry(command="teardown.sh", on_failure="abort")],
+                on_state_start=[HookEntry(command="setup.sh")],
+                on_state_end=[HookEntry(command="teardown.sh", on_failure="abort")],
             )
         )
         assert cfg.hooks is not None
-        assert cfg.hooks.on_start[0].command == "setup.sh"
-        assert cfg.hooks.on_complete[0].on_failure == "abort"
+        assert cfg.hooks.on_state_start[0].command == "setup.sh"
+        assert cfg.hooks.on_state_end[0].on_failure == "abort"
 
     def test_hooks_parsed_from_dict(self):
         """T018: FdsxConfig parses hooks from raw dict via model_validate."""
         cfg = FdsxConfig.model_validate(
             {
                 "hooks": {
-                    "on_start": [{"command": "init.sh"}],
-                    "on_complete": [],
+                    "on_state_start": [{"command": "init.sh"}],
+                    "on_state_end": [],
                 }
             }
         )
         assert cfg.hooks is not None
-        assert cfg.hooks.on_start[0].command == "init.sh"
-        assert cfg.hooks.on_complete == []
+        assert cfg.hooks.on_state_start[0].command == "init.sh"
+        assert cfg.hooks.on_state_end == []
 
     def test_hooks_invalid_on_failure_rejected(self):
         """T018: Invalid on_failure value in hooks config must be rejected."""
         with pytest.raises(ValidationError):
             FdsxConfig.model_validate(
-                {"hooks": {"on_start": [{"command": "x", "on_failure": "skip"}]}}
+                {"hooks": {"on_state_start": [{"command": "x", "on_failure": "skip"}]}}
             )
 
     def test_hooks_empty_command_rejected(self):
         """T018: Empty command in hook entry must be rejected."""
         with pytest.raises(ValidationError):
-            FdsxConfig.model_validate({"hooks": {"on_start": [{"command": ""}]}})
+            FdsxConfig.model_validate({"hooks": {"on_state_start": [{"command": ""}]}})
 
 
 class TestDeepMergeHookListConcatenation:
-    """T018: Tests for _deep_merge list concatenation for on_start/on_complete."""
+    """T018: Tests for _deep_merge list concatenation for on_state_start/on_state_end."""
 
-    def test_on_start_lists_are_concatenated(self):
-        """T018: on_start lists from base and override are concatenated."""
-        base = {"hooks": {"on_start": [{"command": "a.sh"}], "on_complete": []}}
-        override = {"hooks": {"on_start": [{"command": "b.sh"}], "on_complete": []}}
-        result = _deep_merge(base, override)
-        assert len(result["hooks"]["on_start"]) == 2
-        assert result["hooks"]["on_start"][0]["command"] == "a.sh"
-        assert result["hooks"]["on_start"][1]["command"] == "b.sh"
-
-    def test_on_complete_lists_are_concatenated(self):
-        """T018: on_complete lists from base and override are concatenated."""
-        base = {"hooks": {"on_start": [], "on_complete": [{"command": "cleanup.sh"}]}}
+    def test_on_state_start_lists_are_concatenated(self):
+        """T018: on_state_start lists from base and override are concatenated."""
+        base = {"hooks": {"on_state_start": [{"command": "a.sh"}], "on_state_end": []}}
         override = {
-            "hooks": {"on_start": [], "on_complete": [{"command": "notify.sh"}]}
+            "hooks": {"on_state_start": [{"command": "b.sh"}], "on_state_end": []}
         }
         result = _deep_merge(base, override)
-        assert len(result["hooks"]["on_complete"]) == 2
-        assert result["hooks"]["on_complete"][0]["command"] == "cleanup.sh"
-        assert result["hooks"]["on_complete"][1]["command"] == "notify.sh"
+        assert len(result["hooks"]["on_state_start"]) == 2
+        assert result["hooks"]["on_state_start"][0]["command"] == "a.sh"
+        assert result["hooks"]["on_state_start"][1]["command"] == "b.sh"
+
+    def test_on_state_end_lists_are_concatenated(self):
+        """T018: on_state_end lists from base and override are concatenated."""
+        base = {
+            "hooks": {"on_state_start": [], "on_state_end": [{"command": "cleanup.sh"}]}
+        }
+        override = {
+            "hooks": {"on_state_start": [], "on_state_end": [{"command": "notify.sh"}]}
+        }
+        result = _deep_merge(base, override)
+        assert len(result["hooks"]["on_state_end"]) == 2
+        assert result["hooks"]["on_state_end"][0]["command"] == "cleanup.sh"
+        assert result["hooks"]["on_state_end"][1]["command"] == "notify.sh"
 
     def test_empty_base_hook_list_with_override(self):
         """T018: Empty base list + override list yields only override entries."""
-        base = {"hooks": {"on_start": [], "on_complete": []}}
-        override = {"hooks": {"on_start": [{"command": "x.sh"}], "on_complete": []}}
+        base = {"hooks": {"on_state_start": [], "on_state_end": []}}
+        override = {
+            "hooks": {"on_state_start": [{"command": "x.sh"}], "on_state_end": []}
+        }
         result = _deep_merge(base, override)
-        assert result["hooks"]["on_start"] == [{"command": "x.sh"}]
+        assert result["hooks"]["on_state_start"] == [{"command": "x.sh"}]
 
     def test_empty_override_hook_list_with_base(self):
         """T018: Base list + empty override list yields only base entries."""
-        base = {"hooks": {"on_start": [{"command": "base.sh"}], "on_complete": []}}
-        override = {"hooks": {"on_start": [], "on_complete": []}}
+        base = {
+            "hooks": {"on_state_start": [{"command": "base.sh"}], "on_state_end": []}
+        }
+        override = {"hooks": {"on_state_start": [], "on_state_end": []}}
         result = _deep_merge(base, override)
-        assert result["hooks"]["on_start"] == [{"command": "base.sh"}]
+        assert result["hooks"]["on_state_start"] == [{"command": "base.sh"}]
 
     def test_non_hook_list_is_replaced_not_concatenated(self):
-        """T018: Regular list values (not on_start/on_complete) are replaced, not concatenated."""
+        """T018: Regular list values (not on_state_start/on_state_end) are replaced, not concatenated."""
         base = {"items": [1, 2, 3]}
         override = {"items": [4, 5]}
         result = _deep_merge(base, override)
@@ -687,18 +695,21 @@ class TestDeepMergeHookListConcatenation:
         """T018: Concatenation preserves global-first, project-second ordering."""
         base = {
             "hooks": {
-                "on_start": [{"command": "global1.sh"}, {"command": "global2.sh"}],
-                "on_complete": [],
+                "on_state_start": [
+                    {"command": "global1.sh"},
+                    {"command": "global2.sh"},
+                ],
+                "on_state_end": [],
             }
         }
         override = {
             "hooks": {
-                "on_start": [{"command": "project.sh"}],
-                "on_complete": [],
+                "on_state_start": [{"command": "project.sh"}],
+                "on_state_end": [],
             }
         }
         result = _deep_merge(base, override)
-        commands = [e["command"] for e in result["hooks"]["on_start"]]
+        commands = [e["command"] for e in result["hooks"]["on_state_start"]]
         assert commands == ["global1.sh", "global2.sh", "project.sh"]
 
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -757,12 +757,16 @@ class TestLegacyKeyRejection:
 
     def test_on_start_key_rejected_with_rename_hint(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
-            HookConfig.model_validate({"on_start": [{"command": "echo x"}]})
+            HookConfig.model_validate(
+                {"on_start": [{"command": "echo x"}]}
+            )  # intentionally uses legacy key to test rejection
         assert "on_state_start" in str(exc_info.value)
 
     def test_on_complete_key_rejected_with_rename_hint(self) -> None:
         with pytest.raises(ValidationError) as exc_info:
-            HookConfig.model_validate({"on_complete": [{"command": "echo x"}]})
+            HookConfig.model_validate(
+                {"on_complete": [{"command": "echo x"}]}
+            )  # intentionally uses legacy key to test rejection
         assert "on_state_end" in str(exc_info.value)
 
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -764,3 +764,216 @@ class TestLegacyKeyRejection:
         with pytest.raises(ValidationError) as exc_info:
             HookConfig.model_validate({"on_complete": [{"command": "echo x"}]})
         assert "on_state_end" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# T014: TestExecuteWorkflowHooks — execute_workflow_hooks() (US2)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteWorkflowHooks:
+    """Tests for execute_workflow_hooks(). Imports symbol inside each test body."""
+
+    def _make_hook(self, command: str, on_failure: str = "warn") -> HookEntry:
+        return HookEntry(command=command, on_failure=on_failure)  # type: ignore[arg-type]
+
+    def test_env_contains_fdsx_hooks(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_HOOKS"] == "on_workflow_start"
+
+    def test_env_contains_fdsx_status(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_STATUS"] == "starting"
+
+    def test_env_omits_fdsx_state_name(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        env = mock_run.call_args[1]["env"]
+        assert "FDSX_STATE_NAME" not in env
+
+    def test_env_omits_fdsx_data_path(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        env = mock_run.call_args[1]["env"]
+        assert "FDSX_DATA_PATH" not in env
+
+    def test_env_contains_fdsx_flow_name(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_FLOW_NAME"] == "MyFlow"
+
+    def test_env_contains_fdsx_thread_id(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        env = mock_run.call_args[1]["env"]
+        assert env["FDSX_THREAD_ID"] == "t1"
+
+    def test_no_positional_args_in_command(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        full_cmd: str = mock_run.call_args[0][0]
+        assert full_cmd == "echo test"
+
+    def test_timeout_defaults_to_30(self) -> None:
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("echo test")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            execute_workflow_hooks(
+                [hook],
+                status="starting",
+                thread_id="t1",
+                flow_name="MyFlow",
+                event="on_workflow_start",
+            )
+        assert mock_run.call_args[1]["timeout"] == 30.0
+
+    def test_on_failure_abort_ignored_warns_only(self, caplog) -> None:
+        import logging
+
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("false", on_failure="abort")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)
+            # Must NOT raise HookAbortError (abort policy is silently demoted to warn)
+            with caplog.at_level(logging.WARNING, logger="fdsx.core.hooks"):
+                execute_workflow_hooks(
+                    [hook],
+                    status="starting",
+                    thread_id="t1",
+                    flow_name="MyFlow",
+                    event="on_workflow_start",
+                )
+
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING log when workflow hook exits non-zero"
+        )
+
+    def test_timeout_expired_caught_and_logged_as_warning(self, caplog) -> None:
+        import logging
+        import subprocess as _subprocess
+
+        from fdsx.core.hooks import execute_workflow_hooks
+
+        hook = self._make_hook("slow-command")
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = _subprocess.TimeoutExpired(
+                cmd="slow-command", timeout=30.0
+            )
+            # Must NOT raise TimeoutExpired
+            with caplog.at_level(logging.WARNING, logger="fdsx.core.hooks"):
+                execute_workflow_hooks(
+                    [hook],
+                    status="starting",
+                    thread_id="t1",
+                    flow_name="MyFlow",
+                    event="on_workflow_start",
+                )
+
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "Expected a WARNING log when workflow hook times out"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T015: TestStateHookConfigWorkflowKeyRejection — workflow keys rejected in state blocks
+# ---------------------------------------------------------------------------
+
+
+class TestStateHookConfigWorkflowKeyRejection:
+    """Assert that workflow-scope hook keys raise ValidationError when used in state blocks."""
+
+    def test_on_workflow_start_rejected(self) -> None:
+        from fdsx.models.flow import StateHookConfig
+
+        with pytest.raises(ValidationError) as exc_info:
+            StateHookConfig.model_validate(
+                {"on_workflow_start": [{"command": "echo x"}]}
+            )
+        error_msg = str(exc_info.value)
+        assert any(keyword in error_msg for keyword in ("flow", "project", "global"))
+
+    def test_on_workflow_end_rejected(self) -> None:
+        from fdsx.models.flow import StateHookConfig
+
+        with pytest.raises(ValidationError) as exc_info:
+            StateHookConfig.model_validate({"on_workflow_end": [{"command": "echo x"}]})
+        error_msg = str(exc_info.value)
+        assert any(keyword in error_msg for keyword in ("flow", "project", "global"))

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -49,7 +49,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="tid-001",
                 flow_name="MyFlow",
-                event="on_start",
+                event="on_state_start",
             )
         mock_run.assert_not_called()
 
@@ -67,7 +67,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t1",
                 flow_name="F1",
-                event="on_start",
+                event="on_state_start",
             )
 
         assert mock_run.call_count == 1
@@ -88,7 +88,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t1",
                 flow_name="F1",
-                event="on_start",
+                event="on_state_start",
             )
 
         full_cmd: str = mock_run.call_args[0][0]
@@ -110,7 +110,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="tid-42",
                 flow_name="FlowY",
-                event="on_start",
+                event="on_state_start",
             )
 
         env = mock_run.call_args[1]["env"]
@@ -135,7 +135,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_start",
+                event="on_state_start",
             )
 
     def test_abort_on_failure_raises_hook_abort_error(self, tmp_path: Path) -> None:
@@ -153,7 +153,7 @@ class TestExecuteHooks:
                     data_path=data_path,
                     thread_id="t",
                     flow_name="F",
-                    event="on_start",
+                    event="on_state_start",
                 )
         assert exc_info.value.return_code == 2
         assert exc_info.value.command == "false"
@@ -176,7 +176,7 @@ class TestExecuteHooks:
                     data_path=data_path,
                     thread_id="t",
                     flow_name="F",
-                    event="on_start",
+                    event="on_state_start",
                 )
         # Only cmd1 ran; cmd2 was skipped
         assert mock_run.call_count == 1
@@ -199,7 +199,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_start",
+                event="on_state_start",
             )
         assert mock_run.call_count == 2
 
@@ -218,7 +218,7 @@ class TestExecuteHooks:
                     data_path=data_path,
                     thread_id="t",
                     flow_name="F",
-                    event="on_start",
+                    event="on_state_start",
                 )
         assert "my-script.sh" in str(exc_info.value)
 
@@ -240,7 +240,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_start",
+                event="on_state_start",
             )
 
         assert mock_run.call_count == 3
@@ -265,7 +265,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_start",
+                event="on_state_start",
             )
 
         full_cmd: str = mock_run.call_args[0][0]
@@ -286,11 +286,11 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_start",
+                event="on_state_start",
             )
 
         env = mock_run.call_args[1]["env"]
-        assert env["FDSX_HOOKS"] == "on_start"
+        assert env["FDSX_HOOKS"] == "on_state_start"
 
     def test_execute_hooks_sets_fdsx_hooks_on_complete_success(
         self, tmp_path: Path
@@ -308,11 +308,11 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_complete",
+                event="on_state_end",
             )
 
         env = mock_run.call_args[1]["env"]
-        assert env["FDSX_HOOKS"] == "on_complete"
+        assert env["FDSX_HOOKS"] == "on_state_end"
 
     def test_execute_hooks_sets_fdsx_hooks_on_complete_failure(
         self, tmp_path: Path
@@ -330,11 +330,11 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_complete",
+                event="on_state_end",
             )
 
         env = mock_run.call_args[1]["env"]
-        assert env["FDSX_HOOKS"] == "on_complete"
+        assert env["FDSX_HOOKS"] == "on_state_end"
 
     def test_execute_hooks_overrides_inherited_fdsx_hooks(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -353,11 +353,11 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="t",
                 flow_name="F",
-                event="on_start",
+                event="on_state_start",
             )
 
         env = mock_run.call_args[1]["env"]
-        assert env["FDSX_HOOKS"] == "on_start"
+        assert env["FDSX_HOOKS"] == "on_state_start"
 
     def test_execute_hooks_preserves_existing_env_vars(self, tmp_path: Path) -> None:
         """All five existing FDSX_ env vars are still present alongside FDSX_HOOKS (FR-5 regression guard)."""
@@ -373,7 +373,7 @@ class TestExecuteHooks:
                 data_path=data_path,
                 thread_id="tid-42",
                 flow_name="FlowY",
-                event="on_start",
+                event="on_state_start",
             )
 
         env = mock_run.call_args[1]["env"]
@@ -579,16 +579,18 @@ class TestWriteHookData:
 class TestCollectHooks:
     """Tests for collect_hooks()."""
 
-    def _make_config(self, commands: list[str], event: str = "on_start") -> HookConfig:
+    def _make_config(
+        self, commands: list[str], event: str = "on_state_start"
+    ) -> HookConfig:
         entries = [HookEntry(command=cmd) for cmd in commands]
-        kwargs: dict = {"on_start": [], "on_complete": []}
+        kwargs: dict = {"on_state_start": [], "on_state_end": []}
         kwargs[event] = entries
         return HookConfig(**kwargs)
 
     def test_all_none_returns_empty_list(self) -> None:
         """All-None configs produces an empty list."""
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=None,
             project_hooks=None,
             flow_hooks=None,
@@ -600,7 +602,7 @@ class TestCollectHooks:
         """Only global hooks are returned."""
         global_cfg = self._make_config(["global-hook"])
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=global_cfg,
             project_hooks=None,
             flow_hooks=None,
@@ -613,7 +615,7 @@ class TestCollectHooks:
         """Only state hooks are returned."""
         state_cfg = self._make_config(["state-hook"])
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=None,
             project_hooks=None,
             flow_hooks=None,
@@ -630,7 +632,7 @@ class TestCollectHooks:
         state_cfg = self._make_config(["st1"])
 
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=global_cfg,
             project_hooks=project_cfg,
             flow_hooks=flow_cfg,
@@ -645,7 +647,7 @@ class TestCollectHooks:
         state_cfg = self._make_config(["s1", "s2"])
 
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=global_cfg,
             project_hooks=None,
             flow_hooks=None,
@@ -655,21 +657,21 @@ class TestCollectHooks:
         assert [h.command for h in result] == ["g1", "g2", "g3", "s1", "s2"]
 
     def test_on_complete_event(self) -> None:
-        """on_complete event selects the correct hook list."""
+        """on_state_end event selects the correct hook list."""
         config = HookConfig(
-            on_start=[HookEntry(command="start-hook")],
-            on_complete=[HookEntry(command="complete-hook")],
+            on_state_start=[HookEntry(command="start-hook")],
+            on_state_end=[HookEntry(command="complete-hook")],
         )
 
         result_start = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=config,
             project_hooks=None,
             flow_hooks=None,
             state_hooks=None,
         )
         result_complete = collect_hooks(
-            "on_complete",
+            "on_state_end",
             global_hooks=config,
             project_hooks=None,
             flow_hooks=None,
@@ -684,14 +686,14 @@ class TestCollectHooks:
     def test_on_failure_policy_preserved(self) -> None:
         """on_failure values are preserved through collection."""
         cfg = HookConfig(
-            on_start=[
+            on_state_start=[
                 HookEntry(command="cmd-abort", on_failure="abort"),
                 HookEntry(command="cmd-warn", on_failure="warn"),
             ]
         )
 
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=cfg,
             project_hooks=None,
             flow_hooks=None,
@@ -705,7 +707,7 @@ class TestCollectHooks:
         """Return type is a list of HookEntry."""
         cfg = self._make_config(["cmd"])
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=cfg,
             project_hooks=None,
             flow_hooks=None,
@@ -720,7 +722,7 @@ class TestCollectHooks:
         state_cfg = self._make_config(["s1"])
 
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=None,
             project_hooks=project_cfg,
             flow_hooks=None,
@@ -735,7 +737,7 @@ class TestCollectHooks:
         state_cfg = self._make_config(["s1"])
 
         result = collect_hooks(
-            "on_start",
+            "on_state_start",
             global_hooks=empty_cfg,
             project_hooks=None,
             flow_hooks=None,

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from fdsx.core.hooks import (
     ENV_DATA_PATH,
@@ -742,3 +743,22 @@ class TestCollectHooks:
         )
 
         assert [h.command for h in result] == ["s1"]
+
+
+# ---------------------------------------------------------------------------
+# T001: TestLegacyKeyRejection — on_start/on_complete keys must be rejected
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyKeyRejection:
+    """Assert that legacy hook keys raise ValidationError with a rename hint."""
+
+    def test_on_start_key_rejected_with_rename_hint(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            HookConfig.model_validate({"on_start": [{"command": "echo x"}]})
+        assert "on_state_start" in str(exc_info.value)
+
+    def test_on_complete_key_rejected_with_rename_hint(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            HookConfig.model_validate({"on_complete": [{"command": "echo x"}]})
+        assert "on_state_end" in str(exc_info.value)

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -272,8 +272,8 @@ class TestExecuteHooks:
         # Verify the dangerous string is properly quoted (not expanded)
         assert "rm -rf" not in full_cmd.replace("'my state; rm -rf /'", "")
 
-    def test_execute_hooks_sets_fdsx_hooks_on_start(self, tmp_path: Path) -> None:
-        """FDSX_HOOKS env var is set to 'on_start' when event='on_start'."""
+    def test_execute_hooks_sets_fdsx_hooks_on_state_start(self, tmp_path: Path) -> None:
+        """FDSX_HOOKS env var is set to 'on_state_start' when event='on_state_start'."""
         hook = self._make_hook("true")
         data_path = tmp_path / "data.json"
 
@@ -292,10 +292,10 @@ class TestExecuteHooks:
         env = mock_run.call_args[1]["env"]
         assert env["FDSX_HOOKS"] == "on_state_start"
 
-    def test_execute_hooks_sets_fdsx_hooks_on_complete_success(
+    def test_execute_hooks_sets_fdsx_hooks_on_state_end_success(
         self, tmp_path: Path
     ) -> None:
-        """FDSX_HOOKS env var is set to 'on_complete' when event='on_complete' and status='completed'."""
+        """FDSX_HOOKS env var is set to 'on_state_end' when event='on_state_end' and status='completed'."""
         hook = self._make_hook("true")
         data_path = tmp_path / "data.json"
 
@@ -314,10 +314,10 @@ class TestExecuteHooks:
         env = mock_run.call_args[1]["env"]
         assert env["FDSX_HOOKS"] == "on_state_end"
 
-    def test_execute_hooks_sets_fdsx_hooks_on_complete_failure(
+    def test_execute_hooks_sets_fdsx_hooks_on_state_end_failure(
         self, tmp_path: Path
     ) -> None:
-        """FDSX_HOOKS env var is set to 'on_complete' when event='on_complete' and status='failed'."""
+        """FDSX_HOOKS env var is set to 'on_state_end' when event='on_state_end' and status='failed'."""
         hook = self._make_hook("true")
         data_path = tmp_path / "data.json"
 
@@ -656,7 +656,7 @@ class TestCollectHooks:
 
         assert [h.command for h in result] == ["g1", "g2", "g3", "s1", "s2"]
 
-    def test_on_complete_event(self) -> None:
+    def test_on_state_end_event(self) -> None:
         """on_state_end event selects the correct hook list."""
         config = HookConfig(
             on_state_start=[HookEntry(command="start-hook")],
@@ -732,7 +732,7 @@ class TestCollectHooks:
         assert [h.command for h in result] == ["p1", "s1"]
 
     def test_empty_hook_config_contributes_no_entries(self) -> None:
-        """HookConfig with empty on_start adds nothing."""
+        """HookConfig with empty on_state_start adds nothing."""
         empty_cfg = HookConfig()
         state_cfg = self._make_config(["s1"])
 

--- a/tests/unit/test_map_model.py
+++ b/tests/unit/test_map_model.py
@@ -330,7 +330,7 @@ class TestMapState:
         assert state.end is True
 
     def test_with_hooks(self):
-        from fdsx.models.flow import HookConfig, HookEntry
+        from fdsx.models.flow import HookEntry, StateHookConfig
 
         state = MapState(
             items_path="$.items",
@@ -346,7 +346,7 @@ class TestMapState:
                 ]
             ),
             result_path="$.results",
-            hooks=HookConfig(
+            hooks=StateHookConfig(
                 on_state_start=[HookEntry(command="echo starting")],
                 on_state_end=[HookEntry(command="echo done")],
             ),

--- a/tests/unit/test_map_model.py
+++ b/tests/unit/test_map_model.py
@@ -347,12 +347,12 @@ class TestMapState:
             ),
             result_path="$.results",
             hooks=HookConfig(
-                on_start=[HookEntry(command="echo starting")],
-                on_complete=[HookEntry(command="echo done")],
+                on_state_start=[HookEntry(command="echo starting")],
+                on_state_end=[HookEntry(command="echo done")],
             ),
         )
         assert state.hooks is not None
-        assert len(state.hooks.on_start) == 1
+        assert len(state.hooks.on_state_start) == 1
 
     def test_with_max_iterations(self):
         state = MapState(

--- a/tests/unit/test_providers.py
+++ b/tests/unit/test_providers.py
@@ -34,7 +34,7 @@ class TestRunSubprocessFdsxHooksScrub:
         When no env arg is supplied, _run_subprocess must still build an explicit
         env dict (not pass env=None) and strip FDSX_HOOKS from it.
         """
-        monkeypatch.setenv("FDSX_HOOKS", "on_start")
+        monkeypatch.setenv("FDSX_HOOKS", "on_state_start")
 
         with patch("fdsx.providers.base.subprocess.Popen") as mock_popen:
             mock_popen.return_value = _make_mock_process()
@@ -55,7 +55,7 @@ class TestRunSubprocessFdsxHooksScrub:
             mock_popen.return_value = _make_mock_process()
             _run_subprocess(
                 ["echo", "hi"],
-                env={"FDSX_HOOKS": "on_start", "MY_VAR": "hello"},
+                env={"FDSX_HOOKS": "on_state_start", "MY_VAR": "hello"},
             )
 
         captured_env = mock_popen.call_args[1]["env"]
@@ -73,7 +73,7 @@ class TestRunSubprocessFdsxHooksScrub:
             mock_popen.return_value = _make_mock_process()
             _run_subprocess(
                 ["echo", "hi"],
-                env={"FDSX_HOOKS": "on_complete", "FDSX_STATE_NAME": "MyState"},
+                env={"FDSX_HOOKS": "on_state_end", "FDSX_STATE_NAME": "MyState"},
             )
 
         captured_env = mock_popen.call_args[1]["env"]


### PR DESCRIPTION
## Summary

- Implements `on_workflow_start` and `on_workflow_end` hooks that fire at workflow boundary (T022–T025)
- Adds `examples/hooks_smoke.yaml`: a 2-path workflow exercising all 4 lifecycle hooks (`on_workflow_start`, `on_state_start`, `on_state_end`, `on_workflow_end`)
- Adds `examples/hooks_smoke_tasks/`: 3 task files for `--tasks-dir` firing verification
- Documents legacy key detection in `flow.py` validators with inline comments
- Updates `SKILL.md` and `yaml-schema.md` to reflect new hook fields

## What was done

- `HookConfig` extended with optional `on_workflow_start` and `on_workflow_end` fields
- Engine wiring: `on_workflow_start` fires before the first state; `on_workflow_end` fires after the terminal state
- Legacy `on_start`/`on_complete` key rejection preserved with `# legacy key name` comments
- Smoke test covers: run-to-completion, interrupt/resume, and tasks-dir batch modes

## How to test

```bash
# Smoke test: run to completion
rm -f /tmp/fdsx_smoke_hooks.log
fdsx run examples/hooks_smoke.yaml
grep -c on_workflow_start /tmp/fdsx_smoke_hooks.log  # should be 1

# Interrupt/resume: run with mode=wait, then resume
fdsx resume --thread-id <id> --resume-point continue

# Tasks-dir: verify 3x firing
rm -f /tmp/fdsx_smoke_hooks.log
fdsx run --tasks-dir examples/hooks_smoke_tasks/
grep -c on_workflow_start /tmp/fdsx_smoke_hooks.log  # should be 3
```

## Checklist

- [x] All 1988 tests pass (`uv run pytest tests/ -v`)
- [x] Ruff clean (`uv run ruff format --check . && uv run ruff check src/ tests/`)
- [x] Mypy clean (`uv run mypy src/`)
- [x] Smoke test verified (all 4 hook events fire with correct FDSX_HOOKS values)