### PR TITLE
fix(fdsx-ui): collapse ChoiceNode to single-layer diamond

### DIFF
--- a/packages/fdsx-ui/npm-shrinkwrap.json
+++ b/packages/fdsx-ui/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "fdsx-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fdsx-ui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "1.1.8",
@@ -2875,7 +2875,7 @@
       }
     },
     "node_modules/forwarded": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",

--- a/packages/fdsx-ui/package.json
+++ b/packages/fdsx-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdsx-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "description": "Standalone web UI for visualizing fdsx workflow YAML files as interactive directed graphs",
   "license": "MIT",

--- a/packages/fdsx-ui/src/client/components/nodes/ChoiceNode.tsx
+++ b/packages/fdsx-ui/src/client/components/nodes/ChoiceNode.tsx
@@ -7,18 +7,16 @@ export function ChoiceNode({ data }: NodeProps<GraphNode>) {
     <>
       <Handle type="target" position={Position.Top} />
       <div
-        className={`${styles.diamondOuter} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}
+        className={`${styles.diamond} ${data.isStart ? styles.startNode : data.isEnd ? styles.endNode : ''}`}
       >
-        <div className={styles.diamondInner}>
-          <p className={styles.nodeLabel}>
-            {data.isStart ? (
-              <span className={styles.nodeIcon}>▶</span>
-            ) : data.isEnd ? (
-              <span className={styles.nodeIcon}>■</span>
-            ) : null}
-            {data.label}
-          </p>
-        </div>
+        <p className={styles.nodeLabel}>
+          {data.isStart ? (
+            <span className={styles.nodeIcon}>▶</span>
+          ) : data.isEnd ? (
+            <span className={styles.nodeIcon}>■</span>
+          ) : null}
+          {data.label}
+        </p>
       </div>
       <Handle type="source" position={Position.Bottom} />
     </>

--- a/packages/fdsx-ui/src/client/styles/nodes.module.css
+++ b/packages/fdsx-ui/src/client/styles/nodes.module.css
@@ -32,39 +32,23 @@
   white-space: nowrap;
 }
 
-.diamondOuter {
+.diamond {
   clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-  padding: 2px;
-  background-color: #d97706;
-  width: 120px;
-  min-height: 80px;
-  display: flex;
-}
-
-.diamondInner {
-  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-  flex: 1;
-  padding: 18px 28px;
   background-color: #fef3c7;
+  width: 140px;
+  height: 90px;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
+  padding: 0 24px;
+  box-sizing: border-box;
 }
 
-.diamondOuter.startNode {
-  background-color: #4f46e5;
-}
-
-.diamondOuter.startNode .diamondInner {
+.diamond.startNode {
   background-color: #eef2ff;
 }
 
-.diamondOuter.endNode {
-  background-color: #e11d48;
-}
-
-.diamondOuter.endNode .diamondInner {
+.diamond.endNode {
   background-color: #fff1f2;
 }
 
@@ -113,26 +97,26 @@
   box-shadow: 0 0 0 4px rgba(225, 29, 72, 0.4);
 }
 
-:global(.react-flow__node:hover) .diamondOuter {
+:global(.react-flow__node:hover) .diamond {
   filter: drop-shadow(0 0 3px rgba(217, 119, 6, 0.45));
 }
 
-:global(.react-flow__node.selected) .diamondOuter {
+:global(.react-flow__node.selected) .diamond {
   filter: drop-shadow(0 0 5px rgba(217, 119, 6, 0.7));
 }
 
-:global(.react-flow__node:hover) .diamondOuter.startNode {
+:global(.react-flow__node:hover) .diamond.startNode {
   filter: drop-shadow(0 0 3px rgba(79, 70, 229, 0.45));
 }
 
-:global(.react-flow__node.selected) .diamondOuter.startNode {
+:global(.react-flow__node.selected) .diamond.startNode {
   filter: drop-shadow(0 0 5px rgba(79, 70, 229, 0.7));
 }
 
-:global(.react-flow__node:hover) .diamondOuter.endNode {
+:global(.react-flow__node:hover) .diamond.endNode {
   filter: drop-shadow(0 0 3px rgba(225, 29, 72, 0.45));
 }
 
-:global(.react-flow__node.selected) .diamondOuter.endNode {
+:global(.react-flow__node.selected) .diamond.endNode {
   filter: drop-shadow(0 0 5px rgba(225, 29, 72, 0.7));
 }

--- a/packages/fdsx-ui/tests/unit/node-types.test.tsx
+++ b/packages/fdsx-ui/tests/unit/node-types.test.tsx
@@ -144,7 +144,7 @@ describe('TaskNode', () => {
 });
 
 describe('ChoiceNode', () => {
-  it('renders label and has diamondOuter and diamondInner nested', () => {
+  it('renders label inside a single diamond element', () => {
     const props = makeNodeProps({
       label: 'Check Status',
       stateType: 'choice',
@@ -154,12 +154,10 @@ describe('ChoiceNode', () => {
     });
     const { container } = render(<ChoiceNode {...props} />);
     expect(screen.getByText('Check Status')).toBeInTheDocument();
-    expect(container.querySelector('.diamondOuter')).toBeTruthy();
-    expect(container.querySelector('.diamondInner')).toBeTruthy();
-    expect(container.querySelector('.diamondOuter .diamondInner')).toBeTruthy();
+    expect(container.querySelector('.diamond')).toBeTruthy();
   });
 
-  it('applies startNode class on diamondOuter when isStart is true', () => {
+  it('applies startNode class on diamond when isStart is true', () => {
     const props = makeNodeProps({
       label: 'Start Decision',
       stateType: 'choice',
@@ -168,10 +166,10 @@ describe('ChoiceNode', () => {
       state: { type: 'choice' },
     });
     const { container } = render(<ChoiceNode {...props} />);
-    expect(container.querySelector('.diamondOuter.startNode')).toBeTruthy();
+    expect(container.querySelector('.diamond.startNode')).toBeTruthy();
   });
 
-  it('applies endNode class on diamondOuter when isEnd is true', () => {
+  it('applies endNode class on diamond when isEnd is true', () => {
     const props = makeNodeProps({
       label: 'End Decision',
       stateType: 'choice',
@@ -180,8 +178,8 @@ describe('ChoiceNode', () => {
       state: { type: 'choice' },
     });
     const { container } = render(<ChoiceNode {...props} />);
-    expect(container.querySelector('.diamondOuter.endNode')).toBeTruthy();
-    expect(container.querySelector('.diamondOuter.startNode')).toBeFalsy();
+    expect(container.querySelector('.diamond.endNode')).toBeTruthy();
+    expect(container.querySelector('.diamond.startNode')).toBeFalsy();
   });
 
   it('startNode wins when both isStart and isEnd are true', () => {
@@ -193,8 +191,8 @@ describe('ChoiceNode', () => {
       state: { type: 'choice' },
     });
     const { container } = render(<ChoiceNode {...props} />);
-    expect(container.querySelector('.diamondOuter.startNode')).toBeTruthy();
-    expect(container.querySelector('.diamondOuter.endNode')).toBeFalsy();
+    expect(container.querySelector('.diamond.startNode')).toBeTruthy();
+    expect(container.querySelector('.diamond.endNode')).toBeFalsy();
   });
 
   it('does not apply role class when neither flag is set', () => {


### PR DESCRIPTION
## Summary
- Drop the `.diamondOuter` + `.diamondInner` two-layer clip-path setup in `ChoiceNode` and replace it with a single `.diamond` element.
- Fixes the asymmetric orange-triangle fill that appeared when a nowrap label expanded the inner div past the outer's fixed width — the inner clip-path was being computed against the wider box and then re-clipped by the outer diamond.
- Update `node-types.test.tsx` to assert the single-element structure.

## Test plan
- [x] `npx vitest run` (154 passed, 0 failed)
- [ ] Visually verify a long-labeled choice node renders as a clean diamond with no triangular fill artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)