### PR TITLE
feat: Add operator visibility for LLM fallback invocations

### DIFF
--- a/src/fdsx/data/skills/fdsx/SKILL.md
+++ b/src/fdsx/data/skills/fdsx/SKILL.md
@@ -149,6 +149,38 @@ extraction_fallback:
 extraction_fallback: false
 ```
 
+```yaml
+# Workflow that disables the inherited global fallback but keeps a per-rule override:
+name: review-workflow
+extraction_fallback: false        # global config-level fallback suppressed for this workflow
+start_at: classify
+states:
+  classify:
+    type: task
+    provider: claude
+    prompt_template: "Classify the output"
+    result_path: "$.task_result"
+    extract:
+      strategy: [keyword]
+      pattern: "APPROVED|REJECTED"
+      result_path: "$.decision"
+      # no fallback: — disable wins, no LLM recovery attempted
+    end: true
+  classify_with_recovery:
+    type: task
+    provider: claude
+    prompt_template: "Classify the output"
+    result_path: "$.task_result"
+    extract:
+      strategy: [keyword]
+      pattern: "APPROVED|REJECTED"
+      result_path: "$.decision"
+      fallback:                    # per-rule fallback fires normally despite workflow disable
+        provider: claude
+        prompt: "Classify as APPROVED or REJECTED: {output}"
+    end: true
+```
+
 `ExtractionFallback` fields:
 - `provider` — LLM provider (`claude`, `codex`, `opencode`, `gemini`; `system` is forbidden). XOR with `profile`.
 - `profile` — named profile. XOR with `provider`. Exactly one of `provider` or `profile` must be set.

--- a/tests/integration/test_extraction_fallback_workflow_disable.py
+++ b/tests/integration/test_extraction_fallback_workflow_disable.py
@@ -1,0 +1,144 @@
+"""Integration tests for per-workflow extraction_fallback disable (T004)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.core.compiler import compile_flow
+from fdsx.core.config import FdsxConfig
+from fdsx.models.flow import (
+    ExtractionFallback,
+    ExtractRule,
+    Flow,
+    LLMClassifyFallback,
+    TaskState,
+)
+from fdsx.providers.base import ProviderResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MODEL = "claude-sonnet-4-5"
+_CODEX_MODEL = "gpt-4o"
+
+_NO_MATCH = ProviderResult(exit_code=0, stdout="processing complete", stderr="")
+_APPROVED = ProviderResult(exit_code=0, stdout="APPROVED", stderr="")
+
+
+def _flow(
+    extraction_fallback: ExtractionFallback | bool | None = None,
+    per_rule_fallback: LLMClassifyFallback | None = None,
+    profiles: dict | None = None,
+) -> Flow:
+    """Single claude task with keyword extraction that always misses."""
+    ef = False if extraction_fallback is False else extraction_fallback
+
+    return Flow(
+        name="test_workflow_disable",
+        description="Test per-workflow extraction_fallback disable",
+        start_at="step1",
+        profiles=profiles,
+        extraction_fallback=ef,  # type: ignore[arg-type]
+        states={
+            "step1": TaskState(
+                type="task",
+                provider="claude",
+                model=_MODEL,
+                prompt_template="classify the output",
+                result_path="$.task_result",
+                extract=ExtractRule(
+                    strategy=["keyword"],
+                    pattern="APPROVED|REJECTED",
+                    result_path="$.decision",
+                    fallback=per_rule_fallback,
+                ),
+                retry=0,
+                end=True,
+            )
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# T004-1: flow.extraction_fallback = false disables config-level default
+# ---------------------------------------------------------------------------
+
+
+class TestDisableSuppressesGlobalDefault:
+    def test_false_disables_config_fallback(self):
+        flow = _flow(extraction_fallback=False)
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        with patch(
+            "fdsx.providers.claude._run_subprocess",
+            return_value=_NO_MATCH,
+        ) as mock_claude:
+            compiled = compile_flow(flow, config=config)
+            with pytest.raises(RuntimeError, match="Extraction failed"):
+                compiled.graph.invoke({})
+
+        assert mock_claude.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# T004-2: Per-rule explicit fallback fires even when workflow disables
+# ---------------------------------------------------------------------------
+
+
+class TestPerRuleStillFiresWhenDisabled:
+    def test_per_rule_fallback_fires_despite_workflow_disable(self):
+        flow = _flow(
+            extraction_fallback=False,
+            per_rule_fallback=LLMClassifyFallback(
+                provider="claude",
+                prompt="Classify as APPROVED or REJECTED: {output}",
+            ),
+        )
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+
+        claude_responses = [_NO_MATCH, _APPROVED]
+
+        with (
+            patch(
+                "fdsx.providers.claude._run_subprocess",
+                side_effect=claude_responses,
+            ) as mock_claude,
+            patch("fdsx.providers.codex._run_subprocess") as mock_codex,
+        ):
+            compiled = compile_flow(flow, config=config)
+            result = compiled.graph.invoke({})
+
+        assert result.get("decision") == "APPROVED"
+        assert mock_claude.call_count == 2
+        mock_codex.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# T004-3: Removing the disable restores inheritance of the config default
+# ---------------------------------------------------------------------------
+
+
+class TestRemovingDisableRestoresInheritance:
+    def test_toggling_disable_off_restores_global_default(self):
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        # Phase A — disabled: extraction fails
+        with patch(
+            "fdsx.providers.claude._run_subprocess",
+            return_value=_NO_MATCH,
+        ) as mock_claude:
+            compiled = compile_flow(_flow(extraction_fallback=False), config=config)
+            with pytest.raises(RuntimeError, match="Extraction failed"):
+                compiled.graph.invoke({})
+        assert mock_claude.call_count == 1
+
+        # Phase B — disable removed: global default fires
+        with patch(
+            "fdsx.providers.claude._run_subprocess",
+            side_effect=[_NO_MATCH, _APPROVED],
+        ) as mock_claude:
+            compiled = compile_flow(_flow(extraction_fallback=None), config=config)
+            result = compiled.graph.invoke({})
+        assert result.get("decision") == "APPROVED"
+        assert mock_claude.call_count == 2

--- a/tests/integration/test_extraction_fallback_workflow_override.py
+++ b/tests/integration/test_extraction_fallback_workflow_override.py
@@ -7,8 +7,6 @@ extra_instructions, and that per-rule fallback still beats workflow override.
 
 from unittest.mock import patch
 
-import pytest
-
 from fdsx.core.compiler import compile_flow
 from fdsx.core.config import FdsxConfig
 from fdsx.models.flow import (
@@ -38,7 +36,7 @@ def _flow(
     per_rule_fallback: LLMClassifyFallback | None = None,
 ) -> Flow:
     """Single claude task with keyword extraction that always misses."""
-    ef = False if extraction_fallback is False else extraction_fallback
+    ef = extraction_fallback
 
     return Flow(
         name="test_workflow_override",
@@ -301,27 +299,3 @@ class TestNoOverrideFallsBackToGlobal:
 
         assert result.get("decision") == "APPROVED"
         assert mock_claude.call_count == 2  # main task + global fallback
-
-
-# ---------------------------------------------------------------------------
-# T003-8: flow.extraction_fallback = false disables config-level fallback
-# ---------------------------------------------------------------------------
-
-
-class TestWorkflowOverrideFalseDisablesFallback:
-    def test_false_disables_config_fallback(self):
-        """When flow.extraction_fallback is False and strategies miss,
-        no LLM fallback is invoked — not even the config-level default.
-        The workflow raises RuntimeError (extraction failed)."""
-        flow = _flow(extraction_fallback=False)
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
-
-        with patch(
-            "fdsx.providers.claude._run_subprocess", return_value=_NO_MATCH
-        ) as mock_claude:
-            compiled = compile_flow(flow, config=config)
-            with pytest.raises(RuntimeError, match="Extraction failed"):
-                compiled.graph.invoke({})
-
-        # Only the main task call; no fallback call
-        assert mock_claude.call_count == 1

--- a/tests/unit/test_extraction_fallback.py
+++ b/tests/unit/test_extraction_fallback.py
@@ -198,6 +198,16 @@ class TestResolveFallback:
 
         assert result is None
 
+    def test_flow_disabled_with_rule_fallback_returns_rule(self):
+        from fdsx.core.extraction_fallback import resolve_fallback
+
+        rule = self._rule(with_fallback=True)  # has explicit LLMClassifyFallback
+        result = resolve_fallback(rule, self._flow(ef=False), self._cfg())
+
+        assert result is not None
+        assert result.source == "rule"
+        assert result.config is rule.fallback
+
     def test_flow_override_returns_workflow_source(self):
         from fdsx.core.extraction_fallback import ResolvedFallback, resolve_fallback
         from fdsx.models.flow import ExtractionFallback


### PR DESCRIPTION
## Summary

- Persist one record per fallback invocation in `run.json` under each state's `fallback_invocations` list
- Print one stderr line per invocation in format: `[state] ↩ fallback(<source>) → <outcome>`
- Instrument all three source paths (per-rule, workflow override, global) uniformly via an `on_fallback` callback threaded through `ExecutionConfig`

## What was done

### Core implementation

| File | Change |
|---|---|---|
| `src/fdsx/core/extraction_fallback.py` | Added `FallbackEvent` frozen dataclass. Renamed structlog event to `extraction_fallback_invoked`. Added `on_fallback` callback threading. |
| `src/fdsx/core/extraction.py` | Added `on_fallback` + `state_name` params to `extract_value` and `_execute_llm_fallback`. Built and invoked `FallbackEvent` at each terminal branch. |
| `src/fdsx/core/compiler/execution.py` | Added `on_fallback` field to `ExecutionConfig`. |
| `src/fdsx/core/compiler/nodes.py` | Built adapter closure in `_create_task_node`. |
| `src/fdsx/core/compiler/parallel.py` | Built per-branch adapter with `branch_index` curried. |
| `src/fdsx/core/compiler/map_iteration.py` | Built per-iteration adapter with `iter_index` curried. |
| `src/fdsx/logging/recorder.py` | Added `record_fallback_invocation` with thread-safe append and 200-char truncation. |
| `src/fdsx/display/terminal.py` | Added `display_fallback` function. |

### New tests

| File | Description |
|---|---|---|
| `tests/unit/test_recorder_fallback.py` | Unit tests for `record_fallback_invocation` |
| `tests/unit/test_extraction_fallback.py` | Extended with `on_fallback` assertions for all outcome paths |
| `tests/integration/test_extraction_fallback_audit.py` | 10+ integration scenarios |
| `tests/e2e/test_fallback_visibility_smoke.py` | E2E smoke test |

## How to test

```bash
uv run pytest tests/unit/test_recorder_fallback.py tests/unit/test_extraction_fallback.py tests/integration/test_extraction_fallback_audit.py tests/e2e/test_fallback_visibility_smoke.py -v
uv run pytest tests/ -v
uv run ruff check src/ tests/
uv run mypy src/
```
