### PR TITLE
fix(fdsx-ui): restore forwarded@0.2.0 in shrinkwrap to unblock v0.2.1 release

### DIFF
--- a/packages/fdsx-ui/npm-shrinkwrap.json
+++ b/packages/fdsx-ui/npm-shrinkwrap.json
@@ -2875,7 +2875,7 @@
       }
     },
     "node_modules/forwarded": {
-      "version": "0.2.1",
+      "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",


### PR DESCRIPTION
## Summary
- The release commit on PR #62 accidentally bumped the transitive `forwarded` dependency from `0.2.0` to `0.2.1`. `forwarded@0.2.1` does not exist on npm, so `npm ci` failed in the `publish-fdsx-ui` workflow with `ETARGET notarget No matching version found for forwarded@0.2.1`.
- This restores `node_modules/forwarded` to `0.2.0` in `npm-shrinkwrap.json`. fdsx-ui itself stays at `0.2.1` — only the unrelated transitive entry is reverted.

## Release follow-up
- `fdsx-ui@0.2.1` was **not** published (workflow failed before `npm publish`), so the `fdsx-ui-v0.2.1` tag can be safely moved to the merge commit of this PR after merge.

## Test plan
- [ ] Merge, then move tag: `git tag -f fdsx-ui-v0.2.1 <merge-sha> && git push --force origin fdsx-ui-v0.2.1`
- [ ] Verify `publish-fdsx-ui` workflow succeeds and `fdsx-ui@0.2.1` appears on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)