### PR TITLE
fix: add click as explicit dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "langgraph-checkpoint-sqlite>=3,<5",
     "pyyaml>=6",
     "typer>=0.9",
+    "click>=8",
     "httpx>=0.27",
     "structlog>=24",
     "uuid-utils>=0.9",

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+from typing import Any
 
 import click
 import typer
@@ -55,7 +56,7 @@ class _FdsxGroup(typer.core.TyperGroup):
     group args by the time the callback runs.
     """
 
-    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+    def parse_args(self, ctx: Any, args: list[str]) -> list[str]:
         if ctx.obj is None:
             ctx.obj = {}
         if isinstance(ctx.obj, dict):


### PR DESCRIPTION
## Summary

- `typer` 0.12+ made `click` an optional dependency, so it's no longer guaranteed to install as a transitive dep
- `fdsx.cli.main` imports `click` directly, causing `ModuleNotFoundError: No module named 'click'` in environments where `typer>=0.12` is resolved without `click`
- Adds `click>=8` as an explicit project dependency to fix this

## Test plan

- [ ] Install `fdsx` in a clean environment and confirm `fdsx --help` works without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)