### PR TITLE
Complete pi provider integration and default inheritance

### DIFF
--- a/.fdsx/config.yaml
+++ b/.fdsx/config.yaml
@@ -1,21 +1,21 @@
 profiles:
   smarty:
-    provider: claude
-    model: claude-sonnet-4-6
+    provider: codex
+    model: gpt-5.5
 #    provider: claude
 #    model: claude-opus-4-6
   doer:
-    provider: claude
-    model: claude-sonnet-4-6
+    provider: codex
+    model: gpt-5.5
   specialist:
     provider: codex
     model: gpt-5.5
   generalist:
-    provider: claude
-    model: claude-sonnet-4-6
+    provider: codex
+    model: gpt-5.4
   behemoth:
-    provider: claude
-    model: claude-haiku-4-5
+    provider: codex
+    model: gpt-5.4
 #    provider: gemini
 #    model: gemini-2.5-flash
 

--- a/src/fdsx/cli/init_interactive.py
+++ b/src/fdsx/cli/init_interactive.py
@@ -37,6 +37,10 @@ _PROFILE_ORDER: list[str] = [
     "behemoth",
 ]
 
+INIT_SELECTABLE_PROVIDERS = frozenset(
+    provider for provider in VALID_PROVIDERS if provider != "pi"
+)
+
 _console = Console(stderr=True)
 
 
@@ -55,7 +59,7 @@ def select_providers() -> list[str]:
     table.add_column("#", style="dim", width=4)
     table.add_column("Provider")
 
-    providers = sorted(VALID_PROVIDERS)
+    providers = sorted(INIT_SELECTABLE_PROVIDERS)
     for i, provider in enumerate(providers, start=1):
         table.add_row(str(i), provider)
 

--- a/src/fdsx/cli/main.py
+++ b/src/fdsx/cli/main.py
@@ -1,9 +1,11 @@
+import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO, cast
 
 import click
+import structlog
 import typer
 import typer.core
 from pydantic import ValidationError as PydanticValidationError
@@ -46,6 +48,24 @@ from fdsx.models.init import InitConfig
 EXEMPT_SUBCOMMANDS = frozenset({"init", "validate"})
 
 _RAW_ARGS_KEY = "_fdsx_raw_args"
+
+
+class _CurrentStderr:
+    def write(self, message: str) -> int:
+        return sys.stderr.write(message)
+
+    def flush(self) -> None:
+        sys.stderr.flush()
+
+
+def _configure_structlog_for_cli() -> None:
+    structlog.configure(
+        wrapper_class=structlog.make_filtering_bound_logger(logging.INFO),
+        logger_factory=structlog.PrintLoggerFactory(
+            file=cast(TextIO, _CurrentStderr())
+        ),
+        cache_logger_on_first_use=True,
+    )
 
 
 class _FdsxGroup(typer.core.TyperGroup):
@@ -110,6 +130,8 @@ def main(
         help="Run in interactive mode (enables TTY detection if not explicitly set).",
     ),
 ) -> None:
+    _configure_structlog_for_cli()
+
     if ci and interactive:
         typer.echo(
             "Error: --ci and --interactive are mutually exclusive",

--- a/src/fdsx/core/compiler/helpers.py
+++ b/src/fdsx/core/compiler/helpers.py
@@ -154,6 +154,11 @@ def _merge_provider_options(
                 )
                 del merged[field]
 
+    if provider_name == "pi":
+        from fdsx.providers.pi import PiOptions
+
+        PiOptions.model_validate(merged)
+
     return merged if merged else None
 
 

--- a/src/fdsx/core/config.py
+++ b/src/fdsx/core/config.py
@@ -28,6 +28,7 @@ from fdsx.providers.codex import CodexOptions
 from fdsx.providers.cursor import CursorOptions
 from fdsx.providers.gemini import GeminiOptions
 from fdsx.providers.opencode import OpenCodeOptions
+from fdsx.providers.pi import PiOptions
 
 # Keys within HookConfig whose list values are concatenated (not replaced) during deep merge
 _HOOK_LIST_KEYS: frozenset[str] = frozenset(
@@ -154,6 +155,10 @@ class ProviderConfigs(BaseModel):
     gemini: GeminiOptions | None = Field(
         default=None,
         description="Gemini provider options",
+    )
+    pi: PiOptions | None = Field(
+        default=None,
+        description="pi provider options",
     )
 
     model_config = {"extra": "forbid"}

--- a/src/fdsx/data/skills/fdsx/references/yaml-schema.md
+++ b/src/fdsx/data/skills/fdsx/references/yaml-schema.md
@@ -636,6 +636,24 @@ When `output_callback` is provided, `--output-format stream-json --stream-partia
 
 **Requirements:** Cursor's `agent` CLI binary must be in `PATH`. If it is absent, `CursorProvider` raises `CursorProviderError` at execution time.
 
+### Pi
+
+```yaml
+provider_options:
+  allowed_tools?: [string]              # passed as --tools read,bash
+  disallowed_tools?: [string]           # passed as --exclude-tools write,edit
+  disable_tools?: bool                  # default: false — pass --no-tools
+  inactivity_timeout?: int              # default: 300
+```
+
+**Mutual exclusion:** `disable_tools` cannot be combined with non-empty `allowed_tools` or `disallowed_tools`.
+
+Example tool names include `read`, `bash`, `edit`, `write`, `grep`, `find`, and `ls`; fdsx forwards names to pi without validating the current pi tool registry.
+
+CLI binary invoked: `pi -p <prompt> [--model <model>] [--tools <csv>] [--exclude-tools <csv>] [--no-tools]`
+
+**Requirements:** The `pi` CLI binary must be in `PATH`. If it is absent, `PiProvider` raises `PiProviderError` at execution time.
+
 All provider option models use `extra="forbid"` — unknown keys cause validation errors.
 
 ---
@@ -667,6 +685,7 @@ providers?:
   codex?: CodexOptions
   opencode?: OpenCodeOptions
   gemini?: GeminiOptions
+  pi?: PiOptions
 
 hooks?: HookConfig              # workflow/state/wait lifecycle hooks applied to all flows
                                 # accepts: on_state_start, on_state_end, on_workflow_start,

--- a/src/fdsx/models/flow.py
+++ b/src/fdsx/models/flow.py
@@ -352,7 +352,15 @@ def _validate_provider_fields(
     model: str | None,
 ) -> None:
     """Shared provider-field validation logic for TaskState and Branch."""
-    valid_providers = {"claude", "cursor", "opencode", "codex", "gemini", "system"}
+    valid_providers = {
+        "claude",
+        "cursor",
+        "opencode",
+        "codex",
+        "gemini",
+        "pi",
+        "system",
+    }
     if provider not in valid_providers:
         raise ValueError(
             f"provider must be one of {', '.join(sorted(valid_providers))}, got '{provider}'"

--- a/src/fdsx/models/validators.py
+++ b/src/fdsx/models/validators.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 
-VALID_PROVIDERS = frozenset({"claude", "cursor", "opencode", "codex", "gemini"})
+VALID_PROVIDERS = frozenset({"claude", "cursor", "opencode", "codex", "gemini", "pi"})
 PROFILE_NAME_REGEX = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
 
 

--- a/src/fdsx/providers/base.py
+++ b/src/fdsx/providers/base.py
@@ -410,7 +410,7 @@ def get_provider(name: str, options: dict[str, Any] | None = None) -> ProviderBa
     """Factory function to get a provider by name.
 
     Args:
-        name: Provider name (claude, codex, opencode, system).
+        name: Provider name (claude, codex, opencode, pi, system).
         options: Optional dict of provider-specific options. Converted to the
                  appropriate typed options model internally. Ignored for system provider.
 
@@ -434,6 +434,11 @@ def get_provider(name: str, options: dict[str, Any] | None = None) -> ProviderBa
 
         opencode_opts = OpenCodeOptions.model_validate(options) if options else None
         return OpenCodeProvider(opencode_opts)
+    elif name == "pi":
+        from fdsx.providers.pi import PiOptions, PiProvider
+
+        pi_opts = PiOptions.model_validate(options) if options else None
+        return PiProvider(pi_opts)
     elif name == "codex":
         from fdsx.providers.codex import CodexOptions, CodexProvider
 

--- a/src/fdsx/providers/pi.py
+++ b/src/fdsx/providers/pi.py
@@ -65,6 +65,9 @@ class PiProvider(ProviderBase):
             args.append(prompt)
             stdin_data = None
 
+        if model:
+            args.extend(["--model", model])
+
         effective_inactivity = (
             self.options.inactivity_timeout
             if self.options.inactivity_timeout is not None

--- a/src/fdsx/providers/pi.py
+++ b/src/fdsx/providers/pi.py
@@ -1,0 +1,85 @@
+import logging
+import shutil
+import subprocess
+from collections.abc import Callable
+
+from pydantic import BaseModel, ConfigDict
+
+from fdsx.providers.base import (
+    ARG_MAX_STDIN_THRESHOLD,
+    DEFAULT_EXECUTION_TIMEOUT,
+    DEFAULT_INACTIVITY_TIMEOUT,
+    ProviderBase,
+    ProviderResult,
+    _run_subprocess,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PiProviderError(Exception):
+    """Raised when the pi provider encounters a domain-level error."""
+
+
+class PiOptions(BaseModel):
+    """Options for the pi CLI provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    inactivity_timeout: int | None = None
+
+    def to_cli_flags(self) -> list[str]:
+        """Translate options to pi CLI flags."""
+        return []
+
+
+class PiProvider(ProviderBase):
+    """pi provider - executes pi CLI."""
+
+    def __init__(self, options: PiOptions | None = None) -> None:
+        self.options: PiOptions = options if options is not None else PiOptions()
+
+    def execute(
+        self,
+        prompt: str,
+        model: str | None = None,
+        timeout: int | None = None,
+        command: str | None = None,
+        output_callback: Callable[[str], None] | None = None,
+        stderr_callback: Callable[[str], None] | None = None,
+        on_process_start: Callable[[subprocess.Popen[str]], None] | None = None,
+        summary_callback: Callable[[str], None] | None = None,
+    ) -> ProviderResult:
+        """Execute pi CLI with a prompt."""
+        if shutil.which("pi") is None:
+            logger.warning("pi_binary_missing")
+            raise PiProviderError(
+                "pi binary not found on PATH. Ensure pi is installed and available."
+            )
+
+        use_stdin = len(prompt.encode("utf-8")) >= ARG_MAX_STDIN_THRESHOLD
+        args = ["pi", "-p"]
+        if use_stdin:
+            stdin_data: str | None = prompt
+        else:
+            args.append(prompt)
+            stdin_data = None
+
+        effective_inactivity = (
+            self.options.inactivity_timeout
+            if self.options.inactivity_timeout is not None
+            else DEFAULT_INACTIVITY_TIMEOUT
+        )
+        effective_timeout = (
+            timeout if timeout is not None else DEFAULT_EXECUTION_TIMEOUT
+        )
+
+        return _run_subprocess(
+            args=args,
+            timeout=effective_timeout,
+            output_callback=output_callback,
+            stderr_callback=stderr_callback,
+            stdin_data=stdin_data,
+            inactivity_timeout=effective_inactivity,
+            on_process_start=on_process_start,
+        )

--- a/src/fdsx/providers/pi.py
+++ b/src/fdsx/providers/pi.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 from collections.abc import Callable
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from fdsx.providers.base import (
     ARG_MAX_STDIN_THRESHOLD,
@@ -27,10 +27,33 @@ class PiOptions(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     inactivity_timeout: int | None = None
+    allowed_tools: list[str] = []
+    disallowed_tools: list[str] = []
+    disable_tools: bool = False
+
+    @model_validator(mode="after")
+    def validate_tool_restrictions(self) -> "PiOptions":
+        """Validate mutually exclusive pi tool restriction options."""
+        if self.disable_tools and self.allowed_tools:
+            raise ValueError("disable_tools cannot be combined with allowed_tools")
+        if self.disable_tools and self.disallowed_tools:
+            raise ValueError("disable_tools cannot be combined with disallowed_tools")
+        return self
 
     def to_cli_flags(self) -> list[str]:
         """Translate options to pi CLI flags."""
-        return []
+        flags: list[str] = []
+
+        if self.disable_tools:
+            flags.append("--no-tools")
+            return flags
+
+        if self.allowed_tools:
+            flags.extend(["--tools", ",".join(self.allowed_tools)])
+        if self.disallowed_tools:
+            flags.extend(["--exclude-tools", ",".join(self.disallowed_tools)])
+
+        return flags
 
 
 class PiProvider(ProviderBase):
@@ -67,6 +90,8 @@ class PiProvider(ProviderBase):
 
         if model:
             args.extend(["--model", model])
+
+        args.extend(self.options.to_cli_flags())
 
         effective_inactivity = (
             self.options.inactivity_timeout

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,5 +1,6 @@
 """Integration test fixtures for cursor provider."""
 
+import importlib.util
 from unittest.mock import patch
 
 import pytest
@@ -27,4 +28,19 @@ def _mock_cursor_agent_binary(request):
         return
 
     with patch("fdsx.providers.cursor.shutil.which", return_value="/usr/bin/agent"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_pi_binary(request):
+    """Auto-mock 'pi' binary presence for pi provider integration tests."""
+    if "test_pi_provider" not in str(request.node.fspath):
+        yield
+        return
+
+    if importlib.util.find_spec("fdsx.providers.pi") is None:
+        yield
+        return
+
+    with patch("fdsx.providers.pi.shutil.which", return_value="/usr/bin/pi"):
         yield

--- a/tests/integration/test_pi_provider.py
+++ b/tests/integration/test_pi_provider.py
@@ -73,19 +73,72 @@ class TestPiProviderExecution:
         assert run.call_args.kwargs["args"] == ["pi", "-p"]
         assert run.call_args.kwargs["stdin_data"] == prompt
 
-    def test_model_argument_is_ignored_by_pi_execution(self) -> None:
-        """Passing model=... does not emit --model or the model value."""
+    def test_model_argument_is_passed_as_model_flag(self) -> None:
+        """Passing model=... emits --model with the requested model."""
         pi_provider = _pi_symbol("PiProvider")
         provider = pi_provider()
 
-        with patch(
-            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
-        ) as run:
-            provider.execute(prompt="hello", model="pi-large")
+        with (
+            patch("fdsx.providers.pi.shutil.which", return_value="/usr/bin/pi"),
+            patch(
+                "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+            ) as run,
+        ):
+            provider.execute(prompt="hello", model="some-model")
+
+        args = run.call_args.kwargs["args"]
+        assert "--model" in args
+        assert args[args.index("--model") + 1] == "some-model"
+
+    def test_provider_slash_model_id_is_forwarded_verbatim(self) -> None:
+        """Provider-qualified model ids are forwarded without normalization."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        with (
+            patch("fdsx.providers.pi.shutil.which", return_value="/usr/bin/pi"),
+            patch(
+                "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+            ) as run,
+        ):
+            provider.execute(prompt="hello", model="openai/gpt-4o")
+
+        args = run.call_args.kwargs["args"]
+        assert "--model" in args
+        assert args[args.index("--model") + 1] == "openai/gpt-4o"
+
+    def test_shorthand_model_id_is_forwarded_verbatim(self) -> None:
+        """Shorthand model ids are forwarded without provider prefix changes."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        with (
+            patch("fdsx.providers.pi.shutil.which", return_value="/usr/bin/pi"),
+            patch(
+                "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+            ) as run,
+        ):
+            provider.execute(prompt="hello", model="gpt-4o")
+
+        args = run.call_args.kwargs["args"]
+        assert "--model" in args
+        assert args[args.index("--model") + 1] == "gpt-4o"
+
+    def test_model_flag_is_absent_when_model_is_none(self) -> None:
+        """Omitting model selection leaves the pi CLI args without --model."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        with (
+            patch("fdsx.providers.pi.shutil.which", return_value="/usr/bin/pi"),
+            patch(
+                "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+            ) as run,
+        ):
+            provider.execute(prompt="hello", model=None)
 
         args = run.call_args.kwargs["args"]
         assert "--model" not in args
-        assert "pi-large" not in args
 
     def test_default_timeouts_are_passed_to_subprocess(self) -> None:
         """Default execution and inactivity timeouts are passed to _run_subprocess."""

--- a/tests/integration/test_pi_provider.py
+++ b/tests/integration/test_pi_provider.py
@@ -166,6 +166,62 @@ class TestPiProviderExecution:
 
         assert run.call_args.kwargs["inactivity_timeout"] == 10
 
+    def test_allowed_tools_are_passed_to_pi_subprocess_args(self) -> None:
+        """allowed_tools provider options are forwarded as pi --tools args."""
+        pi_options = _pi_symbol("PiOptions")
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider(pi_options(allowed_tools=["read", "bash"]))
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello")
+
+        assert run.call_args.kwargs["args"] == [
+            "pi",
+            "-p",
+            "hello",
+            "--tools",
+            "read,bash",
+        ]
+
+    def test_disallowed_tools_are_passed_to_pi_subprocess_args(self) -> None:
+        """disallowed_tools provider options are forwarded as pi --exclude-tools args."""
+        pi_options = _pi_symbol("PiOptions")
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider(pi_options(disallowed_tools=["write", "edit"]))
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello")
+
+        assert run.call_args.kwargs["args"] == [
+            "pi",
+            "-p",
+            "hello",
+            "--exclude-tools",
+            "write,edit",
+        ]
+
+    def test_disable_tools_is_passed_to_pi_subprocess_args(self) -> None:
+        """disable_tools provider option is forwarded as pi --no-tools."""
+        pi_options = _pi_symbol("PiOptions")
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider(pi_options(disable_tools=True))
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello")
+
+        assert run.call_args.kwargs["args"] == [
+            "pi",
+            "-p",
+            "hello",
+            "--no-tools",
+        ]
+
     def test_callbacks_are_forwarded_to_subprocess(self) -> None:
         """Output, stderr, and process-start callbacks are forwarded directly."""
         pi_provider = _pi_symbol("PiProvider")

--- a/tests/integration/test_pi_provider.py
+++ b/tests/integration/test_pi_provider.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 
 from fdsx.core.config import FdsxConfig
+from fdsx.core.engine import run_flow
 from fdsx.core.loader import load_flow
 from fdsx.providers.base import (
     ARG_MAX_STDIN_THRESHOLD,
@@ -312,3 +313,68 @@ states:
         )
         assert config.task_splitter is not None
         assert config.task_splitter.provider == "pi"
+
+
+class TestPiDefaultsInWorkflowExecution:
+    """Verify inherited pi defaults reach execution through run_flow()."""
+
+    def test_run_flow_converts_inherited_pi_defaults_to_subprocess_args(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A provider: pi flow uses configured pi defaults as CLI flags."""
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        base_dir = tmp_path / ".fdsx"
+        base_dir.mkdir()
+        (base_dir / "config.yaml").write_text(
+            """
+providers:
+  pi:
+    allowed_tools:
+      - read
+      - bash
+    inactivity_timeout: 12
+"""
+        )
+        flow_path = _write_flow(
+            tmp_path / "pi-flow.yaml",
+            """
+name: Pi Defaults Execution
+description: pi defaults reach subprocess args
+start_at: direct
+version: '1.0'
+states:
+  direct:
+    type: task
+    provider: pi
+    model: gpt-4o
+    prompt_template: Hello from flow
+    result_path: $.direct
+    end: true
+""",
+        )
+
+        with (
+            patch("fdsx.providers.pi.shutil.which", return_value="/usr/bin/pi"),
+            patch(
+                "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+            ) as run,
+        ):
+            result = run_flow(
+                flow_path,
+                base_dir=base_dir,
+                thread_id="pi-defaults-test",
+                quiet=True,
+            )
+
+        assert result.results["direct"] == "ok"
+        args = run.call_args.kwargs["args"]
+        assert args == [
+            "pi",
+            "-p",
+            "Hello from flow",
+            "--model",
+            "gpt-4o",
+            "--tools",
+            "read,bash",
+        ]
+        assert run.call_args.kwargs["inactivity_timeout"] == 12

--- a/tests/integration/test_pi_provider.py
+++ b/tests/integration/test_pi_provider.py
@@ -1,0 +1,205 @@
+"""Integration tests for pi provider execution and validation."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from fdsx.core.config import FdsxConfig
+from fdsx.core.loader import load_flow
+from fdsx.providers.base import (
+    ARG_MAX_STDIN_THRESHOLD,
+    DEFAULT_EXECUTION_TIMEOUT,
+    DEFAULT_INACTIVITY_TIMEOUT,
+    ProviderResult,
+)
+
+FAKE_SUCCESS = ProviderResult(exit_code=0, stdout="ok", stderr="")
+
+
+def _pi_symbol(name: str) -> Any:
+    try:
+        module = importlib.import_module("fdsx.providers.pi")
+    except ModuleNotFoundError as exc:
+        if exc.name == "fdsx.providers.pi":
+            pytest.fail("fdsx.providers.pi module is not implemented")
+        raise
+    try:
+        return getattr(module, name)
+    except AttributeError:
+        pytest.fail(f"fdsx.providers.pi.{name} is not implemented")
+
+
+def _write_flow(path: Path, body: str) -> Path:
+    path.write_text(body)
+    return path
+
+
+class TestPiProviderExecution:
+    """Verify PiProvider.execute() observable subprocess routing behavior."""
+
+    def test_normal_prompt_executes_pi_dash_p_prompt(self) -> None:
+        """A normal pi prompt executes as ['pi', '-p', prompt]."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello")
+
+        run.assert_called_once()
+        assert run.call_args.kwargs["args"] == ["pi", "-p", "hello"]
+
+    def test_large_prompt_is_sent_through_stdin_without_positional_prompt(
+        self,
+    ) -> None:
+        """A prompt at ARG_MAX_STDIN_THRESHOLD bytes is sent via stdin_data."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+        prompt = "x" * ARG_MAX_STDIN_THRESHOLD
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt=prompt)
+
+        run.assert_called_once()
+        assert run.call_args.kwargs["args"] == ["pi", "-p"]
+        assert run.call_args.kwargs["stdin_data"] == prompt
+
+    def test_model_argument_is_ignored_by_pi_execution(self) -> None:
+        """Passing model=... does not emit --model or the model value."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello", model="pi-large")
+
+        args = run.call_args.kwargs["args"]
+        assert "--model" not in args
+        assert "pi-large" not in args
+
+    def test_default_timeouts_are_passed_to_subprocess(self) -> None:
+        """Default execution and inactivity timeouts are passed to _run_subprocess."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello")
+
+        assert run.call_args.kwargs["timeout"] == DEFAULT_EXECUTION_TIMEOUT
+        assert run.call_args.kwargs["inactivity_timeout"] == DEFAULT_INACTIVITY_TIMEOUT
+
+    def test_custom_inactivity_timeout_is_passed_to_subprocess(self) -> None:
+        """A custom inactivity_timeout from PiOptions is passed to _run_subprocess."""
+        pi_options = _pi_symbol("PiOptions")
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider(pi_options(inactivity_timeout=10))
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(prompt="hello")
+
+        assert run.call_args.kwargs["inactivity_timeout"] == 10
+
+    def test_callbacks_are_forwarded_to_subprocess(self) -> None:
+        """Output, stderr, and process-start callbacks are forwarded directly."""
+        pi_provider = _pi_symbol("PiProvider")
+        provider = pi_provider()
+
+        def output_callback(line: str) -> None:
+            _ = line
+
+        def stderr_callback(line: str) -> None:
+            _ = line
+
+        def on_process_start(process: subprocess.Popen[str]) -> None:
+            _ = process
+
+        with patch(
+            "fdsx.providers.pi._run_subprocess", return_value=FAKE_SUCCESS
+        ) as run:
+            provider.execute(
+                prompt="hello",
+                output_callback=output_callback,
+                stderr_callback=stderr_callback,
+                on_process_start=on_process_start,
+            )
+
+        assert run.call_args.kwargs["output_callback"] is output_callback
+        assert run.call_args.kwargs["stderr_callback"] is stderr_callback
+        assert run.call_args.kwargs["on_process_start"] is on_process_start
+
+    def test_missing_pi_binary_raises_domain_error_naming_pi(self) -> None:
+        """When pi is missing on PATH, execution raises PiProviderError naming pi."""
+        pi_provider = _pi_symbol("PiProvider")
+        pi_provider_error = _pi_symbol("PiProviderError")
+        provider = pi_provider()
+
+        with (
+            patch("fdsx.providers.pi.shutil.which", return_value=None),
+            pytest.raises(pi_provider_error, match="pi"),
+        ):
+            provider.execute(prompt="hello")
+
+
+class TestPiWorkflowValidation:
+    """Verify workflow and config validation accepts provider: pi."""
+
+    def test_pi_is_valid_where_existing_llm_providers_are_valid(
+        self, tmp_path: Path
+    ) -> None:
+        """Workflow/config validation accepts provider: pi across LLM provider fields."""
+        flow_path = _write_flow(
+            tmp_path / "pi-flow.yaml",
+            """
+name: Pi Provider Flow
+description: pi provider flow
+start_at: direct
+version: '1.0'
+states:
+  direct:
+    type: task
+    provider: pi
+    model: ignored-by-t001
+    prompt_template: Hello
+    result_path: $.direct
+    next: fanout
+  fanout:
+    type: parallel
+    branches:
+      - provider: pi
+        model: ignored-by-t001
+        prompt_template: Branch hello
+    result_path: $.branches
+    end: true
+""",
+        )
+
+        flow, errors = load_flow(
+            flow_path,
+            config_profiles={"pi_profile": {"provider": "pi", "model": "ignored"}},
+        )
+
+        assert errors == []
+        assert flow is not None
+
+        config = FdsxConfig(
+            task_splitter={"provider": "pi", "model": "ignored"},
+            workflow_selector={"provider": "pi", "model": "ignored"},
+            profiles={"pi_profile": {"provider": "pi", "model": "ignored"}},
+            providers={"pi": {"inactivity_timeout": 10}},
+        )
+        assert config.task_splitter is not None
+        assert config.task_splitter.provider == "pi"

--- a/tests/integration/test_provider_options.py
+++ b/tests/integration/test_provider_options.py
@@ -7,6 +7,9 @@ Tests verify that provider options flow correctly through:
 
 from unittest.mock import patch
 
+import pytest
+from pydantic import ValidationError
+
 from fdsx.core.compiler import _merge_provider_options, compile_flow
 from fdsx.core.config import FdsxConfig, ProviderConfigs
 from fdsx.models.flow import Branch, Flow, ParallelState, TaskState
@@ -15,6 +18,7 @@ from fdsx.providers.claude import ClaudeOptions, ClaudeProvider
 from fdsx.providers.codex import CodexOptions, CodexProvider
 from fdsx.providers.gemini import GeminiOptions, GeminiProvider
 from fdsx.providers.opencode import OpenCodeOptions, OpenCodeProvider
+from fdsx.providers.pi import PiOptions, PiProvider
 from fdsx.providers.system import SystemProvider
 
 # ---------------------------------------------------------------------------
@@ -219,6 +223,46 @@ class TestConfigWorkflowMerge:
         assert isinstance(provider, GeminiProvider)
         assert provider.options.yolo is True
 
+    def test_pi_task_inherits_config_allowed_tools_and_inactivity_timeout(self):
+        """Config-level pi defaults are effective when the task has no options."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                pi=PiOptions(allowed_tools=["read", "bash"], inactivity_timeout=15),
+            )
+        )
+        flow = _make_single_task_flow(provider="pi", model="gpt-4o")
+
+        merged = _merge_provider_options(config, flow, "pi", None, state_name="step1")
+
+        assert merged is not None
+        provider = get_provider("pi", merged)
+        assert isinstance(provider, PiProvider)
+        assert provider.options.allowed_tools == ["read", "bash"]
+        assert provider.options.inactivity_timeout == 15
+
+    def test_pi_workflow_options_override_config_defaults(self):
+        """Workflow-level providers.pi values override config-level pi defaults."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                pi=PiOptions(allowed_tools=["read"], inactivity_timeout=15),
+            )
+        )
+        flow = _make_single_task_flow(
+            provider="pi",
+            model="gpt-4o",
+            flow_providers={
+                "pi": {"allowed_tools": ["write"], "inactivity_timeout": 20}
+            },
+        )
+
+        merged = _merge_provider_options(config, flow, "pi", None, state_name="step1")
+
+        assert merged is not None
+        provider = get_provider("pi", merged)
+        assert isinstance(provider, PiProvider)
+        assert provider.options.allowed_tools == ["write"]
+        assert provider.options.inactivity_timeout == 20
+
 
 # ---------------------------------------------------------------------------
 # T019-3: Task-level override
@@ -256,6 +300,141 @@ class TestTaskLevelOverride:
         assert isinstance(provider, ClaudeProvider)
         assert provider.options.permission_mode == "dontAsk"
 
+    def test_pi_task_options_override_config_and_workflow_defaults(self):
+        """Task-level pi provider_options win over config and workflow defaults."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                pi=PiOptions(allowed_tools=["read"], inactivity_timeout=15),
+            )
+        )
+        flow = _make_single_task_flow(
+            provider="pi",
+            model="gpt-4o",
+            flow_providers={
+                "pi": {"allowed_tools": ["write"], "inactivity_timeout": 20}
+            },
+            task_provider_options={
+                "allowed_tools": ["bash"],
+                "inactivity_timeout": 25,
+            },
+        )
+
+        merged = _merge_provider_options(
+            config,
+            flow,
+            "pi",
+            flow.states["step1"].provider_options,
+            state_name="step1",
+        )  # type: ignore[union-attr]
+
+        assert merged is not None
+        provider = get_provider("pi", merged)
+        assert isinstance(provider, PiProvider)
+        assert provider.options.allowed_tools == ["bash"]
+        assert provider.options.inactivity_timeout == 25
+
+    def test_pi_task_tool_lists_replace_inherited_lists(self):
+        """Task-level pi tool lists replace inherited lists instead of appending."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                pi=PiOptions(
+                    allowed_tools=["read"],
+                    disallowed_tools=["write"],
+                ),
+            )
+        )
+        flow = _make_single_task_flow(
+            provider="pi",
+            model="gpt-4o",
+            task_provider_options={
+                "allowed_tools": ["bash"],
+                "disallowed_tools": ["edit"],
+            },
+        )
+
+        merged = _merge_provider_options(
+            config,
+            flow,
+            "pi",
+            flow.states["step1"].provider_options,
+            state_name="step1",
+        )  # type: ignore[union-attr]
+
+        assert merged is not None
+        provider = get_provider("pi", merged)
+        assert isinstance(provider, PiProvider)
+        assert provider.options.allowed_tools == ["bash"]
+        assert provider.options.disallowed_tools == ["edit"]
+
+    def test_pi_task_empty_tool_lists_clear_inherited_lists(self):
+        """Task-level empty pi tool lists clear inherited tool restrictions."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                pi=PiOptions(
+                    allowed_tools=["read"],
+                    disallowed_tools=["write"],
+                ),
+            )
+        )
+        flow = _make_single_task_flow(
+            provider="pi",
+            model="gpt-4o",
+            task_provider_options={"allowed_tools": [], "disallowed_tools": []},
+        )
+
+        merged = _merge_provider_options(
+            config,
+            flow,
+            "pi",
+            flow.states["step1"].provider_options,
+            state_name="step1",
+        )  # type: ignore[union-attr]
+
+        assert merged is not None
+        provider = get_provider("pi", merged)
+        assert isinstance(provider, PiProvider)
+        assert provider.options.allowed_tools == []
+        assert provider.options.disallowed_tools == []
+
+
+class TestPiProviderOptionValidation:
+    """Pi defaults are validated after config/workflow/task inheritance."""
+
+    def test_config_unknown_pi_option_is_rejected(self):
+        """Config-level providers.pi rejects keys outside PiOptions."""
+        with pytest.raises(ValidationError, match="unknown_option"):
+            FdsxConfig(providers={"pi": {"unknown_option": True}})
+
+    def test_workflow_unknown_pi_option_is_rejected_during_merge(self):
+        """Workflow-level providers.pi rejects keys outside PiOptions."""
+        config = FdsxConfig()
+        flow = _make_single_task_flow(
+            provider="pi",
+            model="gpt-4o",
+            flow_providers={"pi": {"unknown_option": True}},
+        )
+
+        with pytest.raises(ValidationError, match="unknown_option"):
+            _merge_provider_options(config, flow, "pi", None, state_name="step1")
+
+    def test_inherited_pi_tool_conflicts_are_rejected_during_merge(self):
+        """Merged pi defaults cannot combine disable_tools with allowed_tools."""
+        config = FdsxConfig(providers=ProviderConfigs(pi=PiOptions(disable_tools=True)))
+        flow = _make_single_task_flow(
+            provider="pi",
+            model="gpt-4o",
+            task_provider_options={"allowed_tools": ["read"]},
+        )
+
+        with pytest.raises(ValidationError, match="disable_tools"):
+            _merge_provider_options(
+                config,
+                flow,
+                "pi",
+                flow.states["step1"].provider_options,
+                state_name="step1",
+            )  # type: ignore[union-attr]
+
 
 # ---------------------------------------------------------------------------
 # T019-4: Unchanged workflows without options
@@ -287,6 +466,47 @@ class TestUnchangedWorkflowsWithoutOptions:
         provider = get_provider("system", {"irrelevant": "value"})
         assert isinstance(provider, SystemProvider)
         # SystemProvider has no .options attribute — it should work fine
+        result = provider.execute(prompt="echo hello", command="echo hello")
+        assert result.exit_code == 0
+
+    def test_pi_without_any_defaults_produces_no_merged_options(self):
+        """A pi task with no defaults preserves the existing no-options behavior."""
+        config = FdsxConfig()
+        flow = _make_single_task_flow(provider="pi", model="gpt-4o")
+
+        merged = _merge_provider_options(config, flow, "pi", None, state_name="step1")
+
+        assert merged is None
+
+    def test_system_provider_ignores_configured_pi_defaults(self):
+        """Provider defaults for pi do not affect system provider execution."""
+        config = FdsxConfig(
+            providers=ProviderConfigs(
+                pi=PiOptions(allowed_tools=["read"], inactivity_timeout=15),
+            )
+        )
+        flow = Flow(
+            name="test",
+            description="System test flow",
+            start_at="step1",
+            states={
+                "step1": TaskState(
+                    type="task",
+                    provider="system",
+                    command="echo hello",
+                    result_path="$.result",
+                    end=True,
+                )
+            },
+        )
+
+        merged = _merge_provider_options(
+            config, flow, "system", None, state_name="step1"
+        )
+        provider = get_provider("system", merged)
+
+        assert merged is None
+        assert isinstance(provider, SystemProvider)
         result = provider.execute(prompt="echo hello", command="echo hello")
         assert result.exit_code == 0
 

--- a/tests/unit/test_pi_options.py
+++ b/tests/unit/test_pi_options.py
@@ -48,6 +48,78 @@ class TestPiOptions:
 
         assert flags == []
 
+    def test_allowed_tools_emit_tools_cli_flag(self) -> None:
+        """allowed_tools emits pi's --tools flag with comma-separated tools."""
+        pi_options = _pi_symbol("PiOptions")
+
+        flags = pi_options(allowed_tools=["read", "bash"]).to_cli_flags()
+
+        assert flags == ["--tools", "read,bash"]
+
+    def test_disallowed_tools_emit_exclude_tools_cli_flag(self) -> None:
+        """disallowed_tools emits pi's --exclude-tools flag."""
+        pi_options = _pi_symbol("PiOptions")
+
+        flags = pi_options(disallowed_tools=["write", "edit"]).to_cli_flags()
+
+        assert flags == ["--exclude-tools", "write,edit"]
+
+    def test_disable_tools_emits_no_tools_cli_flag(self) -> None:
+        """disable_tools emits pi's --no-tools flag."""
+        pi_options = _pi_symbol("PiOptions")
+
+        flags = pi_options(disable_tools=True).to_cli_flags()
+
+        assert flags == ["--no-tools"]
+
+    def test_empty_tool_lists_emit_no_cli_flags(self) -> None:
+        """Empty allowed/disallowed tool lists do not emit pi tool flags."""
+        pi_options = _pi_symbol("PiOptions")
+
+        flags = pi_options(allowed_tools=[], disallowed_tools=[]).to_cli_flags()
+
+        assert flags == []
+
+    def test_allowed_and_disallowed_tools_emit_flags_in_stable_order(self) -> None:
+        """Allow and exclude flags can be combined in stable CLI order."""
+        pi_options = _pi_symbol("PiOptions")
+
+        flags = pi_options(
+            allowed_tools=["read", "bash"],
+            disallowed_tools=["write", "edit"],
+        ).to_cli_flags()
+
+        assert flags == [
+            "--tools",
+            "read,bash",
+            "--exclude-tools",
+            "write,edit",
+        ]
+
+    def test_disable_tools_rejects_allowed_tools(self) -> None:
+        """disable_tools cannot be combined with allowed_tools."""
+        pi_options = _pi_symbol("PiOptions")
+
+        with pytest.raises(ValidationError) as exc_info:
+            pi_options(disable_tools=True, allowed_tools=["read"])
+
+        message = str(exc_info.value)
+        assert "disable_tools" in message
+        assert "allowed_tools" in message
+        assert "cannot be combined" in message
+
+    def test_disable_tools_rejects_disallowed_tools(self) -> None:
+        """disable_tools cannot be combined with disallowed_tools."""
+        pi_options = _pi_symbol("PiOptions")
+
+        with pytest.raises(ValidationError) as exc_info:
+            pi_options(disable_tools=True, disallowed_tools=["write"])
+
+        message = str(exc_info.value)
+        assert "disable_tools" in message
+        assert "disallowed_tools" in message
+        assert "cannot be combined" in message
+
 
 class TestPiProviderFactory:
     """Tests for get_provider('pi') factory behavior."""

--- a/tests/unit/test_pi_options.py
+++ b/tests/unit/test_pi_options.py
@@ -1,0 +1,69 @@
+"""Unit tests for the pi provider options and factory registration."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from fdsx.providers.base import get_provider
+
+
+def _pi_symbol(name: str) -> Any:
+    try:
+        module = importlib.import_module("fdsx.providers.pi")
+    except ModuleNotFoundError as exc:
+        if exc.name == "fdsx.providers.pi":
+            pytest.fail("fdsx.providers.pi module is not implemented")
+        raise
+    try:
+        return getattr(module, name)
+    except AttributeError:
+        pytest.fail(f"fdsx.providers.pi.{name} is not implemented")
+
+
+class TestPiOptions:
+    """Tests for PiOptions model."""
+
+    def test_defaults_emit_no_cli_flags(self) -> None:
+        """PiOptions.to_cli_flags() returns an empty list."""
+        pi_options = _pi_symbol("PiOptions")
+
+        assert pi_options().to_cli_flags() == []
+
+    def test_unknown_option_key_is_rejected(self) -> None:
+        """PiOptions rejects unknown option keys."""
+        pi_options = _pi_symbol("PiOptions")
+
+        with pytest.raises(ValidationError):
+            pi_options(unknown_option=True)
+
+    def test_inactivity_timeout_is_accepted_but_not_emitted_as_cli_flags(self) -> None:
+        """PiOptions accepts inactivity_timeout without emitting CLI flags."""
+        pi_options = _pi_symbol("PiOptions")
+
+        flags = pi_options(inactivity_timeout=10).to_cli_flags()
+
+        assert flags == []
+
+
+class TestPiProviderFactory:
+    """Tests for get_provider('pi') factory behavior."""
+
+    def test_get_provider_pi_returns_pi_provider(self) -> None:
+        """get_provider('pi') returns a PiProvider."""
+        pi_provider = _pi_symbol("PiProvider")
+
+        provider = get_provider("pi")
+
+        assert isinstance(provider, pi_provider)
+
+    def test_get_provider_pi_validates_and_stores_typed_options(self) -> None:
+        """get_provider('pi', options) validates through PiOptions and stores it."""
+        pi_options = _pi_symbol("PiOptions")
+
+        provider = get_provider("pi", {"inactivity_timeout": 10})
+
+        assert provider.options == pi_options(inactivity_timeout=10)

--- a/uv.lock
+++ b/uv.lock
@@ -394,6 +394,7 @@ wheels = [
 name = "fdsx"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "httpx" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
@@ -425,6 +426,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "langgraph", specifier = ">=1.0,<2" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3,<5" },


### PR DESCRIPTION
## What
- add the `pi` provider end to end, including provider registration, validation, CLI routing, and test coverage
- forward per-task `model` values to the `pi` CLI as `--model <value>` while leaving `model=None` unset
- add per-task pi tool restriction options through `provider_options`, translating `allowed_tools`, `disallowed_tools`, and `disable_tools` into the corresponding pi CLI flags
- make `pi` follow the existing provider-option precedence chain: global config `providers.pi`, workflow-level `providers.pi`, then task `provider_options`
- validate merged `pi` defaults after inheritance so unknown keys and mutually exclusive tool settings fail before execution
- add integration coverage for config/workflow/task precedence, list replacement semantics, empty-list overrides, and `run_flow()` propagation of inherited pi CLI flags
- preserve provider-qualified and shorthand model ids verbatim when invoking `pi`
- document the pi provider options in the checked-in YAML schema reference
- configure CLI structlog output to write to the current stderr stream so CLI logging stays aligned with the terminal UI path

## Why
This branch completes the `pi` provider integration so workflows can select a pi model per execution, restrict tool availability, and inherit pi defaults through the same configuration path as the other LLM providers. The added validation prevents invalid inherited settings from reaching runtime, and the documentation and logging updates keep the provider behavior discoverable and aligned with the project's stdout/stderr contract.

## How To Test
- `uv run pytest tests/unit/test_pi_options.py -v`
- `uv run pytest tests/integration/test_pi_provider.py -v`
- `uv run pytest tests/integration/test_provider_options.py -v`
- `uv run pytest tests/integration/ -v`
- `uv run mypy src/`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check .`
