### PR TITLE
Add model field to ExtractionFallback and LLMClassifyFallback with XOR validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
+      - name: upgrade pip
+        run: python -m pip install --upgrade 'pip>=26.1'
       - name: install dev deps
         run: pip install -e ".[dev]"
       - name: ruff check

--- a/src/fdsx/core/compiler/map_iteration.py
+++ b/src/fdsx/core/compiler/map_iteration.py
@@ -251,6 +251,8 @@ def _create_map_node(
                         outcome=event.outcome,
                         value_preview=event.value_preview,
                         error_kind=event.error_kind,
+                        provider=event.provider,
+                        model=event.model,
                     )
 
                 iter_esc_target = build_escalation_target(

--- a/src/fdsx/core/compiler/nodes.py
+++ b/src/fdsx/core/compiler/nodes.py
@@ -100,6 +100,8 @@ def _create_task_node(
             outcome=event.outcome,
             value_preview=event.value_preview,
             error_kind=event.error_kind,
+            provider=event.provider,
+            model=event.model,
         )
 
     def node(state_dict: dict[str, Any]) -> dict[str, Any]:

--- a/src/fdsx/core/compiler/parallel.py
+++ b/src/fdsx/core/compiler/parallel.py
@@ -163,6 +163,8 @@ def _create_branch_executor(
                 outcome=event.outcome,
                 value_preview=event.value_preview,
                 error_kind=event.error_kind,
+                provider=event.provider,
+                model=event.model,
             )
 
         on_esc = None

--- a/src/fdsx/core/extraction.py
+++ b/src/fdsx/core/extraction.py
@@ -324,7 +324,7 @@ def _execute_llm_fallback(
     """
     if provider_factory is None:
         return None
-    if fallback.provider == "system":
+    if not fallback.provider or fallback.provider == "system":
         return None  # system provider not allowed for LLM classification (defense-in-depth)
 
     _pattern_str = pattern or ""
@@ -338,6 +338,8 @@ def _execute_llm_fallback(
             outcome="error",
             error_kind="provider_init_failed",
             state_name=state_name,
+            provider=fallback.provider,
+            model=fallback.model,
         )
         if on_fallback:
             on_fallback(
@@ -347,6 +349,8 @@ def _execute_llm_fallback(
                     state_name=state_name,
                     pattern=_pattern_str,
                     error_kind="provider_init_failed",
+                    provider=fallback.provider,
+                    model=fallback.model,
                 )
             )
         return None
@@ -358,7 +362,7 @@ def _execute_llm_fallback(
 
         result: ProviderResult = provider.execute(
             prompt=prompt,
-            model=None,
+            model=fallback.model,
             timeout=None,
             output_callback=None,
         )
@@ -370,6 +374,8 @@ def _execute_llm_fallback(
                 outcome="error",
                 error_kind="non_zero_exit",
                 state_name=state_name,
+                provider=fallback.provider,
+                model=fallback.model,
             )
             if on_fallback:
                 on_fallback(
@@ -379,6 +385,8 @@ def _execute_llm_fallback(
                         state_name=state_name,
                         pattern=_pattern_str,
                         error_kind="non_zero_exit",
+                        provider=fallback.provider,
+                        model=fallback.model,
                     )
                 )
             return None
@@ -395,6 +403,8 @@ def _execute_llm_fallback(
                         outcome="recovered",
                         value_preview=keyword,
                         state_name=state_name,
+                        provider=fallback.provider,
+                        model=fallback.model,
                     )
                     if on_fallback:
                         on_fallback(
@@ -404,6 +414,8 @@ def _execute_llm_fallback(
                                 state_name=state_name,
                                 pattern=_pattern_str,
                                 value_preview=keyword,
+                                provider=fallback.provider,
+                                model=fallback.model,
                             )
                         )
                     return keyword
@@ -413,6 +425,8 @@ def _execute_llm_fallback(
                 outcome="rejected",
                 value_preview=llm_output,
                 state_name=state_name,
+                provider=fallback.provider,
+                model=fallback.model,
             )
             if on_fallback:
                 on_fallback(
@@ -422,6 +436,8 @@ def _execute_llm_fallback(
                         state_name=state_name,
                         pattern=_pattern_str,
                         value_preview=llm_output,
+                        provider=fallback.provider,
+                        model=fallback.model,
                     )
                 )
             return None
@@ -431,6 +447,8 @@ def _execute_llm_fallback(
             outcome="recovered",
             value_preview=llm_output,
             state_name=state_name,
+            provider=fallback.provider,
+            model=fallback.model,
         )
         if on_fallback:
             on_fallback(
@@ -440,6 +458,8 @@ def _execute_llm_fallback(
                     state_name=state_name,
                     pattern=_pattern_str,
                     value_preview=llm_output,
+                    provider=fallback.provider,
+                    model=fallback.model,
                 )
             )
         return llm_output
@@ -451,6 +471,8 @@ def _execute_llm_fallback(
             outcome="error",
             error_kind="provider_call_failed",
             state_name=state_name,
+            provider=fallback.provider,
+            model=fallback.model,
         )
         if on_fallback:
             on_fallback(
@@ -460,6 +482,8 @@ def _execute_llm_fallback(
                     state_name=state_name,
                     pattern=_pattern_str,
                     error_kind="provider_call_failed",
+                    provider=fallback.provider,
+                    model=fallback.model,
                 )
             )
 

--- a/src/fdsx/core/extraction_fallback.py
+++ b/src/fdsx/core/extraction_fallback.py
@@ -33,6 +33,8 @@ class FallbackEvent:
     error_kind: str | None = None
     branch_index: int | None = None
     iter_index: int | None = None
+    provider: str | None = None
+    model: str | None = None
 
 
 @dataclass(frozen=True)
@@ -134,7 +136,7 @@ def execute_default_fallback(
 
     if config.provider is not None:
         provider_name = config.provider
-        model = None
+        model = config.model
     else:
         profile_name = cast(str, config.profile)
         profile_data = merged_profiles.get(profile_name)
@@ -145,6 +147,8 @@ def execute_default_fallback(
                 strategy_list=rule.strategy,
                 outcome="error",
                 error="profile_not_found",
+                provider=None,
+                model=None,
             )
             event = FallbackEvent(
                 source=resolved.source,
@@ -171,6 +175,8 @@ def execute_default_fallback(
             strategy_list=rule.strategy,
             outcome="error",
             error="provider_init_failed",
+            provider=provider_name,
+            model=model,
         )
         event = FallbackEvent(
             source=resolved.source,
@@ -178,6 +184,8 @@ def execute_default_fallback(
             state_name=state_name,
             pattern=rule.pattern,
             error_kind="provider_init_failed",
+            provider=provider_name,
+            model=model,
         )
         if on_fallback:
             on_fallback(event)
@@ -194,6 +202,8 @@ def execute_default_fallback(
             strategy_list=rule.strategy,
             outcome="error",
             error="timeout",
+            provider=provider_name,
+            model=model,
         )
         event = FallbackEvent(
             source=resolved.source,
@@ -201,6 +211,8 @@ def execute_default_fallback(
             state_name=state_name,
             pattern=rule.pattern,
             error_kind="timeout",
+            provider=provider_name,
+            model=model,
         )
         if on_fallback:
             on_fallback(event)
@@ -212,6 +224,8 @@ def execute_default_fallback(
             strategy_list=rule.strategy,
             outcome="error",
             error="provider_call_failed",
+            provider=provider_name,
+            model=model,
         )
         event = FallbackEvent(
             source=resolved.source,
@@ -219,6 +233,8 @@ def execute_default_fallback(
             state_name=state_name,
             pattern=rule.pattern,
             error_kind="provider_call_failed",
+            provider=provider_name,
+            model=model,
         )
         if on_fallback:
             on_fallback(event)
@@ -231,6 +247,8 @@ def execute_default_fallback(
             strategy_list=rule.strategy,
             outcome="error",
             error="non_zero_exit",
+            provider=provider_name,
+            model=model,
         )
         event = FallbackEvent(
             source=resolved.source,
@@ -238,6 +256,8 @@ def execute_default_fallback(
             state_name=state_name,
             pattern=rule.pattern,
             error_kind="non_zero_exit",
+            provider=provider_name,
+            model=model,
         )
         if on_fallback:
             on_fallback(event)
@@ -253,6 +273,8 @@ def execute_default_fallback(
             strategy_list=rule.strategy,
             outcome="rejected",
             reason="model_returned_none",
+            provider=provider_name,
+            model=model,
         )
         event = FallbackEvent(
             source=resolved.source,
@@ -260,6 +282,8 @@ def execute_default_fallback(
             state_name=state_name,
             pattern=rule.pattern,
             value_preview=llm_output,
+            provider=provider_name,
+            model=model,
         )
         if on_fallback:
             on_fallback(event)
@@ -275,6 +299,8 @@ def execute_default_fallback(
                     source=resolved.source,
                     strategy_list=rule.strategy,
                     outcome="recovered",
+                    provider=provider_name,
+                    model=model,
                 )
                 event = FallbackEvent(
                     source=resolved.source,
@@ -282,6 +308,8 @@ def execute_default_fallback(
                     state_name=state_name,
                     pattern=rule.pattern,
                     value_preview=keyword,
+                    provider=provider_name,
+                    model=model,
                 )
                 if on_fallback:
                     on_fallback(event)
@@ -291,6 +319,8 @@ def execute_default_fallback(
             source=resolved.source,
             strategy_list=rule.strategy,
             outcome="rejected",
+            provider=provider_name,
+            model=model,
         )
         event = FallbackEvent(
             source=resolved.source,
@@ -298,6 +328,8 @@ def execute_default_fallback(
             state_name=state_name,
             pattern=rule.pattern,
             value_preview=llm_output,
+            provider=provider_name,
+            model=model,
         )
         if on_fallback:
             on_fallback(event)
@@ -308,6 +340,8 @@ def execute_default_fallback(
         source=resolved.source,
         strategy_list=rule.strategy,
         outcome="recovered",
+        provider=provider_name,
+        model=model,
     )
     event = FallbackEvent(
         source=resolved.source,
@@ -315,6 +349,8 @@ def execute_default_fallback(
         state_name=state_name,
         pattern=rule.pattern,
         value_preview=llm_output,
+        provider=provider_name,
+        model=model,
     )
     if on_fallback:
         on_fallback(event)

--- a/src/fdsx/core/profiles.py
+++ b/src/fdsx/core/profiles.py
@@ -130,12 +130,20 @@ def _resolve_fallback_profile(
     if "profile" not in fallback:
         return errors
 
+    profile_name = fallback["profile"]
+
     fallback_errors = _resolve_profile_on_dict(
         fallback,
         f"{label}, extract.fallback",
         merged_profiles,
     )
     errors.extend(fallback_errors)
+
+    if not fallback_errors and "model" not in fallback:
+        errors.append(
+            f"profile '{profile_name}' used in {label}, extract.fallback must have both 'provider' and 'model'"
+        )
+
     return errors
 
 
@@ -166,6 +174,22 @@ def resolve_profiles_in_flow(
         return data, ["'profiles' must be a YAML mapping, not a list or scalar"]
 
     merged_profiles = merge_profiles(config_profiles, workflow_profiles)
+
+    # Validate flow-level extraction_fallback profile if present
+    flow_fallback = data.get("extraction_fallback")
+    if isinstance(flow_fallback, dict) and "profile" in flow_fallback:
+        profile_name = flow_fallback["profile"]
+        fb_errors = _resolve_profile_on_dict(
+            flow_fallback,
+            "flow extraction_fallback",
+            merged_profiles,
+        )
+        if not fb_errors and "model" not in flow_fallback:
+            fb_errors.append(
+                f"profile '{profile_name}' used in flow extraction_fallback"
+                f" must have both 'provider' and 'model'"
+            )
+        errors.extend(fb_errors)
 
     states = data.get("states", {})
     if not isinstance(states, dict):
@@ -243,7 +267,7 @@ def resolve_profiles_in_config(
     if profiles is None or not isinstance(profiles, dict):
         profiles = {}
 
-    for config_key in ("task_splitter", "workflow_selector"):
+    for config_key in ("task_splitter", "workflow_selector", "extraction_fallback"):
         config_item = data.get(config_key)
         if not isinstance(config_item, dict):
             continue
@@ -256,6 +280,10 @@ def resolve_profiles_in_config(
             f"config.{config_key}",
             profiles,
         )
+        if not config_errors and "model" not in config_item:
+            config_errors.append(
+                f"profile used in config.{config_key} must have both 'provider' and 'model'"
+            )
         errors.extend(config_errors)
 
     return data, errors

--- a/src/fdsx/data/skills/fdsx/SKILL.md
+++ b/src/fdsx/data/skills/fdsx/SKILL.md
@@ -125,7 +125,8 @@ extract:
   result_path: $.decision
   fallback:                     # optional per-rule LLM classification fallback
     type: llm_classify
-    provider: claude            # or use profile: <name> (XOR with provider)
+    provider: claude            # or use profile: <name> (XOR with provider + model)
+    model: claude-sonnet-4-6
     prompt: "Classify as APPROVED or REJECTED"
 ```
 
@@ -142,7 +143,8 @@ When per-rule `fallback:` is not set, fdsx can fall back to a global extraction 
 ```yaml
 # In workflow YAML (flow level):
 extraction_fallback:
-  provider: claude              # or use profile: <name> (XOR with provider)
+  provider: claude              # or use profile: <name> (XOR with provider + model)
+  model: claude-sonnet-4-6
   extra_instructions: "Always return one of: APPROVED, REJECTED"
 
 # To disable inherited config-level fallback for this workflow:
@@ -177,13 +179,15 @@ states:
       result_path: "$.decision"
       fallback:                    # per-rule fallback fires normally despite workflow disable
         provider: claude
+        model: claude-sonnet-4-6
         prompt: "Classify as APPROVED or REJECTED: {output}"
     end: true
 ```
 
 `ExtractionFallback` fields:
-- `provider` — LLM provider (`claude`, `codex`, `opencode`, `gemini`; `system` is forbidden). XOR with `profile`.
-- `profile` — named profile. XOR with `provider`. Exactly one of `provider` or `profile` must be set.
+- `provider` — LLM provider (`claude`, `codex`, `opencode`, `gemini`; `system` is forbidden). XOR with `profile`. Must be paired with `model`.
+- `model` — model string passed to the provider binary. Required when `provider` is set.
+- `profile` — named profile. XOR with `provider` + `model`. Exactly one of `provider + model` or `profile` must be set.
 - `extra_instructions` — optional string appended to the recovery prompt.
 
 ## CLI Commands
@@ -386,6 +390,6 @@ Inside iterator states, `{item}` refers to the current array element. Use `{item
 - `result_file` must be a top-level `$.varname` path (no nesting)
 - Extract `result_path` must not use reserved keys: `output`, `exit_code`, `error`
 - Map iterator states must all have `type: task` and unique `name` fields
-- `extraction_fallback` at flow level must have exactly one of `provider` or `profile` set (XOR); `system` is forbidden as provider. Set to `false` to disable config-level inheritance.
+- `extraction_fallback` at flow level must have exactly one of `provider + model` or `profile` set (XOR); `provider` requires `model` and vice versa; `system` is forbidden as provider. Set to `false` to disable config-level inheritance.
 - `on_workflow_start` and `on_workflow_end` are forbidden inside per-state `hooks` blocks for `task`, `choice`, `parallel`, `wait`, and `map` states; `pass` state `hooks` accepts all four keys (workflow-scope keys are silently ignored at runtime)
 - `on_run_start` and `on_run_end` are forbidden in flow YAML (`Flow.hooks`) and all state `hooks` blocks — they are only valid in `.fdsx/config.yaml` and `~/.config/fdsx/config.yaml` under the `run_hooks:` key

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -266,11 +266,13 @@ extract:
   result_path: string           # required — JSONPath for extracted value
   fallback?:                    # optional — per-rule LLM classification fallback
     type: "llm_classify"
-    provider: string            # required — claude|codex|opencode|gemini
+    provider?: string           # XOR with profile — claude|codex|opencode|gemini
+    model?: string              # required when provider is set
+    profile?: string            # XOR with provider+model
     prompt: string              # required — classification prompt
 ```
 
-The `fallback` field uses `LLMClassifyFallback` and supports `profile: <name>` (XOR with `provider`), resolved pre-validation. When using `profile`, the `provider` field is populated from the profile during resolution.
+The `fallback` field uses `LLMClassifyFallback` and supports `profile: <name>` (XOR with `provider + model`), resolved pre-validation. When using `profile`, the `provider` and `model` fields are populated from the profile during resolution. When using `provider` directly, `model` is required.
 
 ### Extraction Fallback Priority
 
@@ -292,11 +294,12 @@ Used at **flow level** (`Flow.extraction_fallback`) and in **config files** (`Fd
 ```yaml
 extraction_fallback:
   provider?: string             # XOR with profile — claude|codex|opencode|gemini (system forbidden)
-  profile?: string              # XOR with provider — resolved from profiles
+  model?: string                # required when provider is set
+  profile?: string              # XOR with provider+model — resolved from profiles
   extra_instructions?: string   # optional — appended to the recovery prompt
 ```
 
-**Mutual exclusion:** exactly one of `provider` or `profile` must be set. Setting both or neither raises a validation error.
+**Mutual exclusion:** exactly one of `provider + model` or `profile` must be set. Setting both or neither raises a validation error.
 
 **At flow level**, the value may also be the literal `false` to explicitly disable any config-level fallback for the workflow:
 
@@ -305,7 +308,8 @@ extraction_fallback: false      # disables config-level extraction_fallback for 
 ```
 
 **Validation:**
-- `provider` and `profile` are mutually exclusive (XOR) — exactly one must be provided
+- `provider + model` and `profile` are mutually exclusive (XOR) — exactly one group must be provided
+- When `provider` is set, `model` is required; `provider` without `model` raises a validation error
 - `provider` must be one of the LLM providers (`claude`, `codex`, `opencode`, `gemini`); `system` is forbidden
 - Uses `extra="forbid"` — unknown keys cause validation errors
 

--- a/src/fdsx/display/terminal.py
+++ b/src/fdsx/display/terminal.py
@@ -123,6 +123,8 @@ def display_fallback(
     outcome: str,
     value_preview: str | None = None,
     error_kind: str | None = None,
+    provider: str | None = None,
+    model: str | None = None,
 ) -> None:
     state = _sanitize_output(state_name)
     source_safe = _sanitize_output(source)
@@ -133,7 +135,15 @@ def display_fallback(
         outcome_text = f"{outcome}: {preview}"
     else:
         outcome_text = outcome
-    print(f"[{state}] ↩ fallback({source_safe}) → {outcome_text}", file=sys.stderr)
+    provider_segment = (
+        f"[{_sanitize_spinner_text(provider)}:{_sanitize_spinner_text(model or '')}]"
+        if provider is not None
+        else ""
+    )
+    print(
+        f"[{state}] ↩ fallback({source_safe}){provider_segment} → {outcome_text}",
+        file=sys.stderr,
+    )
 
 
 def display_output_line(line: str) -> None:

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -10,12 +10,42 @@ class LLMClassifyFallback(BaseModel):
     """LLM-based classification fallback."""
 
     type: Literal["llm_classify"] = "llm_classify"
-    provider: str = Field(..., description="LLM provider")
+    provider: str | None = Field(default=None, description="LLM provider")
+    model: str | None = Field(default=None, description="Model name")
+    profile: str | None = Field(default=None, description="Provider profile name")
     prompt: str = Field(..., description="Classification prompt")
 
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_provider_xor_profile(cls, values: Any) -> Any:
+        if isinstance(values, dict):
+            has_provider = values.get("provider") is not None
+            has_model = values.get("model") is not None
+            has_profile = values.get("profile") is not None
+            if has_profile and (has_provider or has_model):
+                raise ValueError(
+                    "llm_classify fallback: profile and provider/model are mutually exclusive"
+                )
+            if not has_profile:
+                if has_provider and not has_model:
+                    raise ValueError(
+                        "llm_classify fallback: provider requires model; "
+                        "example: provider: claude, model: claude-sonnet-4-6"
+                    )
+                if has_model and not has_provider:
+                    raise ValueError("llm_classify fallback: model requires provider")
+                if not has_provider and not has_model:
+                    raise ValueError(
+                        "llm_classify fallback: exactly one of (provider + model) or profile must be set"
+                    )
+        return values
+
     @model_validator(mode="after")
-    def validate_provider(self) -> "LLMClassifyFallback":
-        validate_llm_provider(self.provider, "LLM classify fallback")
+    def validate_provider_name(self) -> "LLMClassifyFallback":
+        if self.provider is not None:
+            validate_llm_provider(self.provider, "LLM classify fallback")
         return self
 
 
@@ -23,6 +53,7 @@ class ExtractionFallback(BaseModel):
     """Global extraction fallback: retry extraction with a different provider or profile."""
 
     provider: str | None = Field(default=None)
+    model: str | None = Field(default=None)
     profile: str | None = Field(default=None)
     extra_instructions: str | None = Field(default=None)
 
@@ -33,15 +64,24 @@ class ExtractionFallback(BaseModel):
     def validate_provider_xor_profile(cls, values: Any) -> Any:
         if isinstance(values, dict):
             has_provider = values.get("provider") is not None
+            has_model = values.get("model") is not None
             has_profile = values.get("profile") is not None
-            if has_provider and has_profile:
+            if has_profile and (has_provider or has_model):
                 raise ValueError(
                     "provider and profile are mutually exclusive in ExtractionFallback"
                 )
-            if not has_provider and not has_profile:
-                raise ValueError(
-                    "exactly one of provider or profile must be set in ExtractionFallback"
-                )
+            if not has_profile:
+                if has_provider and not has_model:
+                    raise ValueError(
+                        "ExtractionFallback: provider requires model; "
+                        "example: provider: claude, model: claude-sonnet-4-6"
+                    )
+                if has_model and not has_provider:
+                    raise ValueError("ExtractionFallback: model requires provider")
+                if not has_provider and not has_model:
+                    raise ValueError(
+                        "exactly one of provider or profile must be set in ExtractionFallback"
+                    )
         return values
 
     @model_validator(mode="after")

--- a/tests/e2e/test_fallback_visibility_smoke.py
+++ b/tests/e2e/test_fallback_visibility_smoke.py
@@ -35,7 +35,11 @@ class TestFallbackVisibilitySmoke:
                 )
             },
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         # Call 1: main task — output misses keyword
         # Call 2: global fallback — returns APPROVED
@@ -51,6 +55,68 @@ class TestFallbackVisibilitySmoke:
         assert result.get("decision") == "APPROVED"
 
         captured = capsys.readouterr()
-        assert "↩ fallback(global) → recovered:" in captured.err, (
-            f"Expected fallback visibility line in stderr, got: {captured.err!r}"
+        assert (
+            "↩ fallback(global)[claude:claude-sonnet-4-6] → recovered:" in captured.err
+        ), f"Expected fallback visibility line in stderr, got: {captured.err!r}"
+
+    def test_global_fallback_recovery_display_includes_provider_model(self, capsys):
+        """Fallback stderr line must include [provider:model] when a direct-provider
+        fallback fires.
+
+        FAILS RED: display_fallback() does not yet emit the [provider:model] segment;
+        FallbackEvent has no provider/model fields; ExtractionFallback has no model field.
+        Uses model_construct to bypass Pydantic validation so the test reaches the
+        display assertion and fails there, not at construction time.
+        """
+        from fdsx.core.compiler import compile_flow
+        from fdsx.core.config import FdsxConfig
+        from fdsx.models.flow import ExtractionFallback, ExtractRule, Flow, TaskState
+        from fdsx.providers.base import ProviderResult
+
+        _MODEL = "claude-sonnet-4-5"
+
+        flow = Flow(
+            name="fallback_provider_model_smoke",
+            description="E2E test: display must include [provider:model]",
+            start_at="classify",
+            states={
+                "classify": TaskState(
+                    type="task",
+                    provider="claude",
+                    model=_MODEL,
+                    prompt_template="classify this output",
+                    result_path="$.task_result",
+                    extract=ExtractRule(
+                        strategy=["keyword"],
+                        pattern="APPROVED|REJECTED",
+                        result_path="$.decision",
+                    ),
+                    retry=0,
+                    end=True,
+                )
+            },
+        )
+
+        # Bypass Pydantic validation: model field does not exist yet on ExtractionFallback.
+        ef = ExtractionFallback.model_construct(
+            provider="claude", model="claude-sonnet-4-6"
+        )
+        config = FdsxConfig.model_construct(extraction_fallback=ef)
+
+        responses = [
+            ProviderResult(exit_code=0, stdout="processing complete", stderr=""),
+            ProviderResult(exit_code=0, stdout="APPROVED", stderr=""),
+        ]
+
+        with patch("fdsx.providers.claude._run_subprocess", side_effect=responses):
+            compiled = compile_flow(flow, config=config)
+            result = compiled.graph.invoke({})
+
+        assert result.get("decision") == "APPROVED"
+
+        captured = capsys.readouterr()
+        assert (
+            "↩ fallback(global)[claude:claude-sonnet-4-6] → recovered:" in captured.err
+        ), (
+            f"Expected '[claude:claude-sonnet-4-6]' in fallback stderr line, got: {captured.err!r}"
         )

--- a/tests/integration/test_extraction_fallback_audit.py
+++ b/tests/integration/test_extraction_fallback_audit.py
@@ -87,7 +87,11 @@ class TestGlobalFallbackAudit:
         stderr contains ↩ fallback(global) → recovered:"""
         recorder = _make_recorder()
         flow = _single_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         responses = [
             ProviderResult(exit_code=0, stdout="processing complete", stderr=""),
@@ -111,9 +115,9 @@ class TestGlobalFallbackAudit:
         )
 
         captured = capsys.readouterr()
-        assert "↩ fallback(global) → recovered:" in captured.err, (
-            f"Expected fallback line in stderr, got: {captured.err!r}"
-        )
+        assert (
+            "↩ fallback(global)[claude:claude-sonnet-4-6] → recovered:" in captured.err
+        ), f"Expected fallback line in stderr, got: {captured.err!r}"
 
 
 class TestWorkflowOverrideAudit:
@@ -121,7 +125,9 @@ class TestWorkflowOverrideAudit:
         """When extraction_fallback is set on the flow (workflow level), record has source=workflow."""
         recorder = _make_recorder()
         flow = _single_task_flow(
-            extraction_fallback=ExtractionFallback(provider="claude")
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
         )
         # No global config fallback; flow-level override fires
         config = FdsxConfig()
@@ -149,6 +155,7 @@ class TestPerRuleFallbackAudit:
             result_path="$.decision",
             fallback=LLMClassifyFallback(
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Please classify the following output as APPROVED or REJECTED.",
             ),
         )
@@ -173,7 +180,11 @@ class TestRejectedOutcomeAudit:
         """When fallback returns out-of-set value, outcome=rejected and no error_kind key."""
         recorder = _make_recorder()
         flow = _single_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         responses = [
             ProviderResult(exit_code=0, stdout="missed", stderr=""),
@@ -196,7 +207,11 @@ class TestTimeoutFallbackAudit:
         """When fallback provider times out, outcome=error, error_kind=timeout."""
         recorder = _make_recorder()
         flow = _single_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         stub_provider = MagicMock()
         stub_provider.execute.side_effect = [
@@ -231,7 +246,11 @@ class TestFallbackDisabledAudit:
         """extraction_fallback: false on the flow disables fallback; key absent from state."""
         recorder = _make_recorder()
         flow = _single_task_flow(extraction_fallback=False)
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         responses = [
             ProviderResult(exit_code=0, stdout="missed", stderr=""),
@@ -252,7 +271,11 @@ class TestAllStrategiesHitAudit:
         """When extraction succeeds on first try, fallback_invocations absent and no ↩ line in stderr."""
         recorder = _make_recorder()
         flow = _single_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            )
+        )
 
         main_response = ProviderResult(
             exit_code=0, stdout="The decision is APPROVED", stderr=""
@@ -292,7 +315,11 @@ class TestSystemProviderMissAudit:
             start_at="classify",
             states={"classify": system_task},
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         with patch("fdsx.providers.claude._run_subprocess") as mock_claude:
             compiled = compile_flow(flow, config=config, recorder=recorder)
@@ -337,7 +364,11 @@ class TestMapStateFallbackAudit:
             start_at="map_classify",
             states={"map_classify": map_state},
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         # item 0: main task matches → no fallback
         # item 1: main task misses → fallback fires → REJECTED recovered
@@ -403,7 +434,11 @@ class TestParallelBranchFallbackAudit:
             start_at="parallel_classify",
             states={"parallel_classify": parallel_state},
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            )
+        )
 
         missed = ProviderResult(exit_code=0, stdout="no keyword here", stderr="")
         recovered = ProviderResult(exit_code=0, stdout="APPROVED", stderr="")

--- a/tests/integration/test_extraction_fallback_default.py
+++ b/tests/integration/test_extraction_fallback_default.py
@@ -87,7 +87,11 @@ class TestGlobalDefaultFallback:
         """When all strategies miss and a global extraction_fallback is set, the
         LLM fallback is invoked and the recovered value is stored in result_path."""
         flow = _claude_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         # Call 1: main task — output has no keyword
         # Call 2: global default fallback — should return APPROVED
@@ -117,7 +121,11 @@ class TestSystemProviderGuard:
         that claude was never called.
         """
         flow = _system_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         with patch("fdsx.providers.claude._run_subprocess") as mock_claude:
             compiled = compile_flow(flow, config=config)
@@ -141,7 +149,11 @@ class TestOutOfSetResponse:
         workflow ultimately fails — proving the response was filtered, not skipped.
         """
         flow = _claude_task_flow()
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         # Call 1: main task misses keyword
         # Call 2: fallback returns MAYBE (outside APPROVED|REJECTED)
@@ -172,7 +184,11 @@ class TestStrategiesHit:
         fallback is not invoked at all."""
         flow = _claude_task_flow()
         # Use codex as fallback provider so we can mock it independently
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            )
+        )
 
         main_task = ProviderResult(
             exit_code=0, stdout="The decision is APPROVED", stderr=""
@@ -205,11 +221,16 @@ class TestPerRuleFallbackWins:
             extra_extract_kwargs={
                 "fallback": LLMClassifyFallback(
                     provider="claude",
+                    model="claude-sonnet-4-6",
                     prompt="Classify as APPROVED or REJECTED: {output}",
                 )
             }
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            )
+        )
 
         # Call 1: main task misses keyword
         # Call 2: per-rule claude fallback returns APPROVED

--- a/tests/integration/test_extraction_fallback_workflow_disable.py
+++ b/tests/integration/test_extraction_fallback_workflow_disable.py
@@ -68,7 +68,11 @@ def _flow(
 class TestDisableSuppressesGlobalDefault:
     def test_false_disables_config_fallback(self):
         flow = _flow(extraction_fallback=False)
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         with patch(
             "fdsx.providers.claude._run_subprocess",
@@ -92,10 +96,15 @@ class TestPerRuleStillFiresWhenDisabled:
             extraction_fallback=False,
             per_rule_fallback=LLMClassifyFallback(
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify as APPROVED or REJECTED: {output}",
             ),
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="codex"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            )
+        )
 
         claude_responses = [_NO_MATCH, _APPROVED]
 
@@ -121,7 +130,11 @@ class TestPerRuleStillFiresWhenDisabled:
 
 class TestRemovingDisableRestoresInheritance:
     def test_toggling_disable_off_restores_global_default(self):
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         # Phase A — disabled: extraction fails
         with patch(

--- a/tests/integration/test_extraction_fallback_workflow_override.py
+++ b/tests/integration/test_extraction_fallback_workflow_override.py
@@ -74,8 +74,16 @@ class TestWorkflowOverrideProvider:
         """When flow.extraction_fallback.provider = 'codex' and
         config.extraction_fallback.provider = 'claude', the codex subprocess is
         called for the fallback and claude is called only for the main task."""
-        flow = _flow(extraction_fallback=ExtractionFallback(provider="codex"))
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        flow = _flow(
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            )
+        )
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         # Call 1 (claude): main task — no keyword match
         # Call 1 (codex): fallback — returns APPROVED
@@ -111,7 +119,11 @@ class TestWorkflowOverrideProfile:
             extraction_fallback=ExtractionFallback(profile="fast-llm"),
             profiles={"fast-llm": {"provider": "codex", "model": _CODEX_MODEL}},
         )
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         claude_responses = [_NO_MATCH]
         codex_response = _APPROVED
@@ -141,7 +153,9 @@ class TestWorkflowOverrideProfile:
             profiles={
                 "shared-model": ProfileConfig(provider="codex", model=_CODEX_MODEL)
             },
-            extraction_fallback=ExtractionFallback(provider="claude"),
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            ),
         )
 
         claude_responses = [_NO_MATCH]
@@ -171,7 +185,9 @@ class TestWorkflowOverrideProfile:
         )
         config = FdsxConfig(
             profiles={"shared-model": ProfileConfig(provider="claude", model=_MODEL)},
-            extraction_fallback=ExtractionFallback(provider="claude"),
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            ),
         )
 
         # If flow profile wins (codex): claude called 1x (main task), codex called 1x
@@ -207,7 +223,9 @@ class TestWorkflowOverrideExtraInstructions:
         instructions = "Use formal language and return uppercase only"
         flow = _flow(
             extraction_fallback=ExtractionFallback(
-                provider="claude", extra_instructions=instructions
+                provider="claude",
+                model="claude-sonnet-4-6",
+                extra_instructions=instructions,
             )
         )
         config = FdsxConfig()
@@ -250,9 +268,12 @@ class TestPerRuleWinsOverWorkflowOverride:
         flow.extraction_fallback.provider = 'codex', the per-rule claude
         fallback is used and codex is never called."""
         flow = _flow(
-            extraction_fallback=ExtractionFallback(provider="codex"),
+            extraction_fallback=ExtractionFallback(
+                provider="codex", model="claude-sonnet-4-6"
+            ),
             per_rule_fallback=LLMClassifyFallback(
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify as APPROVED or REJECTED: {output}",
             ),
         )
@@ -287,7 +308,11 @@ class TestNoOverrideFallsBackToGlobal:
         config.extraction_fallback.provider = 'claude', the config default
         fires and the recovered value is stored in result_path."""
         flow = _flow(extraction_fallback=None)
-        config = FdsxConfig(extraction_fallback=ExtractionFallback(provider="claude"))
+        config = FdsxConfig(
+            extraction_fallback=ExtractionFallback(
+                provider="claude", model="claude-sonnet-4-6"
+            )
+        )
 
         responses = [_NO_MATCH, _APPROVED]
 

--- a/tests/unit/test_extraction.py
+++ b/tests/unit/test_extraction.py
@@ -360,6 +360,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )
@@ -385,6 +386,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )
@@ -410,6 +412,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )
@@ -445,6 +448,7 @@ class TestLLMFallback:
         fallback = LLMClassifyFallback(
             type="llm_classify",
             provider="claude",
+            model="claude-sonnet-4-6",
             prompt="Classify: {output}",
         )
 
@@ -467,6 +471,7 @@ class TestLLMFallback:
         fallback = LLMClassifyFallback(
             type="llm_classify",
             provider="claude",
+            model="claude-sonnet-4-6",
             prompt="Classify: {output}",
         )
 
@@ -491,6 +496,7 @@ class TestLLMFallback:
         fallback = LLMClassifyFallback(
             type="llm_classify",
             provider="claude",
+            model="claude-sonnet-4-6",
             prompt="Classify: {output}",
         )
 
@@ -516,6 +522,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )
@@ -538,6 +545,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )
@@ -562,6 +570,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )
@@ -598,6 +607,7 @@ class TestLLMFallback:
             fallback=LLMClassifyFallback(
                 type="llm_classify",
                 provider="claude",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             ),
         )

--- a/tests/unit/test_extraction_fallback.py
+++ b/tests/unit/test_extraction_fallback.py
@@ -36,7 +36,7 @@ class TestExtractionFallbackValidation:
     def test_provider_only_is_valid(self):
         from fdsx.models.flow import ExtractionFallback
 
-        fb = ExtractionFallback(provider="claude")
+        fb = ExtractionFallback(provider="claude", model="claude-sonnet-4-6")
         assert fb.profile is None
 
     def test_profile_only_is_valid(self):
@@ -66,13 +66,17 @@ class TestExtractionFallbackValidation:
     def test_extra_instructions_defaults_to_none(self):
         from fdsx.models.flow import ExtractionFallback
 
-        fb = ExtractionFallback(provider="claude")
+        fb = ExtractionFallback(provider="claude", model="claude-sonnet-4-6")
         assert fb.extra_instructions is None
 
     def test_extra_instructions_accepted_with_valid_provider(self):
         from fdsx.models.flow import ExtractionFallback
 
-        fb = ExtractionFallback(provider="claude", extra_instructions="append this")
+        fb = ExtractionFallback(
+            provider="claude",
+            model="claude-sonnet-4-6",
+            extra_instructions="append this",
+        )
         assert fb.extra_instructions == "append this"
 
     def test_extra_unknown_keys_rejected(self):
@@ -103,7 +107,11 @@ class TestFlowExtractionFallbackField:
     def test_field_mapping_gives_extraction_fallback_instance(self):
         from fdsx.models.flow import ExtractionFallback
 
-        flow = Flow(**_minimal_flow(extraction_fallback={"provider": "claude"}))
+        flow = Flow(
+            **_minimal_flow(
+                extraction_fallback={"provider": "claude", "model": "claude-sonnet-4-6"}
+            )
+        )
         assert isinstance(flow.extraction_fallback, ExtractionFallback)
         assert flow.extraction_fallback.provider == "claude"
 
@@ -129,7 +137,9 @@ class TestFdsxConfigExtractionFallbackField:
     def test_field_mapping_gives_extraction_fallback_instance(self):
         from fdsx.models.flow import ExtractionFallback
 
-        cfg = FdsxConfig(extraction_fallback={"provider": "opencode"})
+        cfg = FdsxConfig(
+            extraction_fallback={"provider": "opencode", "model": "claude-sonnet-4-6"}
+        )
         assert isinstance(cfg.extraction_fallback, ExtractionFallback)
         assert cfg.extraction_fallback.provider == "opencode"
 
@@ -139,7 +149,13 @@ class TestFdsxConfigExtractionFallbackField:
 
     def test_field_extra_unknown_keys_rejected(self):
         with pytest.raises(ValidationError, match=r"extraction_fallback\.bogus"):
-            FdsxConfig(extraction_fallback={"provider": "claude", "bogus": "val"})
+            FdsxConfig(
+                extraction_fallback={
+                    "provider": "claude",
+                    "model": "claude-sonnet-4-6",
+                    "bogus": "val",
+                }
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -154,7 +170,9 @@ class TestResolveFallback:
         from fdsx.models.flow import ExtractRule, LLMClassifyFallback
 
         fb = (
-            LLMClassifyFallback(provider="claude", prompt="classify")
+            LLMClassifyFallback(
+                provider="claude", model="claude-sonnet-4-6", prompt="classify"
+            )
             if with_fallback
             else None
         )
@@ -193,7 +211,7 @@ class TestResolveFallback:
         from fdsx.models.flow import ExtractionFallback
 
         rule = self._rule(with_fallback=False)
-        global_ef = ExtractionFallback(provider="claude")
+        global_ef = ExtractionFallback(provider="claude", model="claude-sonnet-4-6")
         result = resolve_fallback(rule, self._flow(ef=False), self._cfg(ef=global_ef))
 
         assert result is None
@@ -213,7 +231,7 @@ class TestResolveFallback:
         from fdsx.models.flow import ExtractionFallback
 
         rule = self._rule(with_fallback=False)
-        flow_ef = ExtractionFallback(provider="opencode")
+        flow_ef = ExtractionFallback(provider="opencode", model="claude-sonnet-4-6")
         result = resolve_fallback(rule, self._flow(ef=flow_ef), self._cfg())
 
         assert result is not None
@@ -225,7 +243,7 @@ class TestResolveFallback:
         from fdsx.models.flow import ExtractionFallback
 
         rule = self._rule(with_fallback=False)
-        global_ef = ExtractionFallback(provider="claude")
+        global_ef = ExtractionFallback(provider="claude", model="claude-sonnet-4-6")
         result = resolve_fallback(rule, self._flow(ef=None), self._cfg(ef=global_ef))
 
         assert result is not None
@@ -245,7 +263,7 @@ class TestResolveFallback:
         from fdsx.models.flow import ExtractionFallback
 
         rule = self._rule(with_fallback=False)
-        flow_ef = ExtractionFallback(provider="claude")
+        flow_ef = ExtractionFallback(provider="claude", model="claude-sonnet-4-6")
         flow = self._flow(ef=flow_ef)
         cfg = self._cfg()
 
@@ -361,7 +379,7 @@ def _make_resolved(provider=None, profile=None, extra_instructions=None):
     from fdsx.models.flow import ExtractionFallback
 
     if provider is not None:
-        cfg = ExtractionFallback(provider=provider)
+        cfg = ExtractionFallback(provider=provider, model="claude-sonnet-4-6")
     else:
         cfg = ExtractionFallback(profile=profile)
     if extra_instructions is not None:
@@ -894,3 +912,248 @@ class TestExecuteDefaultFallback:
         assert not any(e == "default_fallback_invoked" for e in info_events), (
             f"Found deprecated 'default_fallback_invoked' in logs: {info_events}"
         )
+
+    def test_model_is_passed_to_provider_execute(self):
+        # Executor must read config.model and forward it to provider.execute().
+        # Currently extraction_fallback.py hard-codes model=None on the provider branch.
+        # FAILS RED: execute receives model=None instead of "claude-sonnet-4-6".
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import (
+            ResolvedFallback,
+            execute_default_fallback,
+        )
+        from fdsx.models.flow import ExtractionFallback
+
+        factory, mock_provider = _make_factory(stdout="APPROVED")
+        # model_construct bypasses Pydantic validation so we can attach the model
+        # field before it exists in the schema.
+        cfg = ExtractionFallback.model_construct(
+            provider="claude", model="claude-sonnet-4-6"
+        )
+        resolved = ResolvedFallback(config=cfg, source="global")
+
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="claude",
+                provider_factory=factory,
+            )
+
+        mock_provider.execute.assert_called_once()
+        call_kwargs = mock_provider.execute.call_args
+        passed_model = (
+            call_kwargs.kwargs.get("model")
+            if call_kwargs.kwargs
+            else (call_kwargs.args[1] if len(call_kwargs.args) > 1 else None)
+        )
+        assert passed_model == "claude-sonnet-4-6", (
+            f"Expected model='claude-sonnet-4-6' forwarded to provider.execute, got: {passed_model!r}"
+        )
+
+    def test_fallback_event_carries_provider_and_model_on_success(self):
+        # FallbackEvent must expose provider and model so display/recorder can use them.
+        # FAILS RED: FallbackEvent dataclass has no provider/model fields yet.
+        from unittest.mock import MagicMock
+
+        import structlog.testing
+
+        from fdsx.core.extraction_fallback import (
+            ResolvedFallback,
+            execute_default_fallback,
+        )
+        from fdsx.models.flow import ExtractionFallback
+
+        factory, _ = _make_factory(stdout="APPROVED")
+        cfg = ExtractionFallback.model_construct(
+            provider="claude", model="claude-sonnet-4-6"
+        )
+        resolved = ResolvedFallback(config=cfg, source="global")
+        callback = MagicMock()
+
+        with structlog.testing.capture_logs():
+            execute_default_fallback(
+                output="text",
+                rule=self._keyword_rule(),
+                resolved=resolved,
+                merged_profiles={},
+                source_provider="claude",
+                provider_factory=factory,
+                on_fallback=callback,
+            )
+
+        callback.assert_called_once()
+        event = callback.call_args[0][0]
+        assert event.provider == "claude", (
+            f"Expected event.provider='claude', got: {event.provider!r}"
+        )
+        assert event.model == "claude-sonnet-4-6", (
+            f"Expected event.model='claude-sonnet-4-6', got: {event.model!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ExtractionFallback — new model field and updated XOR rules (RED)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionFallbackModelField:
+    """Tests for the new `model` field on ExtractionFallback and revised XOR rules.
+
+    All tests in this class FAIL in RED because the model field does not yet
+    exist and the XOR validator does not yet require model alongside provider.
+    """
+
+    def test_provider_and_model_constructs_successfully(self):
+        # FAILS RED: ExtractionFallback has extra="forbid" and no model field.
+        # ValidationError: Extra inputs are not permitted for 'model'.
+        from fdsx.models.flow import ExtractionFallback
+
+        fb = ExtractionFallback(provider="claude", model="claude-sonnet-4-6")
+        assert fb.model == "claude-sonnet-4-6"
+        assert fb.provider == "claude"
+
+    def test_provider_without_model_raises(self):
+        # FAILS RED: ExtractionFallback(provider="claude") currently succeeds.
+        # After GREEN the XOR validator requires model when provider is set.
+        from fdsx.models.flow import ExtractionFallback
+
+        with pytest.raises(ValidationError, match="model"):
+            ExtractionFallback(provider="claude")
+
+    def test_profile_and_model_raises(self):
+        # FAILS RED: model is extra and rejected before the new XOR check fires,
+        # so the test cannot distinguish the intended error from the extra-field error.
+        # After GREEN ExtractionFallback accepts model and the XOR raises the right message.
+        from fdsx.models.flow import ExtractionFallback
+
+        with pytest.raises(ValidationError, match=r"mutually exclusive|profile"):
+            ExtractionFallback(profile="fast", model="claude-sonnet-4-6")
+
+    def test_all_three_raises(self):
+        # FAILS RED: same extra-field problem as above.
+        # After GREEN the XOR check fires and raises the right message.
+        from fdsx.models.flow import ExtractionFallback
+
+        with pytest.raises(ValidationError, match=r"mutually exclusive|profile"):
+            ExtractionFallback(
+                profile="fast", provider="claude", model="claude-sonnet-4-6"
+            )
+
+    def test_empty_raises_mentioning_provider_and_profile(self):
+        # Already covered by test_neither_provider_nor_profile_rejected, but the
+        # new error message must mention both options.  FAILS RED when the message
+        # changes from "provider or profile" to include "model" wording.
+        from fdsx.models.flow import ExtractionFallback
+
+        with pytest.raises(ValidationError, match=r"provider|profile"):
+            ExtractionFallback()
+
+
+# ---------------------------------------------------------------------------
+# LLMClassifyFallback — new model + profile fields and XOR rules (RED)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMClassifyFallbackValidation:
+    """Tests for the new model and profile fields on LLMClassifyFallback.
+
+    All tests that assert a NEW constraint FAIL in RED because the fields do
+    not yet exist and no XOR validator is wired.
+    """
+
+    def test_provider_and_model_constructs_successfully(self):
+        # FAILS RED: model is silently dropped (no model_config extra="forbid"),
+        # so fb.model raises AttributeError or returns wrong value.
+        from fdsx.models.flow import LLMClassifyFallback
+
+        fb = LLMClassifyFallback(
+            provider="claude", model="claude-sonnet-4-6", prompt="classify this"
+        )
+        assert fb.model == "claude-sonnet-4-6"
+
+    def test_profile_only_constructs_successfully(self):
+        # FAILS RED: provider is currently required (Field(...)); passing only
+        # profile raises ValidationError "Field required".
+        from fdsx.models.flow import LLMClassifyFallback
+
+        fb = LLMClassifyFallback(profile="fast", prompt="classify this")
+        assert fb.profile == "fast"
+        assert fb.provider is None
+
+    def test_provider_without_model_raises(self):
+        # FAILS RED: LLMClassifyFallback(provider="claude", prompt="x") currently
+        # succeeds; after GREEN the XOR validator requires model.
+        from fdsx.models.flow import LLMClassifyFallback
+
+        with pytest.raises(ValidationError, match="model"):
+            LLMClassifyFallback(provider="claude", prompt="classify this")
+
+    def test_profile_and_provider_raises(self):
+        # FAILS RED: profile and model are silently ignored (no extra="forbid"),
+        # so the construction currently succeeds.  After GREEN the XOR raises.
+        from fdsx.models.flow import LLMClassifyFallback
+
+        with pytest.raises(ValidationError, match=r"mutually exclusive|profile"):
+            LLMClassifyFallback(
+                profile="fast",
+                provider="claude",
+                model="claude-sonnet-4-6",
+                prompt="classify this",
+            )
+
+    def test_profile_and_model_raises(self):
+        # FAILS RED: model is silently ignored; profile is silently ignored.
+        # Construction currently succeeds (uses required provider from Field(...)).
+        # After GREEN, profile+model without provider raises XOR error.
+        from fdsx.models.flow import LLMClassifyFallback
+
+        with pytest.raises(ValidationError, match=r"mutually exclusive|profile"):
+            LLMClassifyFallback(
+                profile="fast",
+                model="claude-sonnet-4-6",
+                prompt="classify this",
+            )
+
+
+# ---------------------------------------------------------------------------
+# FallbackEvent — new provider / model fields (RED)
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackEventFields:
+    """FallbackEvent must expose provider and model after the plan is implemented.
+
+    Both tests FAIL RED because the frozen dataclass has no such fields yet.
+    """
+
+    def test_event_exposes_provider_and_model(self):
+        # FAILS RED: frozen dataclass raises TypeError for unexpected kwargs.
+        from fdsx.core.extraction_fallback import FallbackEvent
+
+        event = FallbackEvent(
+            source="global",
+            outcome="recovered",
+            state_name="step1",
+            pattern="APPROVED|REJECTED",
+            provider="claude",
+            model="claude-sonnet-4-6",
+        )
+        assert event.provider == "claude"
+        assert event.model == "claude-sonnet-4-6"
+
+    def test_event_provider_model_default_none(self):
+        # FAILS RED: FallbackEvent has no provider/model attributes; AttributeError.
+        from fdsx.core.extraction_fallback import FallbackEvent
+
+        event = FallbackEvent(
+            source="global",
+            outcome="recovered",
+            state_name="step1",
+            pattern="APPROVED|REJECTED",
+        )
+        assert event.provider is None
+        assert event.model is None

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -231,6 +231,7 @@ class TestLLMClassifyFallbackValidation:
             LLMClassifyFallback(
                 type="llm_classify",
                 provider="system",
+                model="claude-sonnet-4-6",
                 prompt="Classify: {output}",
             )
 


### PR DESCRIPTION
## What
Enforce that every direct-provider fallback specifies both `provider` and `model` (or uses a `profile` instead). Surface `provider` and `model` on `FallbackEvent`, in structlog calls, and in the terminal display string.

## Why
Previously `ExtractionFallback(provider="claude")` was valid but incomplete — the model was always `None`. This caused downstream issues when the provider expected a model string. Now:

- `ExtractionFallback` requires either `provider + model` OR `profile`, but not both provider and profile
- `LLMClassifyFallback` gains the same XOR constraint (provider+model vs profile)
- The fallback activation line in the terminal now shows `↩ fallback(global)[claude:claude-sonnet-4-6] →` so operators can see which model was used
- Profile resolution validates at load time that the resolved profile has both `provider` and `model`

## How to test
```bash
# Valid combinations
uv run pytest tests/unit/test_extraction_fallback.py -v -k "valid"
# Invalid combinations raise ValueError
uv run pytest tests/unit/test_extraction_fallback.py -v -k "raises"
# Full test suite
uv run pytest tests/ -v
```

## Breaking change
`ExtractionFallback(provider="claude")` without `model` now raises `ValueError` at construction time.