### PR TITLE
feat(workflow): add STEP:3 escape hatch when TDD is not applicable

### DIFF
--- a/.fdsx/workflows/full-impl/test-implement.md
+++ b/.fdsx/workflows/full-impl/test-implement.md
@@ -22,6 +22,11 @@ Follow the `/tdd` skill for what counts as a good test (behavior over implementa
 ## Routing
 - Tests written and failing for the right reason → `[STEP:1]`
 - Plan unworkable / tooling broken → `[STEP:2]`
+- TDD genuinely not applicable → `[STEP:3]` (skip RED, go straight to implement). All three must hold:
+  1. The plan changes only non-executable artifacts (prompts, docs, configs without behavior, generated assets) — no functions, classes, or modules under test.
+  2. The plan itself states no automated test harness exists or lists "automated tests" as out of scope.
+  3. The behaviors in the plan are LLM prompt-following / human-rubric checks, not assertions a test runner could make.
+  State each of the three conditions explicitly in your output before emitting `[STEP:3]`.
 
 ## Output (use these headings)
 - **Behaviors covered** — one line each

--- a/.fdsx/workflows/simple-impl/test-implement.md
+++ b/.fdsx/workflows/simple-impl/test-implement.md
@@ -22,6 +22,11 @@ Follow the `/tdd` skill for what counts as a good test (behavior over implementa
 ## Routing
 - Tests written and failing for the right reason → `[STEP:1]`
 - Plan unworkable / tooling broken → `[STEP:2]`
+- TDD genuinely not applicable → `[STEP:3]` (skip RED, go straight to implement). All three must hold:
+  1. The plan changes only non-executable artifacts (prompts, docs, configs without behavior, generated assets) — no functions, classes, or modules under test.
+  2. The plan itself states no automated test harness exists or lists "automated tests" as out of scope.
+  3. The behaviors in the plan are LLM prompt-following / human-rubric checks, not assertions a test runner could make.
+  State each of the three conditions explicitly in your output before emitting `[STEP:3]`.
 
 ## Output (use these headings)
 - **Behaviors covered** — one line each


### PR DESCRIPTION
## Summary
- Adds a third routing branch to the `test-implement` step in both `full-impl` and `simple-impl` workflows so the workflow can skip RED when TDD genuinely doesn't apply.
- The escape hatch requires all three conditions to be stated explicitly before emitting `[STEP:3]`: non-executable artifacts only, no automated test harness in scope, and behaviors that are LLM/human-rubric checks rather than runner assertions.

## Test plan
- [ ] Dry-run a plan that targets only prompt/doc edits and confirm the workflow emits `[STEP:3]` after stating the three conditions.
- [ ] Dry-run a plan that touches executable code and confirm it still routes through `[STEP:1]` (RED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)