### PR TITLE
Add operator visibility for LLM fallback invocations

### DIFF
--- a/src/fdsx/core/compiler/execution.py
+++ b/src/fdsx/core/compiler/execution.py
@@ -23,7 +23,7 @@ from fdsx.core.extraction import extract_value
 from fdsx.providers.base import ProviderBase, ProviderResult, get_provider
 
 if TYPE_CHECKING:
-    from fdsx.core.extraction_fallback import ResolvedFallback
+    from fdsx.core.extraction_fallback import FallbackEvent, ResolvedFallback
     from fdsx.logging.stream_logger import StreamLogger
     from fdsx.models.flow import ExtractRule
 
@@ -79,6 +79,7 @@ class ExecutionConfig:
     resolved_fallback: "ResolvedFallback | None" = None
     flow_profiles: "dict[str, dict[str, Any]] | None" = None
     config_profiles: "dict[str, dict[str, Any]] | None" = None
+    on_fallback: "Callable[[FallbackEvent], None] | None" = None
 
 
 @dataclass
@@ -172,6 +173,7 @@ def execute_with_retry(config: ExecutionConfig) -> ExecutionResult:
                         resolved_fallback=config.resolved_fallback,
                         flow_profiles=config.flow_profiles,
                         config_profiles=config.config_profiles,
+                        on_fallback=config.on_fallback,
                     )
                     if extracted is not None:
                         break

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from fdsx.core.extraction_fallback import resolve_fallback
+from fdsx.core.extraction_fallback import FallbackEvent, resolve_fallback
 from fdsx.core.variables import (
     resolve_jsonpath,
     resolve_template,
@@ -17,6 +17,7 @@ from fdsx.core.variables import (
 )
 from fdsx.display.terminal import (
     _sanitize_output,
+    display_fallback,
     display_map_complete,
     display_map_iteration,
     display_map_iteration_complete,
@@ -229,6 +230,26 @@ def _create_map_node(
                     if config is not None and config.profiles
                     else None
                 )
+
+                def _on_fallback(event: FallbackEvent, _idx: int = idx) -> None:
+                    if recorder is not None:
+                        recorder.record_fallback_invocation(
+                            state_name=state_name,
+                            source=event.source,
+                            outcome=event.outcome,
+                            pattern=event.pattern,
+                            value_preview=event.value_preview,
+                            error_kind=event.error_kind,
+                            iter_index=_idx,
+                        )
+                    display_fallback(
+                        state_name=state_name,
+                        source=event.source,
+                        outcome=event.outcome,
+                        value_preview=event.value_preview,
+                        error_kind=event.error_kind,
+                    )
+
                 exec_config = ExecutionConfig(
                     provider=provider,
                     provider_name=iter_state.provider,
@@ -244,6 +265,7 @@ def _create_map_node(
                     resolved_fallback=iter_resolved_fallback,
                     flow_profiles=getattr(flow, "profiles", None),
                     config_profiles=iter_config_profiles,
+                    on_fallback=_on_fallback,
                 )
                 exec_result = execute_with_retry(exec_config)
                 result = exec_result.result

--- a/src/fdsx/core/compiler/nodes.py
+++ b/src/fdsx/core/compiler/nodes.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from langgraph.types import interrupt
 
-from fdsx.core.extraction_fallback import resolve_fallback
+from fdsx.core.extraction_fallback import FallbackEvent, resolve_fallback
 from fdsx.core.variables import (
     resolve_template,
     resolve_template_shell_safe,
@@ -65,6 +65,24 @@ def _create_task_node(
         else None
     )
 
+    def _on_fallback(event: FallbackEvent) -> None:
+        if recorder is not None:
+            recorder.record_fallback_invocation(
+                state_name=state_name,
+                source=event.source,
+                outcome=event.outcome,
+                pattern=event.pattern,
+                value_preview=event.value_preview,
+                error_kind=event.error_kind,
+            )
+        terminal.display_fallback(
+            state_name=state_name,
+            source=event.source,
+            outcome=event.outcome,
+            value_preview=event.value_preview,
+            error_kind=event.error_kind,
+        )
+
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:
         from fdsx.core.compiler.execution import ExecutionConfig, execute_with_retry
         from fdsx.logging.stream_logger import StreamLogger
@@ -117,6 +135,7 @@ def _create_task_node(
             resolved_fallback=node_resolved_fallback,
             flow_profiles=node_flow_profiles,
             config_profiles=node_config_profiles,
+            on_fallback=_on_fallback,
         )
         exec_result = execute_with_retry(exec_config)
         result = exec_result.result

--- a/src/fdsx/core/compiler/parallel.py
+++ b/src/fdsx/core/compiler/parallel.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from langgraph.types import Send
 
-from fdsx.core.extraction_fallback import resolve_fallback
+from fdsx.core.extraction_fallback import FallbackEvent, resolve_fallback
 from fdsx.core.variables import (
     resolve_template,
     resolve_template_shell_safe,
@@ -137,6 +137,26 @@ def _create_branch_executor(
             if config is not None and config.profiles
             else None
         )
+
+        def _on_fallback(event: FallbackEvent, _bi: int = branch_index) -> None:
+            if recorder is not None:
+                recorder.record_fallback_invocation(
+                    state_name=state_name,
+                    source=event.source,
+                    outcome=event.outcome,
+                    pattern=event.pattern,
+                    value_preview=event.value_preview,
+                    error_kind=event.error_kind,
+                    branch_index=_bi,
+                )
+            terminal.display_fallback(
+                state_name=state_name,
+                source=event.source,
+                outcome=event.outcome,
+                value_preview=event.value_preview,
+                error_kind=event.error_kind,
+            )
+
         exec_config = ExecutionConfig(
             provider=provider,
             provider_name=branch.provider,
@@ -152,6 +172,7 @@ def _create_branch_executor(
             resolved_fallback=branch_resolved_fallback,
             flow_profiles=getattr(flow, "profiles", None),
             config_profiles=branch_config_profiles,
+            on_fallback=_on_fallback,
         )
         exec_result = execute_with_retry(exec_config)
         result = exec_result.result

--- a/src/fdsx/core/extraction.py
+++ b/src/fdsx/core/extraction.py
@@ -1,13 +1,20 @@
 import json
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
-from fdsx.core.extraction_fallback import ResolvedFallback, execute_default_fallback
+from fdsx.core.extraction_fallback import (
+    FallbackEvent,
+    ResolvedFallback,
+    execute_default_fallback,
+)
 from fdsx.core.profiles import merge_profiles
 from fdsx.models.flow import ExtractionFallback, ExtractRule, LLMClassifyFallback
+
+if TYPE_CHECKING:
+    pass
 
 log = structlog.get_logger(__name__)
 
@@ -21,6 +28,8 @@ def extract_value(
     resolved_fallback: ResolvedFallback | None = None,
     flow_profiles: dict[str, dict[str, Any]] | None = None,
     config_profiles: dict[str, dict[str, Any]] | None = None,
+    on_fallback: Callable[[FallbackEvent], None] | None = None,
+    state_name: str = "",
 ) -> Any | None:
     """Extract a value from output using the specified extraction rule.
 
@@ -69,7 +78,12 @@ def extract_value(
             extract_rule.pattern if "keyword" in extract_rule.strategy else None
         )
         return _execute_llm_fallback(
-            output, extract_rule.fallback, provider_factory, pattern=validation_pattern
+            output,
+            extract_rule.fallback,
+            provider_factory,
+            pattern=validation_pattern,
+            on_fallback=on_fallback,
+            state_name=state_name,
         )
 
     if (
@@ -85,6 +99,8 @@ def extract_value(
             merged,
             source_provider or "",
             provider_factory,
+            on_fallback=on_fallback,
+            state_name=state_name,
         )
 
     return None
@@ -287,6 +303,8 @@ def _execute_llm_fallback(
     fallback: LLMClassifyFallback,
     provider_factory: Callable[[str], Any] | None,
     pattern: str | None = None,
+    on_fallback: Callable[[FallbackEvent], None] | None = None,
+    state_name: str = "",
 ) -> str | None:
     """Execute LLM-based classification fallback.
 
@@ -297,6 +315,8 @@ def _execute_llm_fallback(
         pattern: Optional pipe-delimited keywords to validate LLM output against.
                  If provided, the LLM response must exactly match one of the keywords
                  (case-insensitive); unrecognised responses are rejected.
+        on_fallback: Optional callback invoked once per terminal outcome.
+        state_name: Name of the calling state (for the FallbackEvent).
 
     Returns:
         The classification result, or None if the LLM call failed or the result
@@ -307,9 +327,28 @@ def _execute_llm_fallback(
     if fallback.provider == "system":
         return None  # system provider not allowed for LLM classification (defense-in-depth)
 
+    _pattern_str = pattern or ""
+
     try:
         provider = provider_factory(fallback.provider)
     except Exception:
+        log.info(
+            "extraction_fallback_invoked",
+            source="rule",
+            outcome="error",
+            error_kind="provider_init_failed",
+            state_name=state_name,
+        )
+        if on_fallback:
+            on_fallback(
+                FallbackEvent(
+                    source="rule",
+                    outcome="error",
+                    state_name=state_name,
+                    pattern=_pattern_str,
+                    error_kind="provider_init_failed",
+                )
+            )
         return None
 
     prompt = fallback.prompt.replace("{output}", output)
@@ -324,18 +363,104 @@ def _execute_llm_fallback(
             output_callback=None,
         )
 
-        if result.exit_code == 0:
-            llm_output = result.stdout.strip()
-            if pattern:
-                keywords = pattern.split("|")
-                llm_lower = llm_output.lower()
-                for keyword in keywords:
-                    if keyword.lower() == llm_lower:
-                        return keyword
-                return None  # LLM output not in allowed set
-            return llm_output
+        if result.exit_code != 0:
+            log.info(
+                "extraction_fallback_invoked",
+                source="rule",
+                outcome="error",
+                error_kind="non_zero_exit",
+                state_name=state_name,
+            )
+            if on_fallback:
+                on_fallback(
+                    FallbackEvent(
+                        source="rule",
+                        outcome="error",
+                        state_name=state_name,
+                        pattern=_pattern_str,
+                        error_kind="non_zero_exit",
+                    )
+                )
+            return None
+
+        llm_output = result.stdout.strip()
+        if pattern:
+            keywords = pattern.split("|")
+            llm_lower = llm_output.lower()
+            for keyword in keywords:
+                if keyword.lower() == llm_lower:
+                    log.info(
+                        "extraction_fallback_invoked",
+                        source="rule",
+                        outcome="recovered",
+                        value_preview=keyword,
+                        state_name=state_name,
+                    )
+                    if on_fallback:
+                        on_fallback(
+                            FallbackEvent(
+                                source="rule",
+                                outcome="recovered",
+                                state_name=state_name,
+                                pattern=_pattern_str,
+                                value_preview=keyword,
+                            )
+                        )
+                    return keyword
+            log.info(
+                "extraction_fallback_invoked",
+                source="rule",
+                outcome="rejected",
+                value_preview=llm_output,
+                state_name=state_name,
+            )
+            if on_fallback:
+                on_fallback(
+                    FallbackEvent(
+                        source="rule",
+                        outcome="rejected",
+                        state_name=state_name,
+                        pattern=_pattern_str,
+                        value_preview=llm_output,
+                    )
+                )
+            return None
+        log.info(
+            "extraction_fallback_invoked",
+            source="rule",
+            outcome="recovered",
+            value_preview=llm_output,
+            state_name=state_name,
+        )
+        if on_fallback:
+            on_fallback(
+                FallbackEvent(
+                    source="rule",
+                    outcome="recovered",
+                    state_name=state_name,
+                    pattern=_pattern_str,
+                    value_preview=llm_output,
+                )
+            )
+        return llm_output
 
     except Exception:
-        pass
+        log.info(
+            "extraction_fallback_invoked",
+            source="rule",
+            outcome="error",
+            error_kind="provider_call_failed",
+            state_name=state_name,
+        )
+        if on_fallback:
+            on_fallback(
+                FallbackEvent(
+                    source="rule",
+                    outcome="error",
+                    state_name=state_name,
+                    pattern=_pattern_str,
+                    error_kind="provider_call_failed",
+                )
+            )
 
     return None

--- a/src/fdsx/core/extraction_fallback.py
+++ b/src/fdsx/core/extraction_fallback.py
@@ -15,7 +15,24 @@ if TYPE_CHECKING:
 
 log = structlog.get_logger(__name__)
 
-__all__ = ["ResolvedFallback", "execute_default_fallback", "resolve_fallback"]
+__all__ = [
+    "FallbackEvent",
+    "ResolvedFallback",
+    "execute_default_fallback",
+    "resolve_fallback",
+]
+
+
+@dataclass(frozen=True)
+class FallbackEvent:
+    source: str
+    outcome: str
+    state_name: str
+    pattern: str
+    value_preview: str | None = None
+    error_kind: str | None = None
+    branch_index: int | None = None
+    iter_index: int | None = None
 
 
 @dataclass(frozen=True)
@@ -110,6 +127,8 @@ def execute_default_fallback(
     merged_profiles: dict[str, dict[str, Any]],
     source_provider: str,
     provider_factory: Callable[[str], Any],
+    on_fallback: Callable[[FallbackEvent], None] | None = None,
+    state_name: str = "",
 ) -> str | None:
     config = cast(ExtractionFallback, resolved.config)
 
@@ -121,12 +140,21 @@ def execute_default_fallback(
         profile_data = merged_profiles.get(profile_name)
         if profile_data is None:
             log.info(
-                "default_fallback_invoked",
+                "extraction_fallback_invoked",
                 source=resolved.source,
                 strategy_list=rule.strategy,
                 outcome="error",
                 error="profile_not_found",
             )
+            event = FallbackEvent(
+                source=resolved.source,
+                outcome="error",
+                state_name=state_name,
+                pattern=rule.pattern,
+                error_kind="profile_not_found",
+            )
+            if on_fallback:
+                on_fallback(event)
             return None
         provider_name = profile_data["provider"]
         model = profile_data.get("model")
@@ -138,12 +166,21 @@ def execute_default_fallback(
         provider = provider_factory(provider_name)
     except Exception:
         log.info(
-            "default_fallback_invoked",
+            "extraction_fallback_invoked",
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="error",
             error="provider_init_failed",
         )
+        event = FallbackEvent(
+            source=resolved.source,
+            outcome="error",
+            state_name=state_name,
+            pattern=rule.pattern,
+            error_kind="provider_init_failed",
+        )
+        if on_fallback:
+            on_fallback(event)
         return None
 
     try:
@@ -152,31 +189,58 @@ def execute_default_fallback(
         )
     except (TimeoutError, subprocess.TimeoutExpired):
         log.info(
-            "default_fallback_invoked",
+            "extraction_fallback_invoked",
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="error",
             error="timeout",
         )
+        event = FallbackEvent(
+            source=resolved.source,
+            outcome="error",
+            state_name=state_name,
+            pattern=rule.pattern,
+            error_kind="timeout",
+        )
+        if on_fallback:
+            on_fallback(event)
         return None
     except Exception:
         log.info(
-            "default_fallback_invoked",
+            "extraction_fallback_invoked",
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="error",
             error="provider_call_failed",
         )
+        event = FallbackEvent(
+            source=resolved.source,
+            outcome="error",
+            state_name=state_name,
+            pattern=rule.pattern,
+            error_kind="provider_call_failed",
+        )
+        if on_fallback:
+            on_fallback(event)
         return None
 
     if result.exit_code != 0:
         log.info(
-            "default_fallback_invoked",
+            "extraction_fallback_invoked",
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="error",
             error="non_zero_exit",
         )
+        event = FallbackEvent(
+            source=resolved.source,
+            outcome="error",
+            state_name=state_name,
+            pattern=rule.pattern,
+            error_kind="non_zero_exit",
+        )
+        if on_fallback:
+            on_fallback(event)
         return None
 
     llm_output: str = result.stdout.strip()
@@ -184,12 +248,21 @@ def execute_default_fallback(
 
     if llm_output == "NONE":
         log.info(
-            "default_fallback_invoked",
+            "extraction_fallback_invoked",
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="rejected",
             reason="model_returned_none",
         )
+        event = FallbackEvent(
+            source=resolved.source,
+            outcome="rejected",
+            state_name=state_name,
+            pattern=rule.pattern,
+            value_preview=llm_output,
+        )
+        if on_fallback:
+            on_fallback(event)
         return None
 
     if "keyword" in rule.strategy:
@@ -198,24 +271,51 @@ def execute_default_fallback(
         for keyword in keywords:
             if keyword.lower() == llm_lower:
                 log.info(
-                    "default_fallback_invoked",
+                    "extraction_fallback_invoked",
                     source=resolved.source,
                     strategy_list=rule.strategy,
                     outcome="recovered",
                 )
+                event = FallbackEvent(
+                    source=resolved.source,
+                    outcome="recovered",
+                    state_name=state_name,
+                    pattern=rule.pattern,
+                    value_preview=keyword,
+                )
+                if on_fallback:
+                    on_fallback(event)
                 return keyword
         log.info(
-            "default_fallback_invoked",
+            "extraction_fallback_invoked",
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="rejected",
         )
+        event = FallbackEvent(
+            source=resolved.source,
+            outcome="rejected",
+            state_name=state_name,
+            pattern=rule.pattern,
+            value_preview=llm_output,
+        )
+        if on_fallback:
+            on_fallback(event)
         return None
 
     log.info(
-        "default_fallback_invoked",
+        "extraction_fallback_invoked",
         source=resolved.source,
         strategy_list=rule.strategy,
         outcome="recovered",
     )
+    event = FallbackEvent(
+        source=resolved.source,
+        outcome="recovered",
+        state_name=state_name,
+        pattern=rule.pattern,
+        value_preview=llm_output,
+    )
+    if on_fallback:
+        on_fallback(event)
     return llm_output

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -117,6 +117,25 @@ def display_state_error(state_name: str, error: str) -> None:
     print(f"  Error: {_sanitize_output(error)}", file=sys.stderr)
 
 
+def display_fallback(
+    state_name: str,
+    source: str,
+    outcome: str,
+    value_preview: str | None = None,
+    error_kind: str | None = None,
+) -> None:
+    state = _sanitize_output(state_name)
+    source_safe = _sanitize_output(source)
+    if outcome == "error":
+        outcome_text = f"error({error_kind})"
+    elif value_preview is not None:
+        preview = _sanitize_output(value_preview)
+        outcome_text = f"{outcome}: {preview}"
+    else:
+        outcome_text = outcome
+    print(f"[{state}] ↩ fallback({source_safe}) → {outcome_text}", file=sys.stderr)
+
+
 def display_output_line(line: str) -> None:
     """Display LLM output line to terminal.
 

--- a/src/fdsx/logging/recorder.py
+++ b/src/fdsx/logging/recorder.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,7 @@ class RunRecorder:
         self.completed_at: str | None = None
         self.final_variables: dict[str, Any] | None = None
         self._current_state: dict[str, Any] | None = None
+        self._lock: threading.Lock = threading.Lock()
 
     def record_state_start(self, state_name: str, state_type: str) -> None:
         """Append new state entry with name, type, started_at."""
@@ -123,6 +125,44 @@ class RunRecorder:
         state["variables_set"] = []
 
         self._current_state = None
+
+    def record_fallback_invocation(
+        self,
+        state_name: str,
+        source: str,
+        outcome: str,
+        pattern: str,
+        value_preview: str | None = None,
+        error_kind: str | None = None,
+        branch_index: int | None = None,
+        iter_index: int | None = None,
+    ) -> None:
+        """Append one fallback invocation record to the state's fallback_invocations list."""
+        record: dict[str, Any] = {
+            "source": source,
+            "outcome": outcome,
+            "state_name": state_name,
+            "pattern": pattern,
+        }
+        if value_preview is not None:
+            record["value_preview"] = value_preview[:200]
+        if error_kind is not None:
+            record["error_kind"] = error_kind
+        if branch_index is not None:
+            record["branch_index"] = branch_index
+        if iter_index is not None:
+            record["iter_index"] = iter_index
+
+        with self._lock:
+            state = self._find_state_by_name(state_name)
+            if state is None:
+                state = {
+                    "name": state_name,
+                    "type": "unknown",
+                    "started_at": datetime.now(timezone.utc).isoformat(),
+                }
+                self.states.append(state)
+            state.setdefault("fallback_invocations", []).append(record)
 
     def record_map_start(self, state_name: str, item_count: int) -> None:
         """Record map state start with item count metadata.

--- a/tests/e2e/test_fallback_visibility_smoke.py
+++ b/tests/e2e/test_fallback_visibility_smoke.py
@@ -1,0 +1,56 @@
+"""E2E smoke test for fallback visibility stderr output (T005)."""
+
+from unittest.mock import patch
+
+from fdsx.core.compiler import compile_flow
+from fdsx.core.config import FdsxConfig
+from fdsx.models.flow import ExtractionFallback, ExtractRule, Flow, TaskState
+from fdsx.providers.base import ProviderResult
+
+_MODEL = "claude-sonnet-4-5"
+
+
+class TestFallbackVisibilitySmoke:
+    def test_global_fallback_recovered_prints_stderr_line(self, capsys):
+        """Running a workflow whose extraction misses but global fallback recovers
+        exits cleanly and stderr contains ↩ fallback(global) → recovered:"""
+        flow = Flow(
+            name="fallback_smoke",
+            description="E2E smoke test for fallback visibility",
+            start_at="classify",
+            states={
+                "classify": TaskState(
+                    type="task",
+                    provider="claude",
+                    model=_MODEL,
+                    prompt_template="classify this output",
+                    result_path="$.task_result",
+                    extract=ExtractRule(
+                        strategy=["keyword"],
+                        pattern="APPROVED|REJECTED",
+                        result_path="$.decision",
+                    ),
+                    retry=0,
+                    end=True,
+                )
+            },
+        )
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        # Call 1: main task — output misses keyword
+        # Call 2: global fallback — returns APPROVED
+        responses = [
+            ProviderResult(exit_code=0, stdout="processing complete", stderr=""),
+            ProviderResult(exit_code=0, stdout="APPROVED", stderr=""),
+        ]
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config)
+            result = compiled.graph.invoke({})
+
+        assert result.get("decision") == "APPROVED"
+
+        captured = capsys.readouterr()
+        assert "↩ fallback(global) → recovered:" in captured.err, (
+            f"Expected fallback visibility line in stderr, got: {captured.err!r}"
+        )

--- a/tests/integration/test_extraction_fallback_audit.py
+++ b/tests/integration/test_extraction_fallback_audit.py
@@ -1,0 +1,431 @@
+"""Integration tests for extraction fallback audit records and stderr output (T005).
+
+Each test runs a compiled flow with mocked providers, then asserts on:
+  - recorder.states: whether fallback_invocations key is present and correct
+  - capsys.readouterr().err: whether ↩ fallback(...) → ... line appears
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.core.compiler import compile_flow
+from fdsx.core.config import FdsxConfig
+from fdsx.logging.recorder import RunRecorder
+from fdsx.models.flow import (
+    Branch,
+    ExtractionFallback,
+    ExtractRule,
+    Flow,
+    IteratorDef,
+    IteratorTaskState,
+    LLMClassifyFallback,
+    MapState,
+    ParallelState,
+    TaskState,
+)
+from fdsx.providers.base import ProviderResult
+
+_MODEL = "claude-sonnet-4-5"
+
+
+def _make_recorder() -> RunRecorder:
+    return RunRecorder(thread_id="audit-test-abc", flow_name="audit-test")
+
+
+def _keyword_rule() -> ExtractRule:
+    return ExtractRule(
+        strategy=["keyword"],
+        pattern="APPROVED|REJECTED",
+        result_path="$.decision",
+    )
+
+
+def _claude_task(state_name: str = "classify", end: bool = True) -> TaskState:
+    return TaskState(
+        type="task",
+        provider="claude",
+        model=_MODEL,
+        prompt_template="classify",
+        result_path="$.task_result",
+        extract=_keyword_rule(),
+        retry=0,
+        end=end,
+    )
+
+
+def _single_task_flow(
+    state_name: str = "classify",
+    extract_rule: ExtractRule | None = None,
+    extraction_fallback: ExtractionFallback | bool | None = None,
+) -> Flow:
+    rule = extract_rule or _keyword_rule()
+    task = TaskState(
+        type="task",
+        provider="claude",
+        model=_MODEL,
+        prompt_template="classify",
+        result_path="$.task_result",
+        extract=rule,
+        retry=0,
+        end=True,
+    )
+    kwargs: dict = dict(
+        name="audit_test",
+        description="audit test",
+        start_at=state_name,
+        states={state_name: task},
+    )
+    if extraction_fallback is not None:
+        kwargs["extraction_fallback"] = extraction_fallback
+    return Flow(**kwargs)
+
+
+class TestGlobalFallbackAudit:
+    def test_global_fallback_recovered_record_has_source_global(self, capsys):
+        """run.json state has source=global, outcome=recovered, value_preview set;
+        stderr contains ↩ fallback(global) → recovered:"""
+        recorder = _make_recorder()
+        flow = _single_task_flow()
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        responses = [
+            ProviderResult(exit_code=0, stdout="processing complete", stderr=""),
+            ProviderResult(exit_code=0, stdout="APPROVED", stderr=""),
+        ]
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" in state, (
+            f"Expected fallback_invocations in state keys, got: {list(state.keys())}"
+        )
+        records = state["fallback_invocations"]
+        assert len(records) == 1
+        record = records[0]
+        assert record["source"] == "global"
+        assert record["outcome"] == "recovered"
+        assert record.get("value_preview"), (
+            "value_preview should be non-empty on recovered"
+        )
+
+        captured = capsys.readouterr()
+        assert "↩ fallback(global) → recovered:" in captured.err, (
+            f"Expected fallback line in stderr, got: {captured.err!r}"
+        )
+
+
+class TestWorkflowOverrideAudit:
+    def test_workflow_override_record_has_source_workflow(self):
+        """When extraction_fallback is set on the flow (workflow level), record has source=workflow."""
+        recorder = _make_recorder()
+        flow = _single_task_flow(
+            extraction_fallback=ExtractionFallback(provider="claude")
+        )
+        # No global config fallback; flow-level override fires
+        config = FdsxConfig()
+
+        responses = [
+            ProviderResult(exit_code=0, stdout="missed", stderr=""),
+            ProviderResult(exit_code=0, stdout="APPROVED", stderr=""),
+        ]
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" in state
+        assert state["fallback_invocations"][0]["source"] == "workflow"
+
+
+class TestPerRuleFallbackAudit:
+    def test_per_rule_fallback_record_has_source_rule(self):
+        """Per-rule LLMClassifyFallback fires: record has source=rule."""
+        recorder = _make_recorder()
+        rule_with_fallback = ExtractRule(
+            strategy=["keyword"],
+            pattern="APPROVED|REJECTED",
+            result_path="$.decision",
+            fallback=LLMClassifyFallback(
+                provider="claude",
+                prompt="Please classify the following output as APPROVED or REJECTED.",
+            ),
+        )
+        flow = _single_task_flow(extract_rule=rule_with_fallback)
+        config = FdsxConfig()
+
+        responses = [
+            ProviderResult(exit_code=0, stdout="missed", stderr=""),
+            ProviderResult(exit_code=0, stdout="APPROVED", stderr=""),
+        ]
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" in state
+        assert state["fallback_invocations"][0]["source"] == "rule"
+
+
+class TestRejectedOutcomeAudit:
+    def test_rejected_outcome_has_no_error_kind(self):
+        """When fallback returns out-of-set value, outcome=rejected and no error_kind key."""
+        recorder = _make_recorder()
+        flow = _single_task_flow()
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        responses = [
+            ProviderResult(exit_code=0, stdout="missed", stderr=""),
+            ProviderResult(exit_code=0, stdout="MAYBE", stderr=""),
+        ]
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            with pytest.raises(RuntimeError):
+                compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" in state
+        record = state["fallback_invocations"][0]
+        assert record["outcome"] == "rejected"
+        assert "error_kind" not in record
+
+
+class TestTimeoutFallbackAudit:
+    def test_timeout_outcome_has_error_kind_timeout(self):
+        """When fallback provider times out, outcome=error, error_kind=timeout."""
+        recorder = _make_recorder()
+        flow = _single_task_flow()
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        stub_provider = MagicMock()
+        stub_provider.execute.side_effect = [
+            # First call: main task misses keyword (returned via normal subprocess mock)
+        ]
+
+        main_response = ProviderResult(exit_code=0, stdout="missed", stderr="")
+
+        call_count = 0
+
+        def side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return main_response
+            raise TimeoutError("timed out")
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=side_effect):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            with pytest.raises(RuntimeError):
+                compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" in state
+        record = state["fallback_invocations"][0]
+        assert record["outcome"] == "error"
+        assert record["error_kind"] == "timeout"
+
+
+class TestFallbackDisabledAudit:
+    def test_extraction_fallback_false_no_fallback_invocations(self):
+        """extraction_fallback: false on the flow disables fallback; key absent from state."""
+        recorder = _make_recorder()
+        flow = _single_task_flow(extraction_fallback=False)
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        responses = [
+            ProviderResult(exit_code=0, stdout="missed", stderr=""),
+        ]
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            with pytest.raises(RuntimeError):
+                compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" not in state, (
+            f"Expected no fallback_invocations when disabled, got: {state.get('fallback_invocations')}"
+        )
+
+
+class TestAllStrategiesHitAudit:
+    def test_strategies_succeed_no_fallback_invocations_key(self, capsys):
+        """When extraction succeeds on first try, fallback_invocations absent and no ↩ line in stderr."""
+        recorder = _make_recorder()
+        flow = _single_task_flow()
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+
+        main_response = ProviderResult(
+            exit_code=0, stdout="The decision is APPROVED", stderr=""
+        )
+        with (
+            patch("fdsx.providers.claude._run_subprocess", return_value=main_response),
+            patch("fdsx.providers.codex._run_subprocess") as mock_codex,
+        ):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            result = compiled.graph.invoke({})
+
+        mock_codex.assert_not_called()
+        assert result.get("decision") == "APPROVED"
+
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" not in state
+
+        captured = capsys.readouterr()
+        assert "↩ fallback" not in captured.err
+
+
+class TestSystemProviderMissAudit:
+    def test_system_provider_miss_no_record_and_no_stderr(self, capsys):
+        """System-provider state whose strategies miss: no fallback_invocations, no ↩ line."""
+        recorder = _make_recorder()
+        system_task = TaskState(
+            type="task",
+            provider="system",
+            command="echo 'unrelated output'",
+            result_path="$.task_result",
+            extract=_keyword_rule(),
+            end=True,
+        )
+        flow = Flow(
+            name="system_miss_test",
+            description="system provider guard test",
+            start_at="classify",
+            states={"classify": system_task},
+        )
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        with patch("fdsx.providers.claude._run_subprocess") as mock_claude:
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            with pytest.raises(RuntimeError):
+                compiled.graph.invoke({})
+
+        mock_claude.assert_not_called()
+        state = recorder._find_state_by_name("classify")
+        assert "fallback_invocations" not in state
+
+        captured = capsys.readouterr()
+        assert "↩ fallback" not in captured.err
+
+
+class TestMapStateFallbackAudit:
+    def test_map_iteration_fallback_record_has_iter_index(self):
+        """Map state where one iteration triggers fallback: record has iter_index set."""
+        recorder = _make_recorder()
+        iterator = IteratorDef(
+            states=[
+                IteratorTaskState(
+                    name="classify_item",
+                    provider="claude",
+                    model=_MODEL,
+                    prompt_template="classify item: {$.item}",
+                    result_path="$.item_decision",
+                    extract=_keyword_rule(),
+                    retry=0,
+                )
+            ]
+        )
+        map_state = MapState(
+            type="map",
+            items_path="$.items",
+            iterator=iterator,
+            result_path="$.map_results",
+            end=True,
+        )
+        flow = Flow(
+            name="map_fallback_test",
+            description="map fallback audit",
+            start_at="map_classify",
+            states={"map_classify": map_state},
+        )
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+
+        # item 0: main task matches → no fallback
+        # item 1: main task misses → fallback fires → REJECTED recovered
+        responses = [
+            ProviderResult(exit_code=0, stdout="APPROVED", stderr=""),
+            ProviderResult(exit_code=0, stdout="no keyword here", stderr=""),
+            ProviderResult(exit_code=0, stdout="REJECTED", stderr=""),
+        ]
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            compiled.graph.invoke({"items": ["item_a", "item_b"]})
+
+        state = recorder._find_state_by_name("map_classify")
+        assert "fallback_invocations" in state, (
+            f"Expected fallback_invocations for map state, got: {list(state.keys())}"
+        )
+        records = state["fallback_invocations"]
+        assert len(records) == 1
+        assert "iter_index" in records[0], (
+            f"Expected iter_index in record, got: {records[0]}"
+        )
+        assert records[0]["iter_index"] == 1
+
+
+class TestParallelBranchFallbackAudit:
+    def test_parallel_two_branches_fallback_records_have_distinct_branch_index(self):
+        """Parallel state where two branches trigger fallbacks: two records with distinct branch_index."""
+        recorder = _make_recorder()
+        parallel_state = ParallelState(
+            type="parallel",
+            branches=[
+                Branch(
+                    provider="claude",
+                    model=_MODEL,
+                    prompt_template="classify branch A",
+                    extract=ExtractRule(
+                        strategy=["keyword"],
+                        pattern="APPROVED|REJECTED",
+                        result_path="$.branch_a",
+                    ),
+                    retry=0,
+                ),
+                Branch(
+                    provider="claude",
+                    model=_MODEL,
+                    prompt_template="classify branch B",
+                    extract=ExtractRule(
+                        strategy=["keyword"],
+                        pattern="APPROVED|REJECTED",
+                        result_path="$.branch_b",
+                    ),
+                    retry=0,
+                ),
+            ],
+            result_path="$.parallel_results",
+            min_success=0,
+            end=True,
+        )
+        flow = Flow(
+            name="parallel_fallback_test",
+            description="parallel fallback audit",
+            start_at="parallel_classify",
+            states={"parallel_classify": parallel_state},
+        )
+        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+
+        missed = ProviderResult(exit_code=0, stdout="no keyword here", stderr="")
+        recovered = ProviderResult(exit_code=0, stdout="APPROVED", stderr="")
+
+        with (
+            patch("fdsx.providers.claude._run_subprocess", return_value=missed),
+            patch("fdsx.providers.codex._run_subprocess", return_value=recovered),
+        ):
+            compiled = compile_flow(flow, config=config, recorder=recorder)
+            compiled.graph.invoke({})
+
+        state = recorder._find_state_by_name("parallel_classify")
+        assert "fallback_invocations" in state, (
+            f"Expected fallback_invocations in parallel state, got: {list(state.keys())}"
+        )
+        records = state["fallback_invocations"]
+        assert len(records) == 2
+
+        branch_indices = {r.get("branch_index") for r in records}
+        assert len(branch_indices) == 2, (
+            f"Expected 2 distinct branch_index values, got: {branch_indices}"
+        )
+        assert None not in branch_indices, (
+            f"branch_index must be set on all records, got: {records}"
+        )

--- a/tests/unit/test_extraction_fallback.py
+++ b/tests/unit/test_extraction_fallback.py
@@ -691,3 +691,206 @@ class TestExecuteDefaultFallback:
         for entry in info_logs:
             assert entry.get("source") == resolved.source
             assert entry.get("strategy_list") == rule.strategy
+
+    # ------------------------------------------------------------------
+    # T005: on_fallback callback and structlog event rename
+    # ------------------------------------------------------------------
+
+    def test_on_fallback_called_once_on_recovered(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory, _ = _make_factory(stdout="APPROVED")
+        resolved = _make_resolved(provider="claude")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "recovered"
+        assert event.source == "global"
+
+    def test_on_fallback_called_once_on_rejected_keyword(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory, _ = _make_factory(stdout="MAYBE")
+        resolved = _make_resolved(provider="claude")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "rejected"
+
+    def test_on_fallback_called_once_on_model_returned_none(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory, _ = _make_factory(stdout="NONE")
+        resolved = _make_resolved(provider="claude")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "rejected"
+
+    def test_on_fallback_called_once_on_timeout(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        stub_provider = MagicMock()
+        stub_provider.execute.side_effect = TimeoutError("timed out")
+        factory = MagicMock(return_value=stub_provider)
+        resolved = _make_resolved(provider="claude")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "error"
+        assert event.error_kind == "timeout"
+
+    def test_on_fallback_called_once_on_provider_init_failed(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory = MagicMock(side_effect=RuntimeError("no binary"))
+        resolved = _make_resolved(provider="claude")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "error"
+        assert event.error_kind == "provider_init_failed"
+
+    def test_on_fallback_called_once_on_non_zero_exit(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory, _ = _make_factory(stdout="", exit_code=1)
+        resolved = _make_resolved(provider="claude")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "error"
+        assert event.error_kind == "non_zero_exit"
+
+    def test_on_fallback_called_once_on_profile_not_found(self):
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory, _ = _make_factory()
+        resolved = _make_resolved(profile="missing")
+        callback = MagicMock()
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.outcome == "error"
+        assert event.error_kind == "profile_not_found"
+
+    def test_structlog_event_renamed_to_extraction_fallback_invoked(self):
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import execute_default_fallback
+
+        factory, _ = _make_factory(stdout="APPROVED")
+        resolved = _make_resolved(provider="claude")
+        with structlog.testing.capture_logs() as logs:
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="system",
+                provider_factory=factory,
+            )
+        info_events = [e["event"] for e in logs if e["log_level"] == "info"]
+        assert any(e == "extraction_fallback_invoked" for e in info_events), (
+            f"Expected 'extraction_fallback_invoked' but got: {info_events}"
+        )
+        assert not any(e == "default_fallback_invoked" for e in info_events), (
+            f"Found deprecated 'default_fallback_invoked' in logs: {info_events}"
+        )

--- a/tests/unit/test_recorder_fallback.py
+++ b/tests/unit/test_recorder_fallback.py
@@ -1,0 +1,104 @@
+"""Unit tests for RunRecorder.record_fallback_invocation (T005 red phase)."""
+
+import threading
+
+from fdsx.logging.recorder import RunRecorder
+
+
+def _make_recorder() -> RunRecorder:
+    r = RunRecorder(thread_id="test-thread", flow_name="test-flow")
+    r.record_state_start("step1", "task")
+    return r
+
+
+class TestRecordFallbackInvocation:
+    def test_zero_invocations_no_key_in_state(self):
+        r = _make_recorder()
+        state = r._find_state_by_name("step1")
+        assert state is not None
+        assert "fallback_invocations" not in state
+
+    def test_one_invocation_creates_list_with_one_entry(self):
+        r = _make_recorder()
+        r.record_fallback_invocation(
+            state_name="step1",
+            source="global",
+            outcome="recovered",
+            pattern="APPROVED|REJECTED",
+            value_preview="APPROVED",
+        )
+        state = r._find_state_by_name("step1")
+        assert "fallback_invocations" in state
+        assert len(state["fallback_invocations"]) == 1
+        entry = state["fallback_invocations"][0]
+        assert entry["source"] == "global"
+        assert entry["outcome"] == "recovered"
+        assert entry["state_name"] == "step1"
+        assert entry["value_preview"] == "APPROVED"
+
+    def test_value_preview_truncated_to_200_chars(self):
+        r = _make_recorder()
+        long_value = "x" * 300
+        r.record_fallback_invocation(
+            state_name="step1",
+            source="global",
+            outcome="recovered",
+            pattern=".*",
+            value_preview=long_value,
+        )
+        state = r._find_state_by_name("step1")
+        entry = state["fallback_invocations"][0]
+        assert len(entry["value_preview"]) == 200
+
+    def test_no_branch_or_iter_index_when_not_supplied(self):
+        r = _make_recorder()
+        r.record_fallback_invocation(
+            state_name="step1",
+            source="global",
+            outcome="recovered",
+            pattern=".*",
+        )
+        state = r._find_state_by_name("step1")
+        entry = state["fallback_invocations"][0]
+        assert "branch_index" not in entry
+        assert "iter_index" not in entry
+
+    def test_no_error_kind_on_recovered_outcome_without_error(self):
+        r = _make_recorder()
+        r.record_fallback_invocation(
+            state_name="step1",
+            source="global",
+            outcome="recovered",
+            pattern="APPROVED|REJECTED",
+        )
+        state = r._find_state_by_name("step1")
+        entry = state["fallback_invocations"][0]
+        assert "error_kind" not in entry
+
+    def test_concurrent_calls_both_land_in_list(self):
+        r = _make_recorder()
+        errors: list[Exception] = []
+
+        def call_invocation(source: str) -> None:
+            try:
+                r.record_fallback_invocation(
+                    state_name="step1",
+                    source=source,
+                    outcome="recovered",
+                    pattern=".*",
+                )
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=call_invocation, args=(f"source-{i}",))
+            for i in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        state = r._find_state_by_name("step1")
+        assert len(state["fallback_invocations"]) == 10


### PR DESCRIPTION
## Summary
- Adds a `FallbackEvent` frozen dataclass and threads an `on_fallback` callback through `ExecutionConfig` so all three fallback source paths (per-rule, workflow override, global) emit uniformly.
- Persists one record per invocation under each state's `fallback_invocations` list in `run.json`, and prints one stderr line per invocation in the format `[state] ↩ fallback(<source>) → <outcome>`.
- Instruments task, parallel, and map-iteration compilers with per-branch / per-iteration adapter closures so multi-branch invocations are attributed correctly.

## Test plan
- [ ] `uv run pytest tests/ -v`
- [ ] `uv run pytest tests/unit/test_recorder_fallback.py tests/unit/test_extraction_fallback.py -v`
- [ ] `uv run pytest tests/integration/test_extraction_fallback_audit.py -v`
- [ ] `uv run pytest tests/e2e/test_fallback_visibility_smoke.py -v`
- [ ] `uv run mypy src/`
- [ ] `uv run ruff check src/ tests/`
- [ ] `uv run ruff format --check .`
- [ ] Manually run a flow that triggers per-rule, workflow-override, and global fallbacks; confirm one stderr line per invocation and matching `fallback_invocations` entries in `run.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)