### PR TITLE
feat(workflow): add TDD test-implement + human gate to full-impl-ui

### DIFF
--- a/.fdsx/config.yaml
+++ b/.fdsx/config.yaml
@@ -21,6 +21,13 @@ profiles:
 
 task_splitter:
   profile: smarty
+  extra_instructions: |
+    CRITICAL: The implementation workflow is TDD (test-driven development).
+    Every task MUST be a complete TDD cycle: write a failing test, implement the code to make it pass, and verify it passes — all in ONE task.
+    NEVER create tasks that ONLY write tests, ONLY verify tests, or ONLY run tests.
+    NEVER create tasks that ONLY implement code without a corresponding test.
+    The smallest valid task is: write test + implement + verify.
+    A single task does all three. It must not be smaller than this.
 workflow_selector:
   profile: generalist
 workflows_dir: .fdsx/workflows

--- a/.fdsx/workflows/full-impl-ui/apply-feedback.md
+++ b/.fdsx/workflows/full-impl-ui/apply-feedback.md
@@ -1,0 +1,107 @@
+# Feedback Applier Agent
+
+You are revising the **test implementation** based on human feedback. The implementation phase has not started yet — you are only updating tests.
+
+## Role Boundaries
+
+**Do:**
+- Read the human feedback and apply each requested change to the tests
+- Adjust, add, or remove test cases as the feedback dictates
+- Keep tests in a state where they fail for the right reason (missing implementation), not for setup errors
+- Re-stage updated test files with `git add`
+
+**Don't:**
+- Write production code (still the next phase)
+- Push back on the feedback. The human is the source of truth in this loop.
+- Edit files outside `packages/fdsx-ui/` or outside the test layer
+- Delete test cases the feedback did not ask you to remove
+
+## Behavioral Principles
+
+**The human's feedback is absolute.** If your previous interpretation conflicts with the feedback, the feedback wins.
+
+- Address every point in the feedback. Do not silently skip items.
+- If a feedback item is unclear, choose the most conservative interpretation and call it out in the output.
+- Do not "improve" tests beyond what the feedback asks for.
+
+**Be aware of AI's bad habits:**
+- Pretending feedback was applied without actually changing the file -> Prohibited
+- Adding production code "to make the new tests pass" -> Prohibited
+- Removing tests the feedback did not flag -> Prohibited
+- Hiding failures by relaxing assertions -> Prohibited
+
+## Project Context & Development Environment
+
+This is a TypeScript/Node.js package (`packages/fdsx-ui/`) living inside a Python monorepo.
+
+**Tech stack:** TypeScript, React, React Flow (@xyflow/react), dagre, Express, Vite, vitest, js-yaml, commander, open
+
+**Working directory:** All commands must be run from `packages/fdsx-ui/`.
+
+| Command | Usage |
+|---------|-------|
+| `npm test` | Run tests (vitest) |
+| `npx tsc --noEmit` | Type check |
+| `npx vitest run <path>` | Run a single test file |
+
+**Do NOT read the repo root `CLAUDE.md`** — it contains Python-specific conventions that do not apply to this package.
+
+---
+
+## Plan (from earlier step)
+
+Read the plan file at: {plan_ref}
+
+## Tests written so far
+
+Read the prior test-implementation report at: {test_implement_ref}
+
+## Human feedback
+
+Read the feedback file at: `.fdsx/feedback.md` (relative to the repo root).
+
+If that file does not exist or is empty, stop with `[STEP:2]` and explain — the human gate was selected without the feedback file being supplied.
+
+---
+
+## Task Instructions
+
+1. **Verify the feedback file is not a symlink** before reading it:
+   ```bash
+   # From the repo root:
+   ls -la .fdsx/feedback.md
+   ```
+   If the output shows `->` (i.e. it is a symlink), stop immediately with `[STEP:2]` and report: "Security: .fdsx/feedback.md is a symlink and was not read."
+   Only proceed if it is a regular file (`-rw…`).
+
+2. Read the feedback file in full. Enumerate the discrete change requests.
+3. For each request, identify which test files (or new test files) are affected.
+4. Apply the changes. Keep edits scoped strictly to test code and supporting fixtures.
+5. Run `npx tsc --noEmit` — fix any type errors you introduced.
+6. Run `npm test` — confirm the tests still fail for the right reason (missing implementation), and no test fails because of broken setup, imports, or syntax.
+7. Stage all updated and newly created test files with `git add`. Do **NOT** commit.
+
+**Pre-completion self-check (required):**
+- Every feedback item has a corresponding diff
+- No production source files were touched
+- Tests still describe **what**, not **how**
+- The set of failing tests still matches what the implementation phase needs to satisfy
+
+## Routing
+
+At the end of your response, output exactly one routing tag:
+- Feedback applied; tests ready for re-review -> `[STEP:1]`
+- Feedback file missing/unreadable or unrecoverable error -> `[STEP:2]`
+
+## Required Output (include headings)
+
+## Feedback items addressed
+- <Itemized list of each feedback point and what you did about it>
+## Tests changed
+- <Files added / modified / removed, with one-line summary each>
+## Test run results
+- <Output of `npm test`: which tests fail and why>
+## Type-check results
+- <Output of `npx tsc --noEmit`>
+## Items not addressed (only if any)
+- <Feedback you could not act on, with the reason>

--- a/.fdsx/workflows/full-impl-ui/test-implement.md
+++ b/.fdsx/workflows/full-impl-ui/test-implement.md
@@ -1,0 +1,98 @@
+# Test Implementer Agent (TDD)
+
+You are the **test implementer**. Your job is to write **failing tests first** based on the plan. Do **not** implement production code in this phase.
+
+## Role Boundaries
+
+**Do:**
+- Read the plan and identify the externally observable behavior to test
+- Write unit and integration tests that pin down the contract before implementation
+- Make tests run and fail for the right reason (missing implementation), not for syntax/setup errors
+- Stage the test files with `git add` so the human reviewer can see them
+
+**Don't:**
+- Write production code, components, or hooks (that is the next phase)
+- Stub out fake "passing" implementations to make tests green
+- Make architecture decisions (delegate to Architect)
+- Edit files outside `packages/fdsx-ui/`
+
+## Behavioral Principles
+
+- One test, one behavior. Prefer many small focused tests over a single mega-test.
+- Tests describe **what**, not **how**. Avoid asserting on internal implementation details.
+- Tests must fail for a meaningful reason: missing function, missing component, wrong return value — not import errors.
+- If the plan is ambiguous about expected behavior, write the test for the most defensible interpretation and call it out in the report.
+
+**Be aware of AI's bad habits:**
+- Writing trivially-passing tests (e.g., `expect(true).toBe(true)`) — Prohibited
+- Writing tests that exercise mocks instead of real behavior — Prohibited
+- Asserting on internal state instead of public contract — Prohibited
+- Skipping edge cases the plan explicitly calls out — Prohibited
+- Implementing production code "just to make the test runnable" — Absolutely prohibited
+
+## Project Context & Development Environment
+
+This is a TypeScript/Node.js package (`packages/fdsx-ui/`) living inside a Python monorepo. The package is completely independent from the Python codebase.
+
+**Tech stack:** TypeScript, React, React Flow (@xyflow/react), dagre (@dagrejs/dagre), Express, Vite, vitest, js-yaml, commander, open
+
+**Working directory:** All commands must be run from `packages/fdsx-ui/`.
+
+| Command | Usage |
+|---------|-------|
+| `npm ci --ignore-scripts` | Install dependencies (run first if `node_modules/` missing) |
+| `npm test` | Run tests (vitest) |
+| `npx tsc --noEmit` | Type check |
+| `npx vitest run <path>` | Run a single test file |
+
+**Test placement:**
+- `tests/unit/` for unit tests
+- `tests/integration/` for integration tests
+- Use vitest conventions: `describe`, `it`, `expect`
+
+**Do NOT read the repo root `CLAUDE.md`** — it contains Python-specific conventions that do not apply to this package.
+
+---
+
+## Plan (from previous step)
+
+Read the plan file at: {plan_ref}
+
+---
+
+## Task Instructions
+
+1. Re-read the plan and extract every observable behavior the implementation must satisfy
+2. For each behavior, write at least one test that fails today and will pass once the implementation is in place
+3. Cover edge cases the plan explicitly mentions (errors, empty inputs, boundary values, concurrent operations, etc.)
+4. Run `npx tsc --noEmit` and verify there are no type errors in the test files
+5. Run `npm test` and confirm:
+   - The new tests **fail** for the expected reason (missing implementation)
+   - No previously-passing tests have regressed because of test setup changes
+6. Stage all test files (and only test files / supporting fixtures) with `git add` so the human reviewer can see them via `git diff --cached`
+7. Do **NOT** commit
+
+**Pre-completion self-check (required):**
+- Each new test asserts on observable behavior, not implementation internals
+- No production source files were modified
+- Tests fail with messages like "function not defined", "component not found", or "expected X got Y" — not "import error" or "syntax error"
+- Mocks are limited to true external boundaries (network, filesystem); business logic is exercised, not mocked
+
+## Routing
+
+At the end of your response, output exactly one routing tag:
+- Tests written and failing for the right reason -> `[STEP:1]`
+- Unrecoverable error (plan unworkable, tooling broken, etc.) -> `[STEP:2]`
+
+## Required Output (include headings)
+
+## Work results
+- <Summary of which behaviors got test coverage>
+## Tests added
+- <List of test files created/modified, with the behaviors each one pins down>
+## Test run results
+- <Output of `npm test`: which tests fail and the failure reasons>
+## Type-check results
+- <Output of `npx tsc --noEmit`>
+## Open questions for the reviewer
+- <Anything ambiguous in the plan you resolved one way and want the human to confirm>

--- a/.fdsx/workflows/full-impl-ui/workflow.yaml
+++ b/.fdsx/workflows/full-impl-ui/workflow.yaml
@@ -1,10 +1,11 @@
 name: full-impl-ui
 description: >
-  Full pipeline for TypeScript projects: plan -> implement -> parallel review
+  Full pipeline for TypeScript projects: plan -> test-implement (TDD) ->
+  human gate (approve / feedback loop) -> implement -> parallel review
   (code quality + security) -> replan (routes by complexity) -> fix-simple
   (cheap model, escalates to fix-complex on failure) / fix-complex (capable
   model) -> finalize with PR creation.
-version: "1.0"
+version: "1.1"
 start_at: plan
 max_loop: 25
 
@@ -31,11 +32,95 @@ states:
       - variable: $.plan_decision
         operator: equals
         value: "STEP:1"
-        next: implement
+        next: test_implement
     default: abort_blocked
 
   # ──────────────────────────────────────────────
-  # 2. Implementation (OpenCode / minimax-m2.7)
+  # 2a. Test Implementation (TDD — Claude / smarty)
+  # ──────────────────────────────────────────────
+  test_implement:
+    type: task
+    profile: smarty
+    prompt_file: test-implement.md
+    result_path: $.test_implement_output
+    result_file: $.test_implement_ref
+    extract:
+      strategy: [keyword, regex]
+      pattern: "STEP:1|STEP:2"
+      result_path: $.test_implement_decision
+    retry: 2
+    next: test_implement_route
+
+  test_implement_route:
+    type: choice
+    choices:
+      - variable: $.test_implement_decision
+        operator: equals
+        value: "STEP:1"
+        next: human_gate
+    default: abort_error
+
+  # ──────────────────────────────────────────────
+  # 2b. Human gate — approve tests or request feedback
+  # ──────────────────────────────────────────────
+  human_gate:
+    type: wait
+    mode: prompt
+    message: |
+      Test implementation is ready for review.
+
+      Tests written in this iteration: {test_implement_ref}
+
+      To proceed to the implementation phase, select "approve".
+      To request changes, write your feedback to .fdsx/feedback.md
+      (relative to the repo root), then select "feedback". The feedback
+      will be applied to the tests and you will be asked again.
+    choices:
+      - approve
+      - feedback
+    result_path: $.gate_decision
+    next: human_gate_route
+
+  human_gate_route:
+    type: choice
+    choices:
+      - variable: $.gate_decision
+        operator: equals
+        value: "approve"
+        next: implement
+      - variable: $.gate_decision
+        operator: equals
+        value: "feedback"
+        next: apply_feedback
+    default: abort_error
+
+  # ──────────────────────────────────────────────
+  # 2c. Apply human feedback to the tests, then loop back to gate
+  # ──────────────────────────────────────────────
+  apply_feedback:
+    type: task
+    profile: smarty
+    prompt_file: apply-feedback.md
+    result_path: $.feedback_output
+    result_file: $.feedback_ref
+    extract:
+      strategy: [keyword, regex]
+      pattern: "STEP:1|STEP:2"
+      result_path: $.apply_feedback_decision
+    retry: 2
+    next: apply_feedback_route
+
+  apply_feedback_route:
+    type: choice
+    choices:
+      - variable: $.apply_feedback_decision
+        operator: equals
+        value: "STEP:1"
+        next: human_gate
+    default: abort_error              # STEP:2 or missing tag → abort
+
+  # ──────────────────────────────────────────────
+  # 3. Implementation (OpenCode / minimax-m2.7)
   # ──────────────────────────────────────────────
   implement:
     type: task
@@ -60,7 +145,7 @@ states:
     default: abort_error
 
   # ──────────────────────────────────────────────
-  # 3. Parallel Review (Codex / gpt-5.4)
+  # 4. Parallel Review (Codex / gpt-5.4)
   # ──────────────────────────────────────────────
   parallel_review:
     type: parallel
@@ -89,7 +174,7 @@ states:
     next: aggregate_reviews
 
   # ──────────────────────────────────────────────
-  # 3b. Aggregate review results
+  # 4b. Aggregate review results
   # ──────────────────────────────────────────────
   aggregate_reviews:
     type: pass
@@ -112,7 +197,7 @@ states:
     default: replan
 
   # ──────────────────────────────────────────────
-  # 4. Replan (Claude — analyze review feedback, classify complexity, route)
+  # 5. Replan (Claude — analyze review feedback, classify complexity, route)
   # ──────────────────────────────────────────────
   replan:
     type: task
@@ -142,7 +227,7 @@ states:
     default: abort_design_issues
 
   # ──────────────────────────────────────────────
-  # 5a. Fix — simple (OpenCode / minimax, cheap)
+  # 6a. Fix — simple (OpenCode / minimax, cheap)
   # ──────────────────────────────────────────────
   fix_simple:
     type: task
@@ -175,7 +260,7 @@ states:
     default: fix_complex
 
   # ──────────────────────────────────────────────
-  # 5b. Fix — complex (Claude / sonnet, capable)
+  # 6b. Fix — complex (Claude / sonnet, capable)
   # ──────────────────────────────────────────────
   fix_complex:
     type: task
@@ -204,7 +289,7 @@ states:
     default: abort_fix_failed
 
   # ──────────────────────────────────────────────
-  # 6. Finalize (Claude — commit, push, PR)
+  # 7. Finalize (Claude — commit, push, PR)
   # ──────────────────────────────────────────────
   finalize:
     type: task

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ specs/
 # fdsx-ui package
 packages/fdsx-ui/node_modules/
 packages/fdsx-ui/dist/
+
+.tmp/

--- a/packages/fdsx-ui/npm-shrinkwrap.json
+++ b/packages/fdsx-ui/npm-shrinkwrap.json
@@ -100,7 +100,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -450,7 +449,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -474,7 +472,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1450,7 +1447,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1675,7 +1673,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1686,7 +1683,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1933,6 +1929,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1943,6 +1940,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2047,7 +2045,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2357,7 +2354,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2539,7 +2535,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3219,7 +3216,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -3304,6 +3300,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3567,7 +3564,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3610,6 +3606,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3686,7 +3683,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3696,7 +3692,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3709,7 +3704,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4818,7 +4814,6 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",


### PR DESCRIPTION
## Summary
- Add a TDD-first stage to the `full-impl-ui` workflow: a new `test_implement` task writes failing tests before implementation, gated by a `human_gate` wait state that lets the reviewer approve or loop through `apply_feedback` to revise the tests.
- Configure `task_splitter.extra_instructions` so each split task is a complete red-green-refactor cycle (write test + implement + verify) rather than a tests-only or implementation-only slice.
- Ignore `.tmp/` and absorb an `npm install` peer-flag reshuffle in `packages/fdsx-ui/npm-shrinkwrap.json`.

## Test plan
- [ ] Run `full-impl-ui` end-to-end and confirm the flow routes `plan -> test_implement -> human_gate` and waits for human input.
- [ ] In `human_gate`, select `feedback` with `.fdsx/feedback.md` populated and confirm `apply_feedback` runs and returns to `human_gate`.
- [ ] In `human_gate`, select `approve` and confirm the flow advances to `implement` and through the rest of the pipeline.
- [ ] Confirm `task_splitter` produces TDD-shaped tasks (each task contains test + impl + verify), not test-only or impl-only tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)