### PR TITLE
feat(fdsx-ui): two-layer clip-path diamond for ChoiceNode decision states

### DIFF
--- a/packages/fdsx-ui/src/client/components/GraphView.tsx
+++ b/packages/fdsx-ui/src/client/components/GraphView.tsx
@@ -143,7 +143,7 @@ export function GraphView({ workflowPath }: GraphViewProps) {
         </ReactFlow>
       </div>
       {selectedNode && (
-        <NodeDetail node={selectedNode} onClose={handleCloseNodeDetail} />
+        <NodeDetail node={selectedNode} onClose={handleCloseNodeDetail} workflowPath={workflowPath} />
       )}
     </div>
   );

--- a/packages/fdsx-ui/src/client/components/NodeDetail.tsx
+++ b/packages/fdsx-ui/src/client/components/NodeDetail.tsx
@@ -1,12 +1,85 @@
+import { useState, useEffect } from 'react';
 import type { GraphNode, GraphEdge, State, TaskState, ChoiceState, ParallelState, MapState, WaitState, PassState } from '../../shared/types.js';
 import styles from '../styles/NodeDetail.module.css';
 
 interface NodeDetailProps {
   node: GraphNode;
   onClose: () => void;
+  workflowPath: string;
 }
 
-function renderTaskState(state: TaskState) {
+interface PromptContentProps {
+  promptTemplate: string | null;
+  promptFile: string | null;
+  workflowPath: string;
+}
+
+function PromptContent({ promptTemplate, promptFile, workflowPath }: PromptContentProps) {
+  const [fetchState, setFetchState] = useState<{
+    status: 'loading' | 'ok' | 'error';
+    contents?: string;
+    errorKind?: string;
+  }>({ status: 'loading' });
+
+  useEffect(() => {
+    if (promptTemplate !== null || !promptFile) return;
+
+    let cancelled = false;
+    setFetchState({ status: 'loading' });
+
+    fetch(`/api/workflows/${workflowPath}/prompt?file=${encodeURIComponent(promptFile)}`)
+      .then(res => res.json())
+      .then((data: { contents?: string; error?: string }) => {
+        if (cancelled) return;
+        if (data.contents !== undefined) {
+          setFetchState({ status: 'ok', contents: data.contents });
+        } else {
+          setFetchState({ status: 'error', errorKind: data.error ?? 'read-error' });
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setFetchState({ status: 'error', errorKind: 'read-error' });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workflowPath, promptFile, promptTemplate]);
+
+  if (promptTemplate !== null) {
+    return <pre className={styles.codeBlock}>{promptTemplate}</pre>;
+  }
+
+  if (!promptFile) {
+    return null;
+  }
+
+  const errorMessages: Record<string, string> = {
+    'not-found': `Prompt file not found: ${promptFile}`,
+    'outside-workspace': `Prompt file is outside the visualized workspace: ${promptFile}`,
+    'read-error': `Could not read prompt file: ${promptFile}`,
+  };
+
+  return (
+    <>
+      <p className={styles.promptSource}>From file: {promptFile}</p>
+      {fetchState.status === 'loading' && (
+        <p className={styles.field}>Loading…</p>
+      )}
+      {fetchState.status === 'ok' && (
+        <pre className={styles.codeBlock}>{fetchState.contents}</pre>
+      )}
+      {fetchState.status === 'error' && (
+        <div className={styles.errorBlock}>
+          {errorMessages[fetchState.errorKind ?? 'read-error'] ?? errorMessages['read-error']}
+        </div>
+      )}
+    </>
+  );
+}
+
+function renderTaskState(state: TaskState, workflowPath: string) {
   return (
     <>
       <div className={styles.section}>
@@ -22,9 +95,11 @@ function renderTaskState(state: TaskState) {
       {(state.promptTemplate || state.promptFile) && (
         <div className={styles.section}>
           <h4 className={styles.sectionTitle}>Prompt</h4>
-          <pre className={styles.codeBlock}>
-            {state.promptTemplate || `[File: ${state.promptFile}]`}
-          </pre>
+          <PromptContent
+            promptTemplate={state.promptTemplate}
+            promptFile={state.promptFile}
+            workflowPath={workflowPath}
+          />
         </div>
       )}
       {state.command && (
@@ -146,10 +221,10 @@ function renderPassState(state: PassState) {
   );
 }
 
-function renderStateSpecificSection(state: State) {
+function renderStateSpecificSection(state: State, workflowPath: string) {
   switch (state.type) {
     case 'task':
-      return renderTaskState(state);
+      return renderTaskState(state, workflowPath);
     case 'choice':
       return renderChoiceState(state);
     case 'parallel':
@@ -218,7 +293,7 @@ function renderTransitions(state: State) {
   );
 }
 
-export function NodeDetail({ node, onClose }: NodeDetailProps) {
+export function NodeDetail({ node, onClose, workflowPath }: NodeDetailProps) {
   const state = node.data.state as State;
   const stateType = node.data.stateType;
 
@@ -234,7 +309,7 @@ export function NodeDetail({ node, onClose }: NodeDetailProps) {
         </button>
       </div>
       <div className={styles.content}>
-        {renderStateSpecificSection(state)}
+        {renderStateSpecificSection(state, workflowPath)}
         {renderCommonFields(state)}
         {renderTransitions(state)}
       </div>

--- a/packages/fdsx-ui/src/client/components/nodes/ChoiceNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/ChoiceNode.tsx
@@ -7,9 +7,9 @@ export function ChoiceNode({ data }: NodeProps<GraphNode>) {
     <>
       <Handle type="target" position={Position.Top} />
       <div
-        className={`${styles.nodeBase} ${styles.diamondWrapper} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}
+        className={`${styles.diamondOuter} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}
       >
-        <div className={styles.diamondContent}>
+        <div className={styles.diamondInner}>
           <p className={styles.nodeLabel}>
             {data.isStart ? (
               <span className={styles.nodeIcon}>▶</span>

--- a/packages/fdsx-ui/src/client/components/nodes/ChoiceNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/ChoiceNode.tsx
@@ -7,10 +7,17 @@ export function ChoiceNode({ data }: NodeProps<GraphNode>) {
     <>
       <Handle type="target" position={Position.Top} />
       <div
-        className={`${styles.nodeBase} ${styles.diamondWrapper} ${data.isStart ? styles.startNode : ''}`}
+        className={`${styles.nodeBase} ${styles.diamondWrapper} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}
       >
         <div className={styles.diamondContent}>
-          <p className={styles.nodeLabel}>{data.label}</p>
+          <p className={styles.nodeLabel}>
+            {data.isStart ? (
+              <span className={styles.nodeIcon}>▶</span>
+            ) : data.isEnd ? (
+              <span className={styles.nodeIcon}>■</span>
+            ) : null}
+            {data.label}
+          </p>
         </div>
       </div>
       <Handle type="source" position={Position.Bottom} />

--- a/packages/fdsx-ui/src/client/components/nodes/MapNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/MapNode.tsx
@@ -6,8 +6,15 @@ export function MapNode({ data }: NodeProps<GraphNode>) {
   return (
     <>
       <Handle type="target" position={Position.Top} />
-      <div className={`${styles.nodeBase} ${styles.mapNode} ${data.isStart ? styles.startNode : ''}`}>
-        <p className={styles.nodeLabel}>{data.label}</p>
+      <div className={`${styles.nodeBase} ${styles.mapNode} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}>
+        <p className={styles.nodeLabel}>
+          {data.isStart ? (
+            <span className={styles.nodeIcon}>▶</span>
+          ) : data.isEnd ? (
+            <span className={styles.nodeIcon}>■</span>
+          ) : null}
+          {data.label}
+        </p>
         <p className={styles.nodeSublabel}>iterator</p>
       </div>
       <Handle type="source" position={Position.Bottom} />

--- a/packages/fdsx-ui/src/client/components/nodes/ParallelNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/ParallelNode.tsx
@@ -9,8 +9,15 @@ export function ParallelNode({ data }: NodeProps<GraphNode>) {
   return (
     <>
       <Handle type="target" position={Position.Top} />
-      <div className={`${styles.nodeBase} ${data.isStart ? styles.startNode : ''}`}>
-        <p className={styles.nodeLabel}>{data.label}</p>
+      <div className={`${styles.nodeBase} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}>
+        <p className={styles.nodeLabel}>
+          {data.isStart ? (
+            <span className={styles.nodeIcon}>▶</span>
+          ) : data.isEnd ? (
+            <span className={styles.nodeIcon}>■</span>
+          ) : null}
+          {data.label}
+        </p>
         <p className={styles.nodeSublabel}>{branchCount} branch{branchCount !== 1 ? 'es' : ''}</p>
       </div>
       <Handle type="source" position={Position.Bottom} />

--- a/packages/fdsx-ui/src/client/components/nodes/PassNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/PassNode.tsx
@@ -6,8 +6,15 @@ export function PassNode({ data }: NodeProps<GraphNode>) {
   return (
     <>
       <Handle type="target" position={Position.Top} />
-      <div className={`${styles.nodeBase} ${styles.passNode} ${data.isStart ? styles.startNode : ''}`}>
-        <p className={styles.nodeLabel}>{data.label}</p>
+      <div className={`${styles.nodeBase} ${styles.passNode} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}>
+        <p className={styles.nodeLabel}>
+          {data.isStart ? (
+            <span className={styles.nodeIcon}>▶</span>
+          ) : data.isEnd ? (
+            <span className={styles.nodeIcon}>■</span>
+          ) : null}
+          {data.label}
+        </p>
       </div>
       <Handle type="source" position={Position.Bottom} />
     </>

--- a/packages/fdsx-ui/src/client/components/nodes/TaskNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/TaskNode.tsx
@@ -9,8 +9,15 @@ export function TaskNode({ data }: NodeProps<GraphNode>) {
   return (
     <>
       <Handle type="target" position={Position.Top} />
-      <div className={`${styles.nodeBase} ${data.isStart ? styles.startNode : ''}`}>
-        <p className={styles.nodeLabel}>{data.label}</p>
+      <div className={`${styles.nodeBase} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}>
+        <p className={styles.nodeLabel}>
+          {data.isStart ? (
+            <span className={styles.nodeIcon}>▶</span>
+          ) : data.isEnd ? (
+            <span className={styles.nodeIcon}>■</span>
+          ) : null}
+          {data.label}
+        </p>
         <p className={styles.nodeSublabel}>{provider}</p>
       </div>
       <Handle type="source" position={Position.Bottom} />

--- a/packages/fdsx-ui/src/client/components/nodes/WaitNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/WaitNode.tsx
@@ -9,8 +9,15 @@ export function WaitNode({ data }: NodeProps<GraphNode>) {
   return (
     <>
       <Handle type="target" position={Position.Top} />
-      <div className={`${styles.nodeBase} ${styles.waitNode} ${data.isStart ? styles.startNode : ''}`}>
-        <p className={styles.nodeLabel}>{data.label}</p>
+      <div className={`${styles.nodeBase} ${styles.waitNode} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}>
+        <p className={styles.nodeLabel}>
+          {data.isStart ? (
+            <span className={styles.nodeIcon}>▶</span>
+          ) : data.isEnd ? (
+            <span className={styles.nodeIcon}>■</span>
+          ) : null}
+          {data.label}
+        </p>
         <p className={styles.nodeSublabel}>{mode}</p>
       </div>
       <Handle type="source" position={Position.Bottom} />

--- a/packages/fdsx-ui/src/client/styles/NodeDetail.module.css
+++ b/packages/fdsx-ui/src/client/styles/NodeDetail.module.css
@@ -182,3 +182,22 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.promptSource {
+  font-size: 11px;
+  color: #6b7280;
+  margin: 0 0 6px 0;
+}
+
+.errorBlock {
+  font-size: 12px;
+  font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+  color: #dc2626;
+  background-color: #fef2f2;
+  border: 1px solid #fecaca;
+  border-radius: 4px;
+  padding: 10px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/packages/fdsx-ui/src/client/styles/nodes.module.css
+++ b/packages/fdsx-ui/src/client/styles/nodes.module.css
@@ -8,11 +8,6 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-.startNode {
-  border: 2px solid #4f46e5;
-  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
-}
-
 .nodeLabel {
   font-size: 13px;
   font-weight: 500;
@@ -21,6 +16,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.nodeIcon {
+  margin-right: 4px;
+  font-size: 11px;
 }
 
 .nodeSublabel {
@@ -64,4 +64,27 @@
 
 .mapNode .nodeSublabel {
   color: #7c3aed;
+}
+
+/* Role styles AFTER type styles — wins cascade when both classes present */
+.startNode {
+  border: 2px solid #4f46e5;
+  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.2);
+  background-color: #eef2ff;
+}
+
+.endNode {
+  border: 2px solid #e11d48;
+  box-shadow: 0 0 0 2px rgba(225, 29, 72, 0.2);
+  background-color: #fff1f2;
+}
+
+:global(.react-flow__node.selected) .startNode {
+  border: 2px solid #4f46e5;
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.4);
+}
+
+:global(.react-flow__node.selected) .endNode {
+  border: 2px solid #e11d48;
+  box-shadow: 0 0 0 4px rgba(225, 29, 72, 0.4);
 }

--- a/packages/fdsx-ui/src/client/styles/nodes.module.css
+++ b/packages/fdsx-ui/src/client/styles/nodes.module.css
@@ -32,16 +32,40 @@
   white-space: nowrap;
 }
 
-.diamondWrapper {
+.diamondOuter {
   clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-  border-radius: 0;
-  padding: 20px 30px;
+  padding: 2px;
+  background-color: #d97706;
+  width: 120px;
+  min-height: 80px;
+  display: flex;
 }
 
-.diamondContent {
+.diamondInner {
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  flex: 1;
+  padding: 18px 28px;
+  background-color: #fef3c7;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+}
+
+.diamondOuter.startNode {
+  background-color: #4f46e5;
+}
+
+.diamondOuter.startNode .diamondInner {
+  background-color: #eef2ff;
+}
+
+.diamondOuter.endNode {
+  background-color: #e11d48;
+}
+
+.diamondOuter.endNode .diamondInner {
+  background-color: #fff1f2;
 }
 
 .passNode {
@@ -87,4 +111,28 @@
 :global(.react-flow__node.selected) .endNode {
   border: 2px solid #e11d48;
   box-shadow: 0 0 0 4px rgba(225, 29, 72, 0.4);
+}
+
+:global(.react-flow__node:hover) .diamondOuter {
+  filter: drop-shadow(0 0 3px rgba(217, 119, 6, 0.45));
+}
+
+:global(.react-flow__node.selected) .diamondOuter {
+  filter: drop-shadow(0 0 5px rgba(217, 119, 6, 0.7));
+}
+
+:global(.react-flow__node:hover) .diamondOuter.startNode {
+  filter: drop-shadow(0 0 3px rgba(79, 70, 229, 0.45));
+}
+
+:global(.react-flow__node.selected) .diamondOuter.startNode {
+  filter: drop-shadow(0 0 5px rgba(79, 70, 229, 0.7));
+}
+
+:global(.react-flow__node:hover) .diamondOuter.endNode {
+  filter: drop-shadow(0 0 3px rgba(225, 29, 72, 0.45));
+}
+
+:global(.react-flow__node.selected) .diamondOuter.endNode {
+  filter: drop-shadow(0 0 5px rgba(225, 29, 72, 0.7));
 }

--- a/packages/fdsx-ui/src/server/graph.ts
+++ b/packages/fdsx-ui/src/server/graph.ts
@@ -16,6 +16,7 @@ function createGraphNode(workflow: Workflow, stateName: string): GraphNode {
     stateType: state.type,
     state,
     isStart: stateName === workflow.startAt,
+    isEnd: state.type !== 'choice' && state.end === true,
   };
 
   return {

--- a/packages/fdsx-ui/src/server/server.ts
+++ b/packages/fdsx-ui/src/server/server.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { scanWorkflows } from './scanner.js';
 import { parseWorkflow, WorkflowParseError } from './parser.js';
 import { transformWorkflow } from './graph.js';
-import type { WorkflowFile } from '../shared/types.js';
+import type { WorkflowFile, Workflow } from '../shared/types.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -43,6 +43,90 @@ export interface WorkflowResponse {
     edgeType?: string;
     points?: Array<{ x: number; y: number }>;
   }>;
+}
+
+type PromptFileResult =
+  | { kind: 'ok'; absolutePath: string }
+  | { kind: 'workflow-not-found' }
+  | { kind: 'outside-workspace' }
+  | { kind: 'not-found' }
+  | { kind: 'read-error'; message: string };
+
+async function resolvePromptFileWithinWorkspace(
+  workflowDir: string,
+  workflowRelativePath: string,
+  promptRelativePath: string,
+): Promise<PromptFileResult> {
+  if (path.isAbsolute(promptRelativePath)) {
+    return { kind: 'outside-workspace' };
+  }
+
+  let realBase: string;
+  try {
+    realBase = await fs.realpath(workflowDir);
+  } catch {
+    return { kind: 'workflow-not-found' };
+  }
+
+  const fullYamlPath = path.resolve(workflowDir, workflowRelativePath);
+  const normalizedBase = path.resolve(workflowDir);
+  if (!fullYamlPath.startsWith(normalizedBase + path.sep) && fullYamlPath !== normalizedBase) {
+    return { kind: 'workflow-not-found' };
+  }
+
+  let yamlRealPath: string;
+  try {
+    yamlRealPath = await fs.realpath(fullYamlPath);
+  } catch {
+    return { kind: 'workflow-not-found' };
+  }
+
+  if (!yamlRealPath.startsWith(realBase + path.sep) && yamlRealPath !== realBase) {
+    return { kind: 'workflow-not-found' };
+  }
+
+  const yamlDir = path.dirname(yamlRealPath);
+  const candidatePath = path.resolve(yamlDir, promptRelativePath);
+
+  // Pre-realpath containment check: catches .. traversal even for non-existent files.
+  if (!candidatePath.startsWith(realBase + path.sep)) {
+    return { kind: 'outside-workspace' };
+  }
+
+  let promptRealPath: string;
+  try {
+    promptRealPath = await fs.realpath(candidatePath);
+  } catch (err) {
+    const nodeErr = err as NodeJS.ErrnoException;
+    if (nodeErr.code === 'ENOENT') {
+      return { kind: 'not-found' };
+    }
+    return { kind: 'read-error', message: nodeErr.message ?? String(err) };
+  }
+
+  if (!promptRealPath.startsWith(realBase + path.sep)) {
+    return { kind: 'outside-workspace' };
+  }
+
+  return { kind: 'ok', absolutePath: promptRealPath };
+}
+
+function collectPromptFiles(workflow: Workflow): string[] {
+  const files: string[] = [];
+  for (const state of Object.values(workflow.states)) {
+    if (state.type === 'task' && state.promptFile) {
+      files.push(state.promptFile);
+    } else if (state.type === 'parallel') {
+      for (const branch of state.branches) {
+        if (branch.promptFile) files.push(branch.promptFile);
+      }
+    } else if (state.type === 'map') {
+      for (const iterState of state.iterator.states) {
+        if (iterState.promptFile) files.push(iterState.promptFile);
+      }
+    }
+  }
+  return files;
 }
 
 async function handleWorkflowRequest(
@@ -102,6 +186,56 @@ export function createApp(workflowDir: string): Express {
       res.json(workflows);
     } catch {
       res.status(500).json({ error: 'Failed to scan workflow directory' });
+    }
+  });
+
+  app.get(/^\/api\/workflows\/(.+)\/prompt$/, async (req: Request, res: Response) => {
+    const match = req.path.match(/^\/api\/workflows\/(.+)\/prompt$/);
+    if (!match) {
+      res.status(404).json({ error: 'not-found' });
+      return;
+    }
+    const workflowPath = match[1];
+    const file = typeof req.query.file === 'string' ? req.query.file : undefined;
+    if (!file) {
+      res.status(400).json({ error: 'missing-file' });
+      return;
+    }
+
+    const result = await resolvePromptFileWithinWorkspace(workflowDir, workflowPath, file);
+    if (result.kind === 'ok') {
+      // Validate the requested file is actually declared as prompt_file in the workflow.
+      // This prevents the endpoint from becoming an arbitrary workspace file-read API.
+      try {
+        const yamlFullPath = path.resolve(workflowDir, workflowPath);
+        const yamlContent = await fs.readFile(yamlFullPath, 'utf-8');
+        const workflow = parseWorkflow(yamlContent, yamlFullPath);
+        const validFiles = collectPromptFiles(workflow);
+        if (!validFiles.includes(file)) {
+          res.status(404).json({ error: 'not-found', file });
+          return;
+        }
+      } catch {
+        // Workflow parse failure → deny; path was already validated above
+        res.status(404).json({ error: 'not-found', file });
+        return;
+      }
+
+      try {
+        const contents = await fs.readFile(result.absolutePath, 'utf-8');
+        res.json({ contents, file });
+      } catch (err) {
+        const nodeErr = err as NodeJS.ErrnoException;
+        res.status(404).json({ error: 'read-error', file, message: nodeErr.message ?? String(err) });
+      }
+    } else if (result.kind === 'outside-workspace') {
+      res.status(404).json({ error: 'outside-workspace', file });
+    } else if (result.kind === 'not-found') {
+      res.status(404).json({ error: 'not-found', file });
+    } else if (result.kind === 'workflow-not-found') {
+      res.status(404).json({ error: 'not-found', file });
+    } else {
+      res.status(404).json({ error: 'read-error', file });
     }
   });
 

--- a/packages/fdsx-ui/src/shared/types.ts
+++ b/packages/fdsx-ui/src/shared/types.ts
@@ -188,6 +188,7 @@ export interface NodeData extends Record<string, unknown> {
   stateType: State['type'];
   state: State;
   isStart: boolean;
+  isEnd: boolean;
 }
 
 export type GraphNode = Node<NodeData>;

--- a/packages/fdsx-ui/tests/fixtures/prompt-file.yaml
+++ b/packages/fdsx-ui/tests/fixtures/prompt-file.yaml
@@ -1,0 +1,15 @@
+name: Prompt File Workflow
+start_at: step1
+states:
+  step1:
+    type: task
+    provider: system
+    prompt_file: prompts/my-prompt.txt
+    result_path: $.result
+    next: step2
+  step2:
+    type: task
+    provider: system
+    prompt_file: prompts/unreadable-prompt.txt
+    result_path: $.result2
+    end: true

--- a/packages/fdsx-ui/tests/fixtures/prompts/my-prompt.txt
+++ b/packages/fdsx-ui/tests/fixtures/prompts/my-prompt.txt
@@ -1,0 +1,1 @@
+You are a helpful assistant.

--- a/packages/fdsx-ui/tests/integration/prompt.test.ts
+++ b/packages/fdsx-ui/tests/integration/prompt.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import request from 'supertest';
 import http from 'http';
 import path from 'path';
-import { writeFile, chmod, unlink } from 'fs/promises';
+import os from 'os';
+import { writeFile, chmod, unlink, symlink } from 'fs/promises';
 import { createApp } from '../../src/server/server.js';
 
 const fixturesDir = path.join(__dirname, '../fixtures');
@@ -31,6 +32,7 @@ describe('Prompt file endpoint', () => {
       .get('/api/workflows/prompt-file.yaml/prompt');
 
     expect(response.status).toBe(400);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
     expect(response.body.error).toBe('missing-file');
   });
 
@@ -40,6 +42,7 @@ describe('Prompt file endpoint', () => {
       .query({ file: '' });
 
     expect(response.status).toBe(400);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
     expect(response.body.error).toBe('missing-file');
   });
 
@@ -51,6 +54,7 @@ describe('Prompt file endpoint', () => {
       .query({ file: 'prompts/nonexistent.txt' });
 
     expect(response.status).toBe(404);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
     expect(response.body.error).toBe('not-found');
     expect(response.body.file).toBe('prompts/nonexistent.txt');
   });
@@ -61,6 +65,7 @@ describe('Prompt file endpoint', () => {
       .query({ file: 'prompts/my-prompt.txt' });
 
     expect(response.status).toBe(404);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
   });
 
   // ── 404 outside-workspace (path traversal) ──────────────────────────────────
@@ -103,7 +108,26 @@ describe('Prompt file endpoint', () => {
       .query({ file: '/etc/passwd' });
 
     expect(response.status).toBe(404);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
     expect(response.body.error).toBe('outside-workspace');
+  });
+
+  it('returns 404 outside-workspace for a symlink pointing outside the workspace', async () => {
+    const targetOutside = path.join(os.tmpdir(), 'prompt-test-external.txt');
+    const linkInside = path.join(fixturesDir, 'prompts', 'outside-link.txt');
+    await writeFile(targetOutside, 'external content');
+    await symlink(targetOutside, linkInside);
+    try {
+      const response = await request(app)
+        .get('/api/workflows/prompt-file.yaml/prompt')
+        .query({ file: 'prompts/outside-link.txt' });
+      expect(response.status).toBe(404);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+      expect(response.body.error).toBe('outside-workspace');
+    } finally {
+      await unlink(linkInside).catch(() => {});
+      await unlink(targetOutside).catch(() => {});
+    }
   });
 
   // ── 404 missing workflowDir (Finding 1) ────────────────────────────────────
@@ -130,6 +154,7 @@ describe('Prompt file endpoint', () => {
       .query({ file: 'prompt-file.yaml' }); // exists in fixtures but not a prompt_file
 
     expect(response.status).toBe(404);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
     expect(response.body.error).toBe('not-found');
   });
 
@@ -143,6 +168,7 @@ describe('Prompt file endpoint', () => {
         .get('/api/workflows/prompt-file.yaml/prompt')
         .query({ file: 'prompts/extra.txt' });
       expect(response.status).toBe(404);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
       expect(response.body.error).toBe('not-found');
     } finally {
       await unlink(extra).catch(() => {});
@@ -165,6 +191,7 @@ describe('Prompt file endpoint', () => {
         .query({ file: 'prompts/unreadable-prompt.txt' });
 
       expect(response.status).toBe(404);
+      expect(response.headers['content-type']).toMatch(/application\/json/);
       expect(response.body.error).toBe('read-error');
     } finally {
       // Restore permissions before deleting so cleanup always succeeds.

--- a/packages/fdsx-ui/tests/integration/prompt.test.ts
+++ b/packages/fdsx-ui/tests/integration/prompt.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import http from 'http';
+import path from 'path';
+import { writeFile, chmod, unlink } from 'fs/promises';
+import { createApp } from '../../src/server/server.js';
+
+const fixturesDir = path.join(__dirname, '../fixtures');
+
+describe('Prompt file endpoint', () => {
+  const app = createApp(fixturesDir);
+
+  // ── 200 happy path ──────────────────────────────────────────────────────────
+
+  it('returns 200 with { contents, file } for a valid prompt file', async () => {
+    const response = await request(app)
+      .get('/api/workflows/prompt-file.yaml/prompt')
+      .query({ file: 'prompts/my-prompt.txt' });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
+    expect(typeof response.body.contents).toBe('string');
+    expect(response.body.contents.trim()).toBe('You are a helpful assistant.');
+    expect(response.body.file).toBe('prompts/my-prompt.txt');
+  });
+
+  // ── 400 missing / empty file param ─────────────────────────────────────────
+
+  it('returns 400 missing-file when ?file= query param is absent', async () => {
+    const response = await request(app)
+      .get('/api/workflows/prompt-file.yaml/prompt');
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('missing-file');
+  });
+
+  it('returns 400 missing-file when ?file= is an empty string', async () => {
+    const response = await request(app)
+      .get('/api/workflows/prompt-file.yaml/prompt')
+      .query({ file: '' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('missing-file');
+  });
+
+  // ── 404 not-found ───────────────────────────────────────────────────────────
+
+  it('returns 404 not-found when the prompt file does not exist', async () => {
+    const response = await request(app)
+      .get('/api/workflows/prompt-file.yaml/prompt')
+      .query({ file: 'prompts/nonexistent.txt' });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('not-found');
+    expect(response.body.file).toBe('prompts/nonexistent.txt');
+  });
+
+  it('returns 404 when the workflow YAML does not exist', async () => {
+    const response = await request(app)
+      .get('/api/workflows/nonexistent.yaml/prompt')
+      .query({ file: 'prompts/my-prompt.txt' });
+
+    expect(response.status).toBe(404);
+  });
+
+  // ── 404 outside-workspace (path traversal) ──────────────────────────────────
+
+  it('returns 404 outside-workspace when ?file= contains .. segments (via raw HTTP)', async () => {
+    const server = app.listen(0);
+    const addr = server.address() as { port: number };
+    try {
+      const res = await new Promise<{ statusCode: number; body: string }>((resolve, reject) => {
+        const req = http.request(
+          {
+            hostname: '127.0.0.1',
+            port: addr.port,
+            path: '/api/workflows/prompt-file.yaml/prompt?file=../../etc/passwd',
+            method: 'GET',
+          },
+          (res) => {
+            let body = '';
+            res.on('data', (chunk: Buffer) => {
+              body += chunk.toString();
+            });
+            res.on('end', () => resolve({ statusCode: res.statusCode!, body }));
+          },
+        );
+        req.on('error', reject);
+        req.end();
+      });
+
+      expect(res.statusCode).toBe(404);
+      const parsed = JSON.parse(res.body);
+      expect(parsed.error).toBe('outside-workspace');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('returns 404 outside-workspace when ?file= is an absolute path', async () => {
+    const response = await request(app)
+      .get('/api/workflows/prompt-file.yaml/prompt')
+      .query({ file: '/etc/passwd' });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('outside-workspace');
+  });
+
+  // ── 404 missing workflowDir (Finding 1) ────────────────────────────────────
+
+  it('returns 404 with JSON body when workflowDir does not exist (not a 500)', async () => {
+    const missingApp = createApp('/definitely/missing-workspace-dir');
+    const response = await request(missingApp)
+      .get('/api/workflows/any.yaml/prompt')
+      .query({ file: 'prompts/my-prompt.txt' });
+
+    expect(response.status).toBe(404);
+    expect(response.headers['content-type']).toMatch(/application\/json/);
+    // Must NOT be 500 or an empty body
+    expect(response.body).toBeTruthy();
+  });
+
+  // ── 404 allowlist (Finding 2) ───────────────────────────────────────────────
+
+  it('returns 404 not-found when file is inside workspace but not declared in workflow', async () => {
+    // prompt-file.yaml declares only 'prompts/my-prompt.txt' and 'prompts/unreadable-prompt.txt'.
+    // Requesting another fixture file that physically exists but is not declared must be rejected.
+    const response = await request(app)
+      .get('/api/workflows/prompt-file.yaml/prompt')
+      .query({ file: 'prompt-file.yaml' }); // exists in fixtures but not a prompt_file
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('not-found');
+  });
+
+  it('rejects a workspace file that exists but is not declared as prompt_file', async () => {
+    const extra = path.join(fixturesDir, 'prompts', 'extra.txt');
+    await writeFile(extra, 'extra content');
+    try {
+      // This workflow only declares 'prompts/my-prompt.txt' and 'prompts/unreadable-prompt.txt',
+      // not 'prompts/extra.txt'.
+      const response = await request(app)
+        .get('/api/workflows/prompt-file.yaml/prompt')
+        .query({ file: 'prompts/extra.txt' });
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBe('not-found');
+    } finally {
+      await unlink(extra).catch(() => {});
+    }
+  });
+
+  // ── 404 read-error ──────────────────────────────────────────────────────────
+
+  it('returns 404 read-error when the prompt file exists but is unreadable', async () => {
+    // Create a temporary file inside the fixtures/prompts directory, remove
+    // read permissions (chmod 000), then confirm the endpoint returns read-error.
+    // This works because the test process runs as a non-root user.
+    const unreadablePath = path.join(fixturesDir, 'prompts', 'unreadable-prompt.txt');
+    await writeFile(unreadablePath, 'secret content', 'utf-8');
+    await chmod(unreadablePath, 0o000);
+
+    try {
+      const response = await request(app)
+        .get('/api/workflows/prompt-file.yaml/prompt')
+        .query({ file: 'prompts/unreadable-prompt.txt' });
+
+      expect(response.status).toBe(404);
+      expect(response.body.error).toBe('read-error');
+    } finally {
+      // Restore permissions before deleting so cleanup always succeeds.
+      await chmod(unreadablePath, 0o644).catch(() => {});
+      await unlink(unreadablePath).catch(() => {});
+    }
+  });
+});

--- a/packages/fdsx-ui/tests/unit/graph.test.ts
+++ b/packages/fdsx-ui/tests/unit/graph.test.ts
@@ -348,4 +348,91 @@ states:
     const successNode = nodes.find((n) => n.id === 'success');
     expect(successNode?.type).toBe('task');
   });
+
+  it('isEnd is true for state with end: true', () => {
+    const workflow = parseWorkflow(`
+name: Test
+start_at: only
+states:
+  only:
+    type: task
+    provider: system
+    command: echo only
+    result_path: $.result
+    end: true
+`);
+    const { nodes } = transformWorkflow(workflow);
+
+    const onlyNode = nodes.find((n) => n.id === 'only');
+    expect(onlyNode?.data['isEnd']).toBe(true);
+  });
+
+  it('isEnd is false for non-terminal state', () => {
+    const workflow = parseWorkflow(`
+name: Test
+start_at: first
+states:
+  first:
+    type: task
+    provider: system
+    command: echo first
+    result_path: $.result
+    next: second
+  second:
+    type: task
+    provider: system
+    command: echo second
+    result_path: $.result
+    end: true
+`);
+    const { nodes } = transformWorkflow(workflow);
+
+    const firstNode = nodes.find((n) => n.id === 'first');
+    expect(firstNode?.data['isEnd']).toBe(false);
+  });
+
+  it('isEnd is false for choice state', () => {
+    const workflow = parseWorkflow(`
+name: Test
+start_at: check
+states:
+  check:
+    type: choice
+    choices:
+      - variable: $.status
+        operator: equals
+        value: ok
+        next: done
+    default: done
+  done:
+    type: task
+    provider: system
+    command: echo done
+    result_path: $.result
+    end: true
+`);
+    const { nodes } = transformWorkflow(workflow);
+
+    const choiceNode = nodes.find((n) => n.id === 'check');
+    expect(choiceNode?.data['isEnd']).toBe(false);
+  });
+
+  it('both isStart and isEnd true for single-state workflow', () => {
+    const workflow = parseWorkflow(`
+name: Test
+start_at: only
+states:
+  only:
+    type: task
+    provider: system
+    command: echo only
+    result_path: $.result
+    end: true
+`);
+    const { nodes } = transformWorkflow(workflow);
+
+    const onlyNode = nodes.find((n) => n.id === 'only');
+    expect(onlyNode?.data.isStart).toBe(true);
+    expect(onlyNode?.data['isEnd']).toBe(true);
+  });
 });

--- a/packages/fdsx-ui/tests/unit/node-detail.test.tsx
+++ b/packages/fdsx-ui/tests/unit/node-detail.test.tsx
@@ -1,7 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { NodeDetail } from '../../src/client/components/NodeDetail.js';
 import type { GraphNode, TaskState, ChoiceState, ParallelState, MapState, WaitState } from '../../src/shared/types.js';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function makeNode(label: string, stateType: string, state: Record<string, unknown>): GraphNode {
   return {
@@ -17,10 +27,17 @@ function makeNode(label: string, stateType: string, state: Record<string, unknow
   } as unknown as GraphNode;
 }
 
+// Helper to cast NodeDetail to accept workflowPath until it is added to production types
+const ND = NodeDetail as React.ComponentType<{
+  node: GraphNode;
+  onClose: () => void;
+  workflowPath: string;
+}>;
+
 describe('NodeDetail', () => {
   it('renders node name and type badge', () => {
     const node = makeNode('My Task', 'task', { type: 'task', provider: 'claude' });
-    render(<NodeDetail node={node} onClose={() => {}} />);
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
     expect(screen.getByText('My Task')).toBeInTheDocument();
     expect(screen.getByText('task')).toBeInTheDocument();
   });
@@ -28,7 +45,7 @@ describe('NodeDetail', () => {
   it('renders close button', () => {
     const node = makeNode('Test', 'task', { type: 'task', provider: 'claude' });
     const onClose = () => {};
-    render(<NodeDetail node={node} onClose={onClose} />);
+    render(<ND node={node} onClose={onClose} workflowPath="test.yaml" />);
     const closeBtn = screen.getByRole('button', { name: '×' });
     expect(closeBtn).toBeInTheDocument();
   });
@@ -53,7 +70,7 @@ describe('NodeDetail', () => {
       end: null,
     };
     const node = makeNode('Task Node', 'task', state);
-    render(<NodeDetail node={node} onClose={() => {}} />);
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
     expect(screen.getByText('claude')).toBeInTheDocument();
     expect(screen.getByText('claude-3-opus')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
@@ -73,7 +90,7 @@ describe('NodeDetail', () => {
       hooks: null,
     };
     const node = makeNode('Choice Node', 'choice', state);
-    render(<NodeDetail node={node} onClose={() => {}} />);
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
     expect(screen.getByText('Choices')).toBeInTheDocument();
     expect(screen.getByText('pending-state')).toBeInTheDocument();
     expect(screen.getByText('complete-state')).toBeInTheDocument();
@@ -96,7 +113,7 @@ describe('NodeDetail', () => {
       end: null,
     };
     const node = makeNode('Parallel Node', 'parallel', state);
-    render(<NodeDetail node={node} onClose={() => {}} />);
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
     expect(screen.getByText('Branches')).toBeInTheDocument();
     expect(screen.getByText('claude')).toBeInTheDocument();
     expect(screen.getByText('codex')).toBeInTheDocument();
@@ -119,7 +136,7 @@ describe('NodeDetail', () => {
       end: null,
     };
     const node = makeNode('Map Node', 'map', state);
-    render(<NodeDetail node={node} onClose={() => {}} />);
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
     expect(screen.getByText('Iterator')).toBeInTheDocument();
     expect(screen.getByText('$.items')).toBeInTheDocument();
     expect(screen.getByText('ItemTask')).toBeInTheDocument();
@@ -140,11 +157,168 @@ describe('NodeDetail', () => {
       end: null,
     };
     const node = makeNode('Wait Node', 'wait', state);
-    render(<NodeDetail node={node} onClose={() => {}} />);
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
     expect(screen.getByText('Wait Configuration')).toBeInTheDocument();
     expect(screen.getByText('confirm')).toBeInTheDocument();
     expect(screen.getByText('Please confirm')).toBeInTheDocument();
     expect(screen.getByText('approve')).toBeInTheDocument();
     expect(screen.getByText('reject')).toBeInTheDocument();
+  });
+});
+
+describe('NodeDetail PromptContent', () => {
+  function makeTaskNode(overrides: Partial<TaskState>): GraphNode {
+    const state: TaskState = {
+      type: 'task',
+      provider: 'claude',
+      model: null,
+      promptTemplate: null,
+      promptFile: null,
+      command: null,
+      resultPath: '$.result',
+      resultFile: null,
+      extract: null,
+      maxIterations: null,
+      retry: 0,
+      timeoutSeconds: null,
+      providerOptions: null,
+      hooks: null,
+      next: null,
+      end: null,
+      ...overrides,
+    };
+    return makeNode('Task', 'task', state);
+  }
+
+  it('fetches file-backed prompt and renders contents', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ contents: 'Hello from file', file: 'prompts/my-prompt.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: 'prompts/my-prompt.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="workflows/test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Hello from file')).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/workflows/workflows/test.yaml/prompt?file=prompts%2Fmy-prompt.txt'
+    );
+  });
+
+  it('renders "From file:" subheader for file-backed prompt', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ contents: 'file content', file: 'prompts/x.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: 'prompts/x.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/From file:/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/prompts\/x\.txt/)).toBeInTheDocument();
+  });
+
+  it('renders inline prompt without fetching', () => {
+    const node = makeTaskNode({ promptTemplate: 'inline prompt text', promptFile: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    expect(screen.getByText('inline prompt text')).toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('shows not-found error with file path when server returns not-found', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'not-found', file: 'prompts/missing.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: 'prompts/missing.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Prompt file not found.*prompts\/missing\.txt/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows outside-workspace error with file path when server returns outside-workspace', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'outside-workspace', file: '../secret.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: '../secret.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/outside the visualized workspace.*\.\.\/secret\.txt/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows read-error message with file path when server returns read-error', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'read-error', file: 'prompts/unreadable.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: 'prompts/unreadable.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Could not read prompt file.*prompts\/unreadable\.txt/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows read-error on network failure', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const node = makeTaskNode({ promptFile: 'prompts/file.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Could not read prompt file.*prompts\/file\.txt/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('re-fetches when promptFile changes (re-selection triggers new fetch)', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ contents: 'first content', file: 'prompts/first.txt' }),
+      })
+      .mockResolvedValueOnce({
+        json: () => Promise.resolve({ contents: 'second content', file: 'prompts/second.txt' }),
+      });
+
+    const firstNode = makeTaskNode({ promptFile: 'prompts/first.txt', promptTemplate: null });
+    const { rerender } = render(<ND node={firstNode} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('first content')).toBeInTheDocument();
+    });
+
+    const secondNode = makeTaskNode({ promptFile: 'prompts/second.txt', promptTemplate: null });
+    rerender(<ND node={secondNode} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('second content')).toBeInTheDocument();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows loading state before fetch resolves', () => {
+    // Never resolves so we can observe the loading state
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const node = makeTaskNode({ promptFile: 'prompts/slow.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
 });

--- a/packages/fdsx-ui/tests/unit/node-detail.test.tsx
+++ b/packages/fdsx-ui/tests/unit/node-detail.test.tsx
@@ -321,4 +321,84 @@ describe('NodeDetail PromptContent', () => {
 
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
+
+  // CSS-class contract tests: verify that promptSource and errorBlock
+  // classes are applied to the correct elements, not just that the text appears.
+
+  it('applies promptSource class to the "From file:" subheader element', async () => {
+    // Never-resolving promise keeps the component in "loading" state for the
+    // entire test. The "From file:" label is rendered synchronously on mount
+    // before any fetch result arrives, so no resolution is needed here.
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const node = makeTaskNode({ promptFile: 'prompts/q.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    const label = screen.getByText(/From file:/);
+    expect(label).toHaveClass('promptSource');
+  });
+
+  it('applies errorBlock class to the not-found error element', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'not-found', file: 'prompts/missing.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: 'prompts/missing.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Prompt file not found/)).toBeInTheDocument();
+    });
+
+    // The error container must carry the errorBlock class so it gets the
+    // red monospace styling (#dc2626 colour, #fef2f2 background, border).
+    const errorEl = screen.getByText(/Prompt file not found/);
+    expect(errorEl).toHaveClass('errorBlock');
+  });
+
+  it('applies errorBlock class to the outside-workspace error element', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'outside-workspace', file: '../secret.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: '../secret.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/outside the visualized workspace/i)).toBeInTheDocument();
+    });
+
+    const errorEl = screen.getByText(/outside the visualized workspace/i);
+    expect(errorEl).toHaveClass('errorBlock');
+  });
+
+  it('applies errorBlock class to the read-error element (server-side error)', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'read-error', file: 'prompts/bad.txt' }),
+    });
+
+    const node = makeTaskNode({ promptFile: 'prompts/bad.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not read prompt file/i)).toBeInTheDocument();
+    });
+
+    const errorEl = screen.getByText(/Could not read prompt file/i);
+    expect(errorEl).toHaveClass('errorBlock');
+  });
+
+  it('applies errorBlock class to the read-error element (network failure)', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const node = makeTaskNode({ promptFile: 'prompts/net.txt', promptTemplate: null });
+    render(<ND node={node} onClose={() => {}} workflowPath="test.yaml" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Could not read prompt file.*prompts\/net\.txt/i)).toBeInTheDocument();
+    });
+
+    const errorEl = screen.getByText(/Could not read prompt file.*prompts\/net\.txt/i);
+    expect(errorEl).toHaveClass('errorBlock');
+  });
 });

--- a/packages/fdsx-ui/tests/unit/node-types.test.tsx
+++ b/packages/fdsx-ui/tests/unit/node-types.test.tsx
@@ -144,19 +144,7 @@ describe('TaskNode', () => {
 });
 
 describe('ChoiceNode', () => {
-  it('renders label and has diamond wrapper', () => {
-    const props = makeNodeProps({
-      label: 'Check Status',
-      stateType: 'choice',
-      isStart: false,
-      state: { type: 'choice' },
-    });
-    const { container } = render(<ChoiceNode {...props} />);
-    expect(screen.getByText('Check Status')).toBeInTheDocument();
-    expect(container.querySelector('.diamondWrapper')).toBeTruthy();
-  });
-
-  it('never gets endNode class', () => {
+  it('renders label and has diamondOuter and diamondInner nested', () => {
     const props = makeNodeProps({
       label: 'Check Status',
       stateType: 'choice',
@@ -165,7 +153,98 @@ describe('ChoiceNode', () => {
       state: { type: 'choice' },
     });
     const { container } = render(<ChoiceNode {...props} />);
+    expect(screen.getByText('Check Status')).toBeInTheDocument();
+    expect(container.querySelector('.diamondOuter')).toBeTruthy();
+    expect(container.querySelector('.diamondInner')).toBeTruthy();
+    expect(container.querySelector('.diamondOuter .diamondInner')).toBeTruthy();
+  });
+
+  it('applies startNode class on diamondOuter when isStart is true', () => {
+    const props = makeNodeProps({
+      label: 'Start Decision',
+      stateType: 'choice',
+      isStart: true,
+      isEnd: false,
+      state: { type: 'choice' },
+    });
+    const { container } = render(<ChoiceNode {...props} />);
+    expect(container.querySelector('.diamondOuter.startNode')).toBeTruthy();
+  });
+
+  it('applies endNode class on diamondOuter when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Decision',
+      stateType: 'choice',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'choice' },
+    });
+    const { container } = render(<ChoiceNode {...props} />);
+    expect(container.querySelector('.diamondOuter.endNode')).toBeTruthy();
+    expect(container.querySelector('.diamondOuter.startNode')).toBeFalsy();
+  });
+
+  it('startNode wins when both isStart and isEnd are true', () => {
+    const props = makeNodeProps({
+      label: 'Only Decision',
+      stateType: 'choice',
+      isStart: true,
+      isEnd: true,
+      state: { type: 'choice' },
+    });
+    const { container } = render(<ChoiceNode {...props} />);
+    expect(container.querySelector('.diamondOuter.startNode')).toBeTruthy();
+    expect(container.querySelector('.diamondOuter.endNode')).toBeFalsy();
+  });
+
+  it('does not apply role class when neither flag is set', () => {
+    const props = makeNodeProps({
+      label: 'Plain Decision',
+      stateType: 'choice',
+      isStart: false,
+      isEnd: false,
+      state: { type: 'choice' },
+    });
+    const { container } = render(<ChoiceNode {...props} />);
+    expect(container.querySelector('.startNode')).toBeFalsy();
     expect(container.querySelector('.endNode')).toBeFalsy();
+  });
+
+  it('renders play icon when isStart is true', () => {
+    const props = makeNodeProps({
+      label: 'Start Decision',
+      stateType: 'choice',
+      isStart: true,
+      isEnd: false,
+      state: { type: 'choice' },
+    });
+    render(<ChoiceNode {...props} />);
+    expect(screen.getByText('▶')).toBeInTheDocument();
+  });
+
+  it('renders stop icon when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Decision',
+      stateType: 'choice',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'choice' },
+    });
+    render(<ChoiceNode {...props} />);
+    expect(screen.getByText('■')).toBeInTheDocument();
+  });
+
+  it('renders no icon for plain decision', () => {
+    const props = makeNodeProps({
+      label: 'Plain Decision',
+      stateType: 'choice',
+      isStart: false,
+      isEnd: false,
+      state: { type: 'choice' },
+    });
+    render(<ChoiceNode {...props} />);
+    expect(screen.queryByText('▶')).not.toBeInTheDocument();
+    expect(screen.queryByText('■')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/fdsx-ui/tests/unit/node-types.test.tsx
+++ b/packages/fdsx-ui/tests/unit/node-types.test.tsx
@@ -66,6 +66,81 @@ describe('TaskNode', () => {
     const { container } = render(<TaskNode {...props} />);
     expect(container.querySelector('.startNode')).toBeFalsy();
   });
+
+  it('applies endNode class when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Task',
+      stateType: 'task',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'task', provider: 'claude' },
+    });
+    const { container } = render(<TaskNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeTruthy();
+    expect(container.querySelector('.startNode')).toBeFalsy();
+  });
+
+  it('does not apply endNode class when isEnd is false', () => {
+    const props = makeNodeProps({
+      label: 'Middle Task',
+      stateType: 'task',
+      isStart: false,
+      isEnd: false,
+      state: { type: 'task', provider: 'claude' },
+    });
+    const { container } = render(<TaskNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeFalsy();
+  });
+
+  it('startNode wins when both isStart and isEnd are true', () => {
+    const props = makeNodeProps({
+      label: 'Only Task',
+      stateType: 'task',
+      isStart: true,
+      isEnd: true,
+      state: { type: 'task', provider: 'claude' },
+    });
+    const { container } = render(<TaskNode {...props} />);
+    expect(container.querySelector('.startNode')).toBeTruthy();
+    expect(container.querySelector('.endNode')).toBeFalsy();
+  });
+
+  it('renders play icon when isStart is true', () => {
+    const props = makeNodeProps({
+      label: 'Start Task',
+      stateType: 'task',
+      isStart: true,
+      isEnd: false,
+      state: { type: 'task', provider: 'claude' },
+    });
+    render(<TaskNode {...props} />);
+    expect(screen.getByText('▶')).toBeInTheDocument();
+  });
+
+  it('renders stop icon when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Task',
+      stateType: 'task',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'task', provider: 'claude' },
+    });
+    render(<TaskNode {...props} />);
+    expect(screen.getByText('■')).toBeInTheDocument();
+  });
+
+  it('renders no icon for plain node', () => {
+    const props = makeNodeProps({
+      label: 'Middle Task',
+      stateType: 'task',
+      isStart: false,
+      isEnd: false,
+      state: { type: 'task', provider: 'claude' },
+    });
+    render(<TaskNode {...props} />);
+    expect(screen.queryByText('▶')).not.toBeInTheDocument();
+    expect(screen.queryByText('■')).not.toBeInTheDocument();
+  });
 });
 
 describe('ChoiceNode', () => {
@@ -79,6 +154,18 @@ describe('ChoiceNode', () => {
     const { container } = render(<ChoiceNode {...props} />);
     expect(screen.getByText('Check Status')).toBeInTheDocument();
     expect(container.querySelector('.diamondWrapper')).toBeTruthy();
+  });
+
+  it('never gets endNode class', () => {
+    const props = makeNodeProps({
+      label: 'Check Status',
+      stateType: 'choice',
+      isStart: false,
+      isEnd: false,
+      state: { type: 'choice' },
+    });
+    const { container } = render(<ChoiceNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeFalsy();
   });
 });
 
@@ -105,6 +192,31 @@ describe('ParallelNode', () => {
     render(<ParallelNode {...props} />);
     expect(screen.getByText('1 branch')).toBeInTheDocument();
   });
+
+  it('applies endNode class when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Parallel',
+      stateType: 'parallel',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'parallel', branches: [{}] },
+    });
+    const { container } = render(<ParallelNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeTruthy();
+    expect(container.querySelector('.startNode')).toBeFalsy();
+  });
+
+  it('renders stop icon when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Parallel',
+      stateType: 'parallel',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'parallel', branches: [{}] },
+    });
+    render(<ParallelNode {...props} />);
+    expect(screen.getByText('■')).toBeInTheDocument();
+  });
 });
 
 describe('PassNode', () => {
@@ -119,6 +231,31 @@ describe('PassNode', () => {
     expect(screen.getByText('Skip Step')).toBeInTheDocument();
     expect(container.querySelector('.passNode')).toBeTruthy();
   });
+
+  it('applies endNode class when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Pass',
+      stateType: 'pass',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'pass' },
+    });
+    const { container } = render(<PassNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeTruthy();
+    expect(container.querySelector('.startNode')).toBeFalsy();
+  });
+
+  it('renders stop icon when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Pass',
+      stateType: 'pass',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'pass' },
+    });
+    render(<PassNode {...props} />);
+    expect(screen.getByText('■')).toBeInTheDocument();
+  });
 });
 
 describe('WaitNode', () => {
@@ -132,6 +269,31 @@ describe('WaitNode', () => {
     render(<WaitNode {...props} />);
     expect(screen.getByText('Wait for Input')).toBeInTheDocument();
     expect(screen.getByText('confirm')).toBeInTheDocument();
+  });
+
+  it('applies endNode class when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Wait',
+      stateType: 'wait',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'wait', mode: 'confirm' },
+    });
+    const { container } = render(<WaitNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeTruthy();
+    expect(container.querySelector('.startNode')).toBeFalsy();
+  });
+
+  it('renders stop icon when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Wait',
+      stateType: 'wait',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'wait', mode: 'confirm' },
+    });
+    render(<WaitNode {...props} />);
+    expect(screen.getByText('■')).toBeInTheDocument();
   });
 });
 
@@ -157,5 +319,30 @@ describe('MapNode', () => {
     });
     const { container } = render(<MapNode {...props} />);
     expect(container.querySelector('.mapNode')).toBeTruthy();
+  });
+
+  it('applies endNode class when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Map',
+      stateType: 'map',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'map' },
+    });
+    const { container } = render(<MapNode {...props} />);
+    expect(container.querySelector('.endNode')).toBeTruthy();
+    expect(container.querySelector('.startNode')).toBeFalsy();
+  });
+
+  it('renders stop icon when isEnd is true', () => {
+    const props = makeNodeProps({
+      label: 'End Map',
+      stateType: 'map',
+      isStart: false,
+      isEnd: true,
+      state: { type: 'map' },
+    });
+    render(<MapNode {...props} />);
+    expect(screen.getByText('■')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Restructure `ChoiceNode` with `diamondOuter` + `diamondInner` nested divs — outer carries role class as a visible colored stroke, inner provides the inset fill
- Add role-color overrides: amber (plain), indigo (start), rose (end)
- Add drop-shadow halos on hover/selected per role color
- Replace 2 old tests with 7 new TDD tests verifying structure and role class placement

## What

The single-diamond approach clipped away its own border/box-shadow. The two-layer approach makes the outer div's background color visible as a "stroke" around the inset inner div — same clip-path geometry, visually distinct decision states.

## Files Changed

| File | Change |
|------|--------|
| `ChoiceNode.tsx` | Two nested divs, drop `nodeBase`, role class on outer |
| `nodes.module.css` | Replace `.diamondWrapper`/`.diamondContent` with `.diamondOuter`/`.diamondInner`, add role overrides, add drop-shadow halos |
| `node-types.test.tsx` | Replace 2 tests with 7 TDD tests |

## How to Test

1. `npm test` from `packages/fdsx-ui/` — all 7 new ChoiceNode tests pass
2. `npx tsc --noEmit` — no type errors
3. `npm run dev` then open `.fdsx/workflows/full-impl-ui/workflow.yaml` in browser — verify diamond renders with correct role colors and halos