### PR TITLE
feat: add on_wait_start/on_wait_end lifecycle hooks to wait states

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ fdsx enables you to define AI agent workflows in YAML, combining the durability 
 - Multiple LLM provider support (Claude, Codex, Gemini, OpenCode, and system commands)
 - Named profiles for reusable provider/model configuration
 - Webhook notifications on wait states
-- Lifecycle hooks (on_state_start / on_state_end / on_workflow_start / on_workflow_end / on_run_start / on_run_end) at global, project, flow, and state level
+- Lifecycle hooks (on_state_start / on_state_end / on_workflow_start / on_workflow_end / on_run_start / on_run_end / on_wait_start / on_wait_end) at global, project, flow, and state level
 - Output extraction with JSON, regex, keyword strategies and LLM fallback
 - Global and per-flow extraction fallback and retry escalation
 - Workflow auto-selection via LLM-based matching
@@ -117,6 +117,12 @@ hooks:
   on_workflow_end:                       # fires once when the workflow finishes (all terminal paths)
     - command: "echo 'Workflow done'"
       on_failure: warn
+  on_wait_start:                         # fires before a wait state suspends for user input
+    - command: "echo 'Waiting for input'"
+      on_failure: warn
+  on_wait_end:                           # fires after a wait state resumes (user has responded)
+    - command: "echo 'Input received'"
+      on_failure: warn
 
 # --- Per-flow extraction fallback (optional) ---
 # Overrides the global config-level extraction_fallback for this workflow.
@@ -197,7 +203,8 @@ states:
       permission_mode: dontAsk
 
     # --- State-level hooks (optional) ---
-    # Note: on_workflow_start and on_workflow_end are NOT valid here; use flow-level hooks.
+    # Note: on_workflow_start, on_workflow_end, on_wait_start, and on_wait_end are NOT valid
+    # here; use flow-level hooks (on_wait_start/on_wait_end are only valid on wait states).
     hooks:
       on_state_start:
         - command: "echo 'task starting'"
@@ -317,7 +324,8 @@ states:
 
     max_iterations: 3                   # (int, optional)
     hooks:                              # (optional) pass states accept all hook keys including
-                                        #   on_workflow_start and on_workflow_end
+                                        #   on_workflow_start, on_workflow_end, on_wait_start,
+                                        #   and on_wait_end
     next: review_route                  # next / end — same rules as task
     # end: true
 
@@ -345,7 +353,10 @@ states:
                                         # Non-2xx responses are logged as warnings, never fail the flow
 
     max_iterations: 1                   # (int, optional)
-    hooks:                              # (optional) on_state_start / on_state_end only
+    hooks:                              # (optional) on_state_start / on_state_end /
+                                        #   on_wait_start / on_wait_end
+                                        # on_wait_start fires before the prompt is shown
+                                        # on_wait_end fires after the user selects a choice
     next: post_approval                 # next / end — same rules as task
     # end: true
 
@@ -374,7 +385,7 @@ Every hook command receives context via **environment variables** and **position
 | `FDSX_DATA_PATH` | Path to the state data JSON file | `.fdsx/runs/<thread_id>/hooks/plan/input.json` |
 | `FDSX_THREAD_ID` | Current run thread ID | `abc123` |
 | `FDSX_FLOW_NAME` | Name of the flow | `MyWorkflow` |
-| `FDSX_HOOKS` | Lifecycle event name that triggered the hook | `on_state_start`, `on_workflow_end`, `on_run_start`, `on_run_end` |
+| `FDSX_HOOKS` | Lifecycle event name that triggered the hook | `on_state_start`, `on_workflow_end`, `on_wait_start`, `on_wait_end`, `on_run_start`, `on_run_end` |
 
 **Positional arguments** (appended to your command):
 
@@ -409,6 +420,7 @@ hooks:
 - `on_state_start` and `on_state_end` are valid at all levels (global config, project config, flow, and individual states).
 - `on_workflow_start` and `on_workflow_end` are only valid at global config, project config, and flow scope — placing them inside a state's `hooks:` block will raise a validation error (the one exception is `pass` states, which accept all hook keys).
 - `on_run_start` and `on_run_end` fire once per CLI invocation (wrapping the entire `fdsx run` or `fdsx resume` call). They are only valid in global config (`~/.config/fdsx/config.yaml`) and project config (`.fdsx/config.yaml`) under the `run_hooks:` key — placing them in flow or state YAML will raise a validation error.
+- `on_wait_start` and `on_wait_end` are only valid on `wait` states and at global config, project config, and flow scope (inside `hooks:`). Placing them inside any non-wait state's `hooks:` block raises a validation error. `on_wait_start` fires before the wait prompt is shown to the user; `on_wait_end` fires after the user selects a choice and execution resumes.
 
 ### Variable References
 
@@ -569,6 +581,12 @@ hooks:
       on_failure: warn
   on_workflow_end:
     - command: "echo 'global workflow done'"
+      on_failure: warn
+  on_wait_start:
+    - command: "echo 'global wait state entered'"
+      on_failure: warn
+  on_wait_end:
+    - command: "echo 'global wait state resumed'"
       on_failure: warn
 
 # --- Run-level hooks (optional) ---

--- a/src/fdsx/core/compiler/compile.py
+++ b/src/fdsx/core/compiler/compile.py
@@ -12,6 +12,7 @@ from fdsx.core.hooks import (
     INPUT_FILENAME,
     OUTPUT_FILENAME,
     collect_hooks,
+    collect_wait_hooks,
     execute_hooks,
     write_hook_data,
 )
@@ -415,9 +416,25 @@ def compile_flow(
             )  # type: ignore[call-overload]
         elif state.type == "wait":
             on_state_start, on_state_end = _collect_state_hooks(state)
+            on_wait_start = collect_wait_hooks(
+                "on_wait_start",
+                global_hooks=config_hooks,
+                project_hooks=None,
+                flow_hooks=flow.hooks,
+                state_hooks=state.hooks,
+            )
+            on_wait_end = collect_wait_hooks(
+                "on_wait_end",
+                global_hooks=config_hooks,
+                project_hooks=None,
+                flow_hooks=flow.hooks,
+                state_hooks=state.hooks,
+            )
             # WaitState is split into two nodes: notify (pre-interrupt) and interrupt.
             # on_state_start hooks fire in the notify node; on_state_end hooks fire in the interrupt node.
-            notify_node = _create_wait_notify_node(state_name, state, recorder)
+            notify_node = _create_wait_notify_node(
+                state_name, state, recorder, on_wait_start
+            )
             graph.add_node(
                 state_name,
                 _wrap_with_hooks(
@@ -429,7 +446,9 @@ def compile_flow(
                     fdsx_base_dir=fdsx_base_dir,
                 ),
             )  # type: ignore[call-overload]
-            interrupt_node = _create_wait_interrupt_node(state_name, state, recorder)
+            interrupt_node = _create_wait_interrupt_node(
+                state_name, state, recorder, on_wait_end
+            )
             graph.add_node(
                 f"_{state_name}_int",
                 _wrap_with_hooks(

--- a/src/fdsx/core/compiler/nodes.py
+++ b/src/fdsx/core/compiler/nodes.py
@@ -1,5 +1,6 @@
 """Node factory functions for the compiler package."""
 
+import json
 import subprocess
 import time
 from collections.abc import Callable
@@ -10,6 +11,12 @@ import structlog
 from langgraph.types import interrupt
 
 from fdsx.core.extraction_fallback import FallbackEvent, resolve_fallback
+from fdsx.core.hooks import (
+    INPUT_FILENAME,
+    OUTPUT_FILENAME,
+    execute_hooks,
+    write_hook_data,
+)
 from fdsx.core.variables import (
     _strip_reserved_keys,
     inject_builtin_vars,
@@ -24,6 +31,7 @@ from fdsx.models.flow import (
     ChoiceState,
     FailState,
     Flow,
+    HookEntry,
     PassState,
     TaskState,
     WaitState,
@@ -354,7 +362,10 @@ def _create_fail_node(
 
 
 def _create_wait_notify_node(
-    state_name: str, state: WaitState, recorder: Any = None
+    state_name: str,
+    state: WaitState,
+    recorder: Any = None,
+    on_wait_start_hooks: list[HookEntry] | None = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create the pre-interrupt notify node for a Wait state.
 
@@ -377,13 +388,41 @@ def _create_wait_notify_node(
             from fdsx.notify.webhook import send_notification
 
             send_notification(state.notify, state_dict)
+
+        if on_wait_start_hooks:
+            resolved_message = resolve_template(
+                state.message, inject_builtin_vars(state_dict)
+            )
+            data_path = write_hook_data(
+                state_dict,
+                state_name=state_name,
+                filename=INPUT_FILENAME,
+                thread_id=recorder.thread_id if recorder is not None else "",
+            )
+            execute_hooks(
+                on_wait_start_hooks,
+                state_name=state_name,
+                status="starting",
+                data_path=data_path,
+                thread_id=recorder.thread_id if recorder is not None else "",
+                flow_name=recorder.flow_name if recorder is not None else "",
+                event="on_wait_start",
+                extra_env={
+                    "FDSX_WAIT_MESSAGE": resolved_message,
+                    "FDSX_WAIT_CHOICES": json.dumps(state.choices),
+                },
+            )
+
         return {"_state_iterations": iters}
 
     return node
 
 
 def _create_wait_interrupt_node(
-    state_name: str, state: WaitState, recorder: Any = None
+    state_name: str,
+    state: WaitState,
+    recorder: Any = None,
+    on_wait_end_hooks: list[HookEntry] | None = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     """Create the interrupt node for a Wait state.
 
@@ -406,6 +445,24 @@ def _create_wait_interrupt_node(
         )
 
         partial: dict[str, Any] = set_jsonpath(state.result_path, {}, user_selection)
+
+        if on_wait_end_hooks:
+            data_path = write_hook_data(
+                {**state_dict, **partial},
+                state_name=state_name,
+                filename=OUTPUT_FILENAME,
+                thread_id=recorder.thread_id if recorder is not None else "",
+            )
+            execute_hooks(
+                on_wait_end_hooks,
+                state_name=state_name,
+                status="completed",
+                data_path=data_path,
+                thread_id=recorder.thread_id if recorder is not None else "",
+                flow_name=recorder.flow_name if recorder is not None else "",
+                event="on_wait_end",
+                extra_env={"FDSX_WAIT_SELECTION": str(user_selection)},
+            )
 
         if recorder is not None:
             recorder.record_state_complete(

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -37,6 +37,8 @@ _HOOK_LIST_KEYS: frozenset[str] = frozenset(
         "on_workflow_end",
         "on_run_start",
         "on_run_end",
+        "on_wait_start",
+        "on_wait_end",
     }
 )
 

--- a/src/fdsx/core/engine/run.py
+++ b/src/fdsx/core/engine/run.py
@@ -326,6 +326,8 @@ def run_flow(
         display_completion_summary(
             flow.name, _calc_elapsed(recorder), failed_state_name, error_message
         )
+        if isinstance(e, HookAbortError):
+            raise
         raise RuntimeError(f"Flow execution failed: {e}") from e
     finally:
         if checkpoint_manager is not None:

--- a/src/fdsx/core/hooks.py
+++ b/src/fdsx/core/hooks.py
@@ -18,7 +18,7 @@ from typing import Any, Literal
 
 from fdsx.core.config import RunHookConfig
 from fdsx.logging.recorder import FDSX_DIR_NAME, RUNS_DIR_NAME
-from fdsx.models.flow import HookConfig, HookEntry
+from fdsx.models.flow import HookConfig, HookEntry, WaitStateHookConfig
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,7 @@ ENV_FLOW_NAME = "FDSX_FLOW_NAME"
 ENV_HOOKS = "FDSX_HOOKS"
 
 
-class HookAbortError(Exception):
+class HookAbortError(RuntimeError):
     """Raised when a hook with on_failure='abort' exits with a non-zero code."""
 
     def __init__(self, command: str, return_code: int) -> None:
@@ -58,7 +58,8 @@ def execute_hooks(
     data_path: Path,
     thread_id: str,
     flow_name: str,
-    event: Literal["on_state_start", "on_state_end"],
+    event: Literal["on_state_start", "on_state_end", "on_wait_start", "on_wait_end"],
+    extra_env: dict[str, str] | None = None,
 ) -> None:
     """Execute a flat list of hook commands in order.
 
@@ -88,6 +89,7 @@ def execute_hooks(
         ENV_THREAD_ID: thread_id,
         ENV_FLOW_NAME: flow_name,
         ENV_HOOKS: event,
+        **(extra_env or {}),
     }
 
     # Build positional arg suffix (safely quoted)
@@ -334,7 +336,7 @@ def collect_hooks(
     global_hooks: HookConfig | None,
     project_hooks: HookConfig | None,
     flow_hooks: HookConfig | None,
-    state_hooks: HookConfig | None,
+    state_hooks: HookConfig | WaitStateHookConfig | None,
 ) -> list[HookEntry]:
     """Collect and merge hooks from all configuration levels for a given event.
 
@@ -355,4 +357,35 @@ def collect_hooks(
     for hook_config in (global_hooks, project_hooks, flow_hooks, state_hooks):
         if hook_config is not None:
             result.extend(getattr(hook_config, event))
+    return result
+
+
+def collect_wait_hooks(
+    event: Literal["on_wait_start", "on_wait_end"],
+    *,
+    global_hooks: HookConfig | None,
+    project_hooks: HookConfig | None,
+    flow_hooks: HookConfig | None,
+    state_hooks: WaitStateHookConfig | None,
+) -> list[HookEntry]:
+    """Collect and merge wait hooks from all configuration levels.
+
+    Merges in order: global → project → flow → state.
+
+    Args:
+        event: "on_wait_start" or "on_wait_end".
+        global_hooks: Hook config from global ~/.config/fdsx/config.yaml.
+        project_hooks: Hook config from project .fdsx/config.yaml.
+        flow_hooks: Hook config from the flow definition.
+        state_hooks: Wait-specific hook config from the individual wait state.
+
+    Returns:
+        Concatenated list of HookEntry objects in global → project → flow → state order.
+    """
+    result: list[HookEntry] = []
+    for hook_config in (global_hooks, project_hooks, flow_hooks):
+        if hook_config is not None:
+            result.extend(getattr(hook_config, event, []))
+    if state_hooks is not None:
+        result.extend(getattr(state_hooks, event, []))
     return result

--- a/src/fdsx/data/skills/fdsx/SKILL.md
+++ b/src/fdsx/data/skills/fdsx/SKILL.md
@@ -216,11 +216,11 @@ When `fdsx run` is invoked with no workflow, no `--tasks-dir`, and no `--input`,
 
 ## Hooks
 
-Shell commands that run at lifecycle events. There are three scopes with different behaviors:
+Shell commands that run at lifecycle events. There are four scopes with different behaviors:
 
 ### State-scope hooks (`on_state_start`, `on_state_end`)
 
-Run before/after individual state execution. Can be defined at flow level and per-state level. Per-state `hooks` blocks on `task`, `choice`, `parallel`, `wait`, and `map` states **only** accept `on_state_start` and `on_state_end` — using `on_workflow_start` or `on_workflow_end` in those state blocks raises a validation error. **Exception:** `pass` state `hooks` blocks use the full `HookConfig` and accept all four keys (workflow-scope keys are silently ignored at runtime).
+Run before/after individual state execution. Can be defined at flow level and per-state level. Per-state `hooks` blocks on `task`, `choice`, `parallel`, `map`, and `fail` states **only** accept `on_state_start` and `on_state_end` — using `on_workflow_start`, `on_workflow_end`, `on_wait_start`, or `on_wait_end` in those state blocks raises a validation error. **Exception:** `pass` state `hooks` blocks use the full `HookConfig` and accept all six keys (workflow-scope and wait-scope keys are silently ignored at runtime). **Wait state exception:** `wait` state `hooks` blocks use `WaitStateHookConfig`, which accepts `on_state_start`, `on_state_end`, `on_wait_start`, and `on_wait_end` — but not `on_workflow_start` or `on_workflow_end`.
 
 ```yaml
 hooks:
@@ -243,6 +243,44 @@ Each state-scope hook command receives:
 Hook data files are written to `.fdsx/runs/<thread-id>/hooks/<state-name>/input.json` (before execution) and `output.json` (after execution).
 
 State-scope hooks respect `on_failure: abort` — a non-zero exit with `abort` policy raises an error and stops the workflow. `warn` (default) logs a warning and continues.
+
+### Wait-scope hooks (`on_wait_start`, `on_wait_end`)
+
+Run when a `wait` state suspends (before prompting the user) and resumes (after the user provides input). Can be defined at flow level, config level, or in a `wait` state's `hooks` block.
+
+```yaml
+states:
+  approval:
+    type: wait
+    mode: prompt
+    message: "Approve this change?"
+    choices: [APPROVED, REJECTED]
+    result_path: $.decision
+    hooks:
+      on_wait_start:
+        - command: "notify.sh 'Waiting for approval'"
+          on_failure: warn
+      on_wait_end:
+        - command: "notify.sh 'Decision received'"
+    next: process
+```
+
+**`on_wait_start`** fires before the wait state suspends and the user prompt is displayed.
+
+**`on_wait_end`** fires after the user provides input and the wait state resumes execution.
+
+Each wait-scope hook command receives the same positional arguments and environment variables as state-scope hooks:
+
+- **Positional arguments:** `$1=state_name`, `$2=status`, `$3=data_path`
+- **Environment variables:** `FDSX_STATE_NAME`, `FDSX_STATUS`, `FDSX_DATA_PATH`, `FDSX_THREAD_ID`, `FDSX_FLOW_NAME`, `FDSX_HOOKS`
+
+`FDSX_STATUS` values: `starting` (on_wait_start), `completed` or `failed` (on_wait_end).
+
+`FDSX_HOOKS` contains `on_wait_start` or `on_wait_end`.
+
+Wait-scope hooks respect `on_failure: abort` — a non-zero exit with `abort` policy raises an error and stops the workflow. `warn` (default) logs a warning and continues.
+
+Hook merging: global → project → flow → state (same order as state-scope hooks).
 
 ### Workflow-scope hooks (`on_workflow_start`, `on_workflow_end`)
 
@@ -318,6 +356,10 @@ hooks:                          # global hooks applied to all flows
     - command: "echo starting"
   on_workflow_end:
     - command: "notify.sh"
+  on_wait_start:
+    - command: "echo wait starting"
+  on_wait_end:
+    - command: "echo wait ended"
 run_hooks:                      # run-level hooks fired once per CLI invocation
   on_run_start:
     - command: "echo CLI starting"
@@ -335,7 +377,7 @@ Both `workflow_selector` and `task_splitter` support `profile: <name>` (XOR with
 
 `retry_escalation` at config level sets the project-wide default escalation target used when a workflow AI task exhausts its primary-provider retries. Individual workflows can override it with their own `retry_escalation:` field (full `provider` + `model` object) or opt out entirely with `retry_escalation: false`. When a workflow omits `retry_escalation`, the config-level value is inherited automatically. When both global (`~/.config/fdsx/config.yaml`) and project (`.fdsx/config.yaml`) declare this block, the project block fully replaces the global one — fields are not merged.
 
-`hooks` at config level supports all four lifecycle keys (`on_state_start`, `on_state_end`, `on_workflow_start`, `on_workflow_end`) and are prepended to flow-level and state-level hooks.
+`hooks` at config level supports all six lifecycle keys (`on_state_start`, `on_state_end`, `on_workflow_start`, `on_workflow_end`, `on_wait_start`, `on_wait_end`) and are prepended to flow-level and state-level hooks.
 
 `run_hooks` is a separate key from `hooks` and only supports `on_run_start` and `on_run_end`.
 
@@ -422,5 +464,6 @@ states:
 - Extract `result_path` must not use reserved keys: `output`, `exit_code`, `error`
 - Map iterator states must all have `type: task` and unique `name` fields
 - `extraction_fallback` at flow level must have exactly one of `provider + model` or `profile` set (XOR); `provider` requires `model` and vice versa; `system` is forbidden as provider. Set to `false` to disable config-level inheritance.
-- `on_workflow_start` and `on_workflow_end` are forbidden inside per-state `hooks` blocks for `task`, `choice`, `parallel`, `wait`, and `map` states; `pass` state `hooks` accepts all four keys (workflow-scope keys are silently ignored at runtime)
+- `on_workflow_start` and `on_workflow_end` are forbidden inside per-state `hooks` blocks for `task`, `choice`, `parallel`, `wait`, `map`, and `fail` states; `pass` state `hooks` accepts all six keys (workflow-scope and wait-scope keys are silently ignored at runtime)
+- `on_wait_start` and `on_wait_end` are only valid on `wait` state `hooks` blocks and at flow/config level; using them on `task`, `choice`, `parallel`, `map`, or `fail` state `hooks` blocks raises a validation error (`pass` state accepts them via `HookConfig` but silently ignores them at runtime)
 - `on_run_start` and `on_run_end` are forbidden in flow YAML (`Flow.hooks`) and all state `hooks` blocks — they are only valid in `.fdsx/config.yaml` and `~/.config/fdsx/config.yaml` under the `run_hooks:` key

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -21,6 +21,7 @@ Complete field-by-field reference for fdsx workflow YAML files, derived from the
 - [AggregateRule](#aggregaterule)
 - [HookConfig](#hookconfig)
 - [StateHookConfig](#statehookconfig)
+- [WaitStateHookConfig](#waitstatehookconfig)
 - [RunHookConfig](#runhookconfig)
 - [ProfileConfig](#profileconfig)
 - [Provider Options](#provider-options)
@@ -149,7 +150,7 @@ choices: [string]               # required — min 1 item, user selection option
 result_path: string             # required — JSONPath for selection result
 notify?: NotifyConfig           # optional — webhook notification
 max_iterations?: int            # optional — >=1
-hooks?: StateHookConfig         # optional — per-state hooks (on_state_start/on_state_end only)
+hooks?: WaitStateHookConfig     # optional — per-state hooks (on_state_start/on_state_end/on_wait_start/on_wait_end)
 next?: string                   # XOR with end
 end?: bool                      # XOR with next
 ```
@@ -366,7 +367,7 @@ aggregate:
 
 ## HookConfig
 
-Used at **flow level** (`Flow.hooks`), in **config files** (under `hooks:`), and in `PassState.hooks`. Supports all four state/workflow lifecycle events.
+Used at **flow level** (`Flow.hooks`), in **config files** (under `hooks:`), and in `PassState.hooks`. Supports all state/workflow/wait lifecycle events.
 
 ```yaml
 hooks:
@@ -382,6 +383,12 @@ hooks:
   on_workflow_end:              # optional — hooks run once when the workflow ends
     - command: string
       on_failure: string        # note: ignored for workflow-scope hooks (always warn-only)
+  on_wait_start:                # optional — hooks run before a wait state suspends
+    - command: string
+      on_failure: string
+  on_wait_end:                  # optional — hooks run after a wait state resumes
+    - command: string
+      on_failure: string
 ```
 
 **Legacy keys rejected:** `on_start` and `on_complete` raise a validation error. Use `on_state_start` and `on_state_end`.
@@ -389,6 +396,8 @@ hooks:
 **Run-scope keys rejected:** `on_run_start` and `on_run_end` raise a validation error when used in `Flow.hooks` (flow YAML). These keys are only valid in `.fdsx/config.yaml` and `~/.config/fdsx/config.yaml` under the separate `run_hooks:` key — see [RunHookConfig](#runhookconfig).
 
 **Workflow-scope key restriction:** `on_workflow_start` and `on_workflow_end` are **only valid** at flow level, project config, and global config scope. Using them inside a state's `hooks` block raises a validation error (except in `PassState`, which uses the full `HookConfig` — see [PassState](#passstate)).
+
+**Wait-scope key restriction:** `on_wait_start` and `on_wait_end` in `HookConfig` are honoured at flow level and config level (they fire for all wait states). At per-state level, only `WaitState.hooks` (typed as `WaitStateHookConfig`) accepts these keys; other state types using `StateHookConfig` will raise a validation error if they include `on_wait_start` or `on_wait_end`.
 
 ---
 
@@ -435,9 +444,33 @@ Each command receives:
 
 ---
 
+### Wait Hook Behavior (`on_wait_start` / `on_wait_end`)
+
+**`on_wait_start`** fires in the wait state's notify node, before the interrupt suspends and control is handed to the user. It fires on both fresh runs and resumes.
+
+**`on_wait_end`** fires in the wait state's interrupt node, after the user provides input and execution resumes.
+
+These hooks can be defined at flow level (`Flow.hooks`), in config files (under `hooks:`), and at the state level (only on `WaitState.hooks` via `WaitStateHookConfig`). They are collected and merged in global → project → flow → state order.
+
+Each command receives:
+
+**Positional arguments:** `$1=state_name`, `$2=status`, `$3=data_path`
+
+**Environment variables:**
+- `FDSX_STATE_NAME` — current wait state name
+- `FDSX_STATUS` — lifecycle status: `starting` (on_wait_start), `completed` (on_wait_end)
+- `FDSX_DATA_PATH` — path to the state data JSON file
+- `FDSX_THREAD_ID` — current run thread ID
+- `FDSX_FLOW_NAME` — name of the flow
+- `FDSX_HOOKS` — lifecycle event name: `on_wait_start` or `on_wait_end`
+
+**Failure policy:** Follows the same `on_failure: abort|warn` policy as state-scope hooks.
+
+---
+
 ## StateHookConfig
 
-Used by **most state types** (`TaskState`, `ChoiceState`, `ParallelState`, `WaitState`, `MapState`, `FailState`) for per-state hook configuration. Identical to `HookConfig` except that `on_workflow_start`, `on_workflow_end`, `on_run_start`, and `on_run_end` are explicitly forbidden.
+Used by **most state types** (`TaskState`, `ChoiceState`, `ParallelState`, `MapState`, `FailState`) for per-state hook configuration. Identical to `HookConfig` except that `on_workflow_start`, `on_workflow_end`, `on_run_start`, `on_run_end`, `on_wait_start`, and `on_wait_end` are explicitly forbidden.
 
 ```yaml
 hooks:
@@ -449,7 +482,37 @@ hooks:
       on_failure: string
 ```
 
-**Rejected keys:** `on_start`, `on_complete` (legacy), `on_workflow_start`, `on_workflow_end`, `on_run_start`, and `on_run_end` all raise a validation error when used inside a state's `hooks` block. Workflow-scope keys (`on_workflow_start`, `on_workflow_end`) are only valid at flow level or in config files. Run-scope keys (`on_run_start`, `on_run_end`) are only valid in config files under the `run_hooks:` key.
+**Rejected keys:** `on_start`, `on_complete` (legacy), `on_workflow_start`, `on_workflow_end`, `on_run_start`, `on_run_end`, `on_wait_start`, and `on_wait_end` all raise a validation error when used inside a non-wait state's `hooks` block.
+
+- Workflow-scope keys (`on_workflow_start`, `on_workflow_end`) are only valid at flow level or in config files.
+- Run-scope keys (`on_run_start`, `on_run_end`) are only valid in config files under the `run_hooks:` key.
+- Wait-scope keys (`on_wait_start`, `on_wait_end`) are only valid on `WaitState.hooks` (via `WaitStateHookConfig`) or at flow/config level.
+
+---
+
+## WaitStateHookConfig
+
+Used exclusively by **`WaitState.hooks`** for per-state hook configuration on wait states. Extends state-scope hooks with `on_wait_start` and `on_wait_end`.
+
+```yaml
+hooks:
+  on_state_start:               # optional — hooks run before wait state execution
+    - command: string           # required — shell command (min 1 char)
+      on_failure: string        # default: "warn" — abort|warn
+  on_state_end:                 # optional — hooks run after wait state completes
+    - command: string
+      on_failure: string
+  on_wait_start:                # optional — hooks run before the wait interrupt suspends
+    - command: string
+      on_failure: string
+  on_wait_end:                  # optional — hooks run after the wait interrupt resumes
+    - command: string
+      on_failure: string
+```
+
+**Rejected keys:** `on_start`, `on_complete` (legacy), `on_workflow_start`, `on_workflow_end`, `on_run_start`, and `on_run_end` all raise a validation error. Workflow-scope and run-scope keys are not valid at state level for any state type.
+
+**Accepted keys unique to wait states:** `on_wait_start` and `on_wait_end`. These are rejected by `StateHookConfig` (used by all other state types) with the error: `"'{key}' is only valid on wait states, not on this state type"`.
 
 ---
 
@@ -467,7 +530,7 @@ run_hooks:
       on_failure: string        # note: on_failure is ignored; run hooks are always warn-only
 ```
 
-**Scope:** `run_hooks` is a **separate top-level key** in `.fdsx/config.yaml` and `~/.config/fdsx/config.yaml`. It is distinct from `hooks:` (which contains state/workflow lifecycle events). Using `on_run_start`/`on_run_end` inside `hooks:` raises a validation error.
+**Scope:** `run_hooks` is a **separate top-level key** in `.fdsx/config.yaml` and `~/.config/fdsx/config.yaml`. It is distinct from `hooks:` (which contains state/workflow/wait lifecycle events). Using `on_run_start`/`on_run_end` inside `hooks:` raises a validation error.
 
 **`on_run_start`** fires once at the start of a `fdsx run` or `fdsx resume` CLI invocation, before any workflow or checkpoint logic executes.
 
@@ -604,8 +667,9 @@ providers?:
   opencode?: OpenCodeOptions
   gemini?: GeminiOptions
 
-hooks?: HookConfig              # workflow/state lifecycle hooks applied to all flows
-                                # accepts: on_state_start, on_state_end, on_workflow_start, on_workflow_end
+hooks?: HookConfig              # workflow/state/wait lifecycle hooks applied to all flows
+                                # accepts: on_state_start, on_state_end, on_workflow_start,
+                                #          on_workflow_end, on_wait_start, on_wait_end
                                 # does NOT accept: on_run_start, on_run_end (use run_hooks: instead)
 
 run_hooks?:                     # run-level lifecycle hooks fired once per CLI invocation
@@ -629,7 +693,7 @@ retry_escalation?:              # absent by default — global escalation target
 
 Config uses `extra="forbid"` — unknown keys cause validation errors.
 
-**Hook merging:** During global → project config deep merge, all six hook list keys (`on_state_start`, `on_state_end`, `on_workflow_start`, `on_workflow_end`, `on_run_start`, `on_run_end`) are **concatenated** (base + override), not replaced. This means hooks defined in global config are prepended to hooks defined in project config. Flow-level and state-level hooks are further appended at runtime in global → project → flow → state order. Run-scope hooks (`on_run_start`, `on_run_end`) only merge at global → project level; they are not present at flow or state level.
+**Hook merging:** During global → project config deep merge, all eight hook list keys (`on_state_start`, `on_state_end`, `on_workflow_start`, `on_workflow_end`, `on_run_start`, `on_run_end`, `on_wait_start`, `on_wait_end`) are **concatenated** (base + override), not replaced. This means hooks defined in global config are prepended to hooks defined in project config. Flow-level and state-level hooks are further appended at runtime in global → project → flow → state order. Run-scope hooks (`on_run_start`, `on_run_end`) only merge at global → project level; they are not present at flow or state level. Wait-scope hooks (`on_wait_start`, `on_wait_end`) merge at global → project → flow → state (wait states only) level.
 
 Both `workflow_selector` and `task_splitter` support `profile: <name>` (XOR with `provider`/`model`).
 

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -162,6 +162,12 @@ class HookConfig(BaseModel):
     on_workflow_end: list[HookEntry] = Field(
         default_factory=list, description="Hooks to run when the workflow ends"
     )
+    on_wait_start: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run before wait state suspends"
+    )
+    on_wait_end: list[HookEntry] = Field(
+        default_factory=list, description="Hooks to run after wait state resumes"
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -266,6 +272,62 @@ class StateHookConfig(BaseModel):
                 "configuration, not in flow or state YAML."
             )
         return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_wait_hooks(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            for key in ("on_wait_start", "on_wait_end"):
+                if key in data:
+                    raise ValueError(
+                        f"'{key}' is only valid on wait states, not on this state type"
+                    )
+        return data
+
+
+class WaitStateHookConfig(BaseModel):
+    """Hook configuration for wait states (includes on_wait_start / on_wait_end)."""
+
+    on_state_start: list[HookEntry] = Field(default_factory=list)
+    on_state_end: list[HookEntry] = Field(default_factory=list)
+    on_wait_start: list[HookEntry] = Field(default_factory=list)
+    on_wait_end: list[HookEntry] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_keys(cls, values: Any) -> Any:
+        if not isinstance(values, dict):
+            return values
+        if "on_start" in values:
+            raise ValueError(
+                "Hook key 'on_start' has been renamed to 'on_state_start'. "
+                "Update the YAML file and retry."
+            )
+        if "on_complete" in values:
+            raise ValueError(
+                "Hook key 'on_complete' has been renamed to 'on_state_end'. "
+                "Update the YAML file and retry."
+            )
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_workflow_and_run_hooks(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        for key in ("on_workflow_start", "on_workflow_end"):
+            if key in data:
+                raise ValueError(
+                    f"Hook key '{key}' is only valid at flow/project/global scope, "
+                    "not in state blocks."
+                )
+        for key in ("on_run_start", "on_run_end"):
+            if key in data:
+                raise ValueError(
+                    f"Hook key '{key}' may only appear in global or project "
+                    "configuration, not in flow or state YAML."
+                )
+        return data
 
 
 class ChoiceRule(BaseModel):
@@ -612,7 +674,7 @@ class WaitState(BaseModel):
     max_iterations: int | None = Field(
         default=None, ge=1, description="Max times this state can be entered"
     )
-    hooks: StateHookConfig | None = Field(
+    hooks: WaitStateHookConfig | None = Field(
         default=None, description="Hook configuration"
     )
     next: str | None = Field(

--- a/tests/integration/test_wait_hooks.py
+++ b/tests/integration/test_wait_hooks.py
@@ -1,0 +1,581 @@
+"""Integration tests: on_wait_start / on_wait_end lifecycle hooks for wait states.
+
+Covers:
+  T001 — state-level hook execution, env vars, failure semantics, resume semantics
+  T002 — multi-level config (flow-level and additive state + flow merge)
+"""
+
+import json
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from fdsx.core.config import FdsxConfig
+from fdsx.core.engine import resume_flow, run_flow
+from fdsx.core.hooks import HookAbortError
+from fdsx.models.flow import HookConfig, HookEntry
+
+# ─── YAML helpers ─────────────────────────────────────────────────────────────
+
+
+def _write_flow(
+    path: Path,
+    *,
+    state_hooks_yaml: str = "",
+    flow_hooks_yaml: str = "",
+) -> Path:
+    """Write a minimal single-wait-state flow YAML.
+
+    *flow_hooks_yaml* lines are indented 2 spaces under ``hooks:``.
+    *state_hooks_yaml* lines are indented 6 spaces under ``    hooks:``.
+    """
+    lines = [
+        "name: WaitHooksTest",
+        "description: wait hooks integration test",
+        "start_at: await_approval",
+    ]
+    if flow_hooks_yaml:
+        lines.append("hooks:")
+        for line in textwrap.dedent(flow_hooks_yaml).strip().splitlines():
+            lines.append("  " + line)
+    lines += [
+        "states:",
+        "  await_approval:",
+        "    type: wait",
+        '    message: "Approve the request?"',
+        "    choices:",
+        "      - approve",
+        "      - reject",
+        "    result_path: $.approval",
+    ]
+    if state_hooks_yaml:
+        lines.append("    hooks:")
+        for line in textwrap.dedent(state_hooks_yaml).strip().splitlines():
+            lines.append("      " + line)
+    lines.append("    end: true")
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def _write_two_wait_flow(path: Path, *, flow_hooks_yaml: str = "") -> Path:
+    """Write a flow with two sequential wait states (for multi-level hook tests)."""
+    lines = [
+        "name: TwoWaitFlow",
+        "description: two-wait flow",
+        "start_at: wait_one",
+    ]
+    if flow_hooks_yaml:
+        lines.append("hooks:")
+        for line in textwrap.dedent(flow_hooks_yaml).strip().splitlines():
+            lines.append("  " + line)
+    lines += [
+        "states:",
+        "  wait_one:",
+        "    type: wait",
+        '    message: "First decision?"',
+        "    choices:",
+        "      - approve",
+        "      - reject",
+        "    result_path: $.decision1",
+        "    next: wait_two",
+        "  wait_two:",
+        "    type: wait",
+        '    message: "Second decision?"',
+        "    choices:",
+        "      - approve",
+        "      - reject",
+        "    result_path: $.decision2",
+        "    end: true",
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+# ─── T001: state-level hook execution ─────────────────────────────────────────
+
+
+class TestWaitHookExecution:
+    """on_wait_start and on_wait_end fire at the right moments in the wait lifecycle."""
+
+    def test_on_wait_start_fires_before_interrupt(self, tmp_path: Path) -> None:
+        """execute_hooks must be called with event='on_wait_start' when the flow reaches
+        the wait state (before the LangGraph interrupt suspends execution)."""
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo on_wait_start"
+            """,
+        )
+        with (
+            patch("fdsx.core.compiler.nodes.execute_hooks", create=True) as mock_exec,
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        start_calls = [
+            c
+            for c in mock_exec.call_args_list
+            if c.kwargs.get("event") == "on_wait_start"
+        ]
+        assert len(start_calls) == 1, (
+            "expected execute_hooks called once with event='on_wait_start'"
+        )
+
+    def test_on_wait_end_fires_after_selection(self, tmp_path: Path) -> None:
+        """execute_hooks must be called with event='on_wait_end' after user_selection
+        is written to result_path and before state completion."""
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_end:
+                  - command: "echo on_wait_end"
+            """,
+        )
+        with (
+            patch("fdsx.core.compiler.nodes.execute_hooks", create=True) as mock_exec,
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        end_calls = [
+            c
+            for c in mock_exec.call_args_list
+            if c.kwargs.get("event") == "on_wait_end"
+        ]
+        assert len(end_calls) == 1, (
+            "expected execute_hooks called once with event='on_wait_end'"
+        )
+
+    def test_on_wait_start_fires_before_on_wait_end(self, tmp_path: Path) -> None:
+        """on_wait_start must be invoked before on_wait_end in a single wait state execution."""
+        call_log: list[str] = []
+
+        def _track(hooks, *, event, **kwargs):  # type: ignore[no-untyped-def]
+            call_log.append(event)
+
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo start"
+                on_wait_end:
+                  - command: "echo end"
+            """,
+        )
+        with (
+            patch(
+                "fdsx.core.compiler.nodes.execute_hooks",
+                create=True,
+                side_effect=_track,
+            ),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        assert "on_wait_start" in call_log, "on_wait_start never fired"
+        assert "on_wait_end" in call_log, "on_wait_end never fired"
+        assert call_log.index("on_wait_start") < call_log.index("on_wait_end"), (
+            "on_wait_start must fire before on_wait_end"
+        )
+
+
+class TestWaitHookEnvVars:
+    """Hooks receive the correct FDSX_WAIT_* environment variables."""
+
+    def test_on_wait_start_env_includes_wait_message_and_choices(
+        self, tmp_path: Path
+    ) -> None:
+        """The subprocess spawned by on_wait_start must have FDSX_WAIT_MESSAGE and
+        FDSX_WAIT_CHOICES in its environment."""
+        captured_envs: list[dict] = []
+
+        def _capture_subprocess(*args, **kwargs):  # type: ignore[no-untyped-def]
+            env = kwargs.get("env") or {}
+            if "FDSX_WAIT_MESSAGE" in env or "FDSX_WAIT_CHOICES" in env:
+                captured_envs.append(dict(env))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo check_env"
+            """,
+        )
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=_capture_subprocess),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        assert captured_envs, (
+            "No subprocess calls with FDSX_WAIT_MESSAGE/FDSX_WAIT_CHOICES — "
+            "on_wait_start hook env vars not yet implemented"
+        )
+        env = captured_envs[0]
+        assert "FDSX_WAIT_MESSAGE" in env, (
+            "FDSX_WAIT_MESSAGE missing from on_wait_start env"
+        )
+        assert "FDSX_WAIT_CHOICES" in env, (
+            "FDSX_WAIT_CHOICES missing from on_wait_start env"
+        )
+        choices = json.loads(env["FDSX_WAIT_CHOICES"])
+        assert "approve" in choices
+
+    def test_on_wait_end_env_includes_wait_selection(self, tmp_path: Path) -> None:
+        """The subprocess spawned by on_wait_end must have FDSX_WAIT_SELECTION in its env."""
+        captured_envs: list[dict] = []
+
+        def _capture_subprocess(*args, **kwargs):  # type: ignore[no-untyped-def]
+            env = kwargs.get("env") or {}
+            if "FDSX_WAIT_SELECTION" in env:
+                captured_envs.append(dict(env))
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_end:
+                  - command: "echo check_end_env"
+            """,
+        )
+        with (
+            patch("fdsx.core.hooks.subprocess.run", side_effect=_capture_subprocess),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        assert captured_envs, (
+            "No subprocess call with FDSX_WAIT_SELECTION — "
+            "on_wait_end env var not yet implemented"
+        )
+        assert "FDSX_WAIT_SELECTION" in captured_envs[0]
+
+
+class TestWaitHookFailureSemantics:
+    """on_failure: abort and on_failure: warn behave correctly."""
+
+    def test_on_failure_abort_halts_workflow(self, tmp_path: Path) -> None:
+        """A hook with on_failure: abort that exits non-zero must raise HookAbortError,
+        preventing subsequent states from running."""
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "exit 1"
+                    on_failure: abort
+            """,
+        )
+        with pytest.raises(HookAbortError), patch("builtins.input", return_value="1"):
+            run_flow(path, base_dir=tmp_path)
+
+    def test_on_failure_warn_workflow_continues(self, tmp_path: Path) -> None:
+        """A hook with on_failure: warn that exits non-zero must log a warning and
+        allow the workflow to continue normally to completion."""
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "exit 1"
+                    on_failure: warn
+            """,
+        )
+        with (
+            patch("fdsx.core.compiler.nodes.execute_hooks", create=True) as mock_exec,
+            patch("builtins.input", return_value="1"),
+        ):
+            result = run_flow(path, base_dir=tmp_path)
+
+        assert result is not None, "run_flow must return a result when on_failure=warn"
+        warn_calls = [
+            c
+            for c in mock_exec.call_args_list
+            if c.kwargs.get("event") == "on_wait_start"
+        ]
+        assert len(warn_calls) == 1, (
+            "on_wait_start hook must have been called even with on_failure=warn"
+        )
+
+
+# ─── T001: resume semantics ────────────────────────────────────────────────────
+
+
+class TestWaitHookResumeSemantics:
+    """on_wait_start and on_wait_end fire exactly the right number of times across
+    an initial run + checkpoint resume."""
+
+    def _write_resumable_flow(self, tmp_path: Path) -> Path:
+        return _write_flow(
+            tmp_path / "flow.yaml",
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo start"
+                on_wait_end:
+                  - command: "echo end"
+            """,
+        )
+
+    def test_on_wait_start_does_not_refire_on_resume(self, tmp_path: Path) -> None:
+        """on_wait_start fires exactly once — before the first suspension —
+        and must NOT fire again when the workflow is resumed from a checkpoint."""
+        path = self._write_resumable_flow(tmp_path)
+        thread_id = "test-wait-hooks-no-refire"
+        start_fire_count = 0
+
+        def _count_start(hooks, *, event, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal start_fire_count
+            if event == "on_wait_start":
+                start_fire_count += 1
+
+        with patch(
+            "fdsx.core.compiler.nodes.execute_hooks",
+            create=True,
+            side_effect=_count_start,
+        ):
+            with (
+                pytest.raises(RuntimeError),
+                patch(
+                    "fdsx.core.engine.interrupts.display_wait_prompt",
+                    side_effect=RuntimeError("simulated interrupt for checkpoint"),
+                ),
+            ):
+                run_flow(path, base_dir=tmp_path, thread_id=thread_id)
+
+            count_after_first_run = start_fire_count
+
+            with patch("builtins.input", return_value="1"):
+                resume_flow(thread_id, tmp_path, path)
+
+        assert count_after_first_run == 1, (
+            "on_wait_start must fire exactly once before the first suspension"
+        )
+        assert start_fire_count == 1, (
+            "on_wait_start must NOT re-fire on checkpoint resume"
+        )
+
+    def test_on_wait_end_fires_exactly_once_on_resume(self, tmp_path: Path) -> None:
+        """on_wait_end fires exactly once — after user_selection is written on the
+        resumed run — and must not fire during the initial suspended run."""
+        path = self._write_resumable_flow(tmp_path)
+        thread_id = "test-wait-hooks-end-once"
+        end_fire_count = 0
+
+        def _count_end(hooks, *, event, **kwargs):  # type: ignore[no-untyped-def]
+            nonlocal end_fire_count
+            if event == "on_wait_end":
+                end_fire_count += 1
+
+        with patch(
+            "fdsx.core.compiler.nodes.execute_hooks",
+            create=True,
+            side_effect=_count_end,
+        ):
+            with (
+                pytest.raises(RuntimeError),
+                patch(
+                    "fdsx.core.engine.interrupts.display_wait_prompt",
+                    side_effect=RuntimeError("simulated interrupt for checkpoint"),
+                ),
+            ):
+                run_flow(path, base_dir=tmp_path, thread_id=thread_id)
+
+            count_after_first_run = end_fire_count
+
+            with patch("builtins.input", return_value="1"):
+                resume_flow(thread_id, tmp_path, path)
+
+        assert count_after_first_run == 0, (
+            "on_wait_end must not fire during the initial suspended run"
+        )
+        assert end_fire_count == 1, (
+            "on_wait_end must fire exactly once after user provides selection on resume"
+        )
+
+
+# ─── T002: multi-level configuration ──────────────────────────────────────────
+
+
+class TestWaitHookMultiLevelConfig:
+    """on_wait_start / on_wait_end hooks declared at flow level fire for all wait states,
+    and state-level declarations are additive (not replacing) higher-level hooks."""
+
+    def test_flow_level_on_wait_start_fires_for_all_wait_states(
+        self, tmp_path: Path
+    ) -> None:
+        """on_wait_start declared in flow.hooks (not per-state) must fire for every
+        wait state in the flow, even when the wait state has no per-state hooks."""
+        path = _write_two_wait_flow(
+            tmp_path / "flow.yaml",
+            flow_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo flow-level start"
+            """,
+        )
+        with (
+            patch("fdsx.core.compiler.nodes.execute_hooks", create=True) as mock_exec,
+            patch(
+                "fdsx.core.compiler.nodes.write_hook_data",
+                return_value=Path("/dev/null"),
+            ),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        start_calls = [
+            c
+            for c in mock_exec.call_args_list
+            if c.kwargs.get("event") == "on_wait_start"
+        ]
+        assert len(start_calls) == 2, (
+            "flow-level on_wait_start must fire once per wait state "
+            f"(2 wait states); got {len(start_calls)} calls"
+        )
+
+    def test_flow_level_on_wait_end_fires_for_all_wait_states(
+        self, tmp_path: Path
+    ) -> None:
+        """on_wait_end declared in flow.hooks must fire for every wait state in the flow."""
+        path = _write_two_wait_flow(
+            tmp_path / "flow.yaml",
+            flow_hooks_yaml="""\
+                on_wait_end:
+                  - command: "echo flow-level end"
+            """,
+        )
+        with (
+            patch("fdsx.core.compiler.nodes.execute_hooks", create=True) as mock_exec,
+            patch(
+                "fdsx.core.compiler.nodes.write_hook_data",
+                return_value=Path("/dev/null"),
+            ),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        end_calls = [
+            c
+            for c in mock_exec.call_args_list
+            if c.kwargs.get("event") == "on_wait_end"
+        ]
+        assert len(end_calls) == 2, (
+            "flow-level on_wait_end must fire once per wait state "
+            f"(2 wait states); got {len(end_calls)} calls"
+        )
+
+    def test_state_level_hooks_append_to_flow_level_hooks(self, tmp_path: Path) -> None:
+        """When on_wait_start is declared at both flow level and state level, both
+        hook entries must run (additive merge, not replacement)."""
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            flow_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo flow-level"
+            """,
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo state-level"
+            """,
+        )
+
+        executed_commands: list[str] = []
+
+        def _capture(hooks, *, event, **kwargs):  # type: ignore[no-untyped-def]
+            if event == "on_wait_start":
+                for h in hooks:
+                    executed_commands.append(getattr(h, "command", str(h)))
+
+        with (
+            patch(
+                "fdsx.core.compiler.nodes.execute_hooks",
+                create=True,
+                side_effect=_capture,
+            ),
+            patch(
+                "fdsx.core.compiler.nodes.write_hook_data",
+                return_value=Path("/dev/null"),
+            ),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        assert len(executed_commands) >= 2, (
+            "Both flow-level and state-level on_wait_start hooks must run "
+            f"(additive merge); only {len(executed_commands)} hook(s) ran"
+        )
+
+    def test_global_config_on_wait_start_fires_for_wait_state(
+        self, tmp_path: Path
+    ) -> None:
+        """on_wait_start declared in global FdsxConfig.hooks fires even when the
+        flow and state have no per-level declarations."""
+        path = _write_flow(tmp_path / "flow.yaml")
+        global_config = FdsxConfig(
+            hooks=HookConfig(on_wait_start=[HookEntry(command="echo global-start")])
+        )
+        with (
+            patch("fdsx.core.engine.run.load_config", return_value=global_config),
+            patch("fdsx.core.compiler.nodes.execute_hooks", create=True) as mock_exec,
+            patch(
+                "fdsx.core.compiler.nodes.write_hook_data",
+                return_value=Path("/dev/null"),
+            ),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        start_calls = [
+            c
+            for c in mock_exec.call_args_list
+            if c.kwargs.get("event") == "on_wait_start"
+        ]
+        assert len(start_calls) == 1, (
+            f"global on_wait_start must fire once; got {len(start_calls)} calls"
+        )
+
+    def test_global_flow_state_merge_order(self, tmp_path: Path) -> None:
+        """Hooks at all three levels run in global -> flow -> state order."""
+        path = _write_flow(
+            tmp_path / "flow.yaml",
+            flow_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo flow-level"
+            """,
+            state_hooks_yaml="""\
+                on_wait_start:
+                  - command: "echo state-level"
+            """,
+        )
+        global_config = FdsxConfig(
+            hooks=HookConfig(on_wait_start=[HookEntry(command="echo global-level")])
+        )
+
+        executed_commands: list[str] = []
+
+        def _capture(hooks, *, event, **kwargs):  # type: ignore[no-untyped-def]
+            if event == "on_wait_start":
+                for h in hooks:
+                    executed_commands.append(getattr(h, "command", str(h)))
+
+        with (
+            patch("fdsx.core.engine.run.load_config", return_value=global_config),
+            patch(
+                "fdsx.core.compiler.nodes.execute_hooks",
+                create=True,
+                side_effect=_capture,
+            ),
+            patch(
+                "fdsx.core.compiler.nodes.write_hook_data",
+                return_value=Path("/dev/null"),
+            ),
+            patch("builtins.input", return_value="1"),
+        ):
+            run_flow(path, base_dir=tmp_path)
+
+        assert executed_commands == [
+            "echo global-level",
+            "echo flow-level",
+            "echo state-level",
+        ], f"Expected global->flow->state order; got {executed_commands}"

--- a/tests/unit/test_wait_hooks_validation.py
+++ b/tests/unit/test_wait_hooks_validation.py
@@ -1,0 +1,135 @@
+"""Validation: on_wait_start / on_wait_end rejected on non-wait states, accepted on wait states."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from fdsx.core.loader import load_flow
+from fdsx.models.flow import StateHookConfig
+
+_WAIT_STATE_YAML = textwrap.dedent("""\
+    name: WaitHookValidationTest
+    description: wait hooks validation test
+    start_at: await_approval
+    states:
+      await_approval:
+        type: wait
+        message: "Approve the request?"
+        choices:
+          - approve
+          - reject
+        result_path: $.approval
+        hooks:
+          {hook_key}:
+            - command: echo hook fired
+        end: true
+""")
+
+
+class TestWaitHookRejectedOnStateHookConfig:
+    """StateHookConfig (used by task/choice/parallel/map/fail states) must reject wait hook keys."""
+
+    @pytest.mark.parametrize("hook_key", ["on_wait_start", "on_wait_end"])
+    def test_state_hook_config_rejects_wait_hook_keys(self, hook_key: str) -> None:
+        with pytest.raises(ValidationError):
+            StateHookConfig.model_validate({hook_key: [{"command": "echo bad"}]})
+
+    def test_on_wait_start_rejected_on_task_state_via_load_flow(
+        self, tmp_path: Path
+    ) -> None:
+        yaml_text = textwrap.dedent("""\
+            name: TestFlow
+            description: test
+            start_at: s1
+            states:
+              s1:
+                type: task
+                provider: system
+                command: echo hi
+                hooks:
+                  on_wait_start:
+                    - command: echo bad
+                end: true
+        """)
+        path = tmp_path / "flow.yaml"
+        path.write_text(yaml_text)
+        _, errors = load_flow(path)
+        assert errors, "Expected a validation error for on_wait_start on a task state"
+
+    def test_on_wait_end_rejected_on_task_state_via_load_flow(
+        self, tmp_path: Path
+    ) -> None:
+        yaml_text = textwrap.dedent("""\
+            name: TestFlow
+            description: test
+            start_at: s1
+            states:
+              s1:
+                type: task
+                provider: system
+                command: echo hi
+                hooks:
+                  on_wait_end:
+                    - command: echo bad
+                end: true
+        """)
+        path = tmp_path / "flow.yaml"
+        path.write_text(yaml_text)
+        _, errors = load_flow(path)
+        assert errors, "Expected a validation error for on_wait_end on a task state"
+
+    def test_on_wait_start_rejected_on_fail_state_via_load_flow(
+        self, tmp_path: Path
+    ) -> None:
+        yaml_text = textwrap.dedent("""\
+            name: TestFlow
+            description: test
+            start_at: s1
+            states:
+              s1:
+                type: fail
+                error: TestError
+                cause: something broke
+                hooks:
+                  on_wait_start:
+                    - command: echo bad
+        """)
+        path = tmp_path / "flow.yaml"
+        path.write_text(yaml_text)
+        _, errors = load_flow(path)
+        assert errors, "Expected a validation error for on_wait_start on a fail state"
+
+
+class TestWaitHookAcceptedOnWaitState:
+    """on_wait_start and on_wait_end must be valid fields on a wait state."""
+
+    def test_on_wait_start_accepted_on_wait_state(self, tmp_path: Path) -> None:
+        path = tmp_path / "flow.yaml"
+        path.write_text(_WAIT_STATE_YAML.format(hook_key="on_wait_start"))
+        flow, errors = load_flow(path)
+        assert not errors, f"Unexpected validation errors: {errors}"
+        assert flow is not None
+        hooks = flow.states["await_approval"].hooks
+        assert hooks is not None
+        # WaitStateHookConfig must expose on_wait_start; fails until WaitStateHookConfig is added
+        hook_list = getattr(hooks, "on_wait_start", None)
+        assert hook_list is not None, (
+            "hooks.on_wait_start is None — WaitStateHookConfig not yet implemented"
+        )
+        assert len(hook_list) == 1
+
+    def test_on_wait_end_accepted_on_wait_state(self, tmp_path: Path) -> None:
+        path = tmp_path / "flow.yaml"
+        path.write_text(_WAIT_STATE_YAML.format(hook_key="on_wait_end"))
+        flow, errors = load_flow(path)
+        assert not errors, f"Unexpected validation errors: {errors}"
+        assert flow is not None
+        hooks = flow.states["await_approval"].hooks
+        assert hooks is not None
+        hook_list = getattr(hooks, "on_wait_end", None)
+        assert hook_list is not None, (
+            "hooks.on_wait_end is None — WaitStateHookConfig not yet implemented"
+        )
+        assert len(hook_list) == 1


### PR DESCRIPTION
## What was done

Implements wait state lifecycle hooks (`on_wait_start` / `on_wait_end`) with multi-level configuration (global → project → flow → state) and additive merge semantics.

### Key changes

| File | Change |
|------|--------|
| `src/fdsx/models/flow.py` | New `WaitStateHookConfig` for wait-only hook keys; `StateHookConfig` validator rejects `on_wait_start`/`on_wait_end` on non-wait states; `WaitState.hooks` now typed as `WaitStateHookConfig \| None`; `HookConfig` gains both new fields for flow/global-level configuration |
| `src/fdsx/core/config.py` | `_HOOK_LIST_KEYS` extended with `on_wait_start` and `on_wait_end` so `_deep_merge()` applies additive list concatenation across all config levels |
| `src/fdsx/core/hooks.py` | `execute_hooks` event Literal extended; new `collect_wait_hooks()` helper wires all four config levels; `extra_env` parameter threads wait-specific env vars through |
| `src/fdsx/core/compiler/nodes.py` | `_create_wait_notify_node` executes `on_wait_start` hooks (before interrupt, so they never re-fire on resume); `_create_wait_interrupt_node` executes `on_wait_end` hooks after `user_selection` is stored |
| `src/fdsx/core/compiler/compile.py` | Wait state branch collects merged hook lists via `collect_wait_hooks` and passes them into the node constructors |
| `tests/integration/test_wait_hooks.py` | Full integration test suite covering state-level execution, env vars, abort/warn semantics, resume behavior, and multi-level merge order |
| `tests/unit/test_wait_hooks_validation.py` | Validation tests asserting rejection of wait hook keys on all non-wait state types |

### Why

Wait states are the only states that suspend execution via LangGraph's `interrupt()`. The existing `on_state_start`/`on_state_end` hooks fire at wrong moments (they straddle the entire state, not just the notification/resume boundary). The new hooks give precise control:

- `on_wait_start` — fires in the notify node, after the user-facing prompt is rendered but **before** `interrupt()` suspends the graph. Never re-fires on checkpoint resume.
- `on_wait_end` — fires in the interrupt node, after `user_selection` is written to `result_path` but before the state completes. Fires exactly once per user interaction.

Environment variables injected into hook processes:

- `on_wait_start`: `FDSX_WAIT_MESSAGE` (the resolved prompt), `FDSX_WAIT_CHOICES` (JSON array)
- `on_wait_end`: `FDSX_WAIT_SELECTION` (the value the user selected)

## How to test

```bash
# Validation tests
uv run pytest tests/unit/test_wait_hooks_validation.py -v

# Integration tests
uv run pytest tests/integration/test_wait_hooks.py -v

# Full suite
uv run pytest tests/ -v
```

Key scenarios covered:
- `on_wait_start` fires once before interrupt, not again on resume
- `on_wait_end` fires once after selection, with correct env var
- `on_failure: abort` stops workflow execution
- `on_failure: warn` logs warning and continues
- Flow-level hooks apply to all wait states without per-state declaration
- Global → project → flow → state merge order is preserved (additive, not replacing)
- Declaring `on_wait_start`/`on_wait_end` on a task/choice/parallel/map/pass/fail state raises `FlowValidationError` at load time